### PR TITLE
Convert to github source defaults

### DIFF
--- a/recipes-kernel/linux/linux-lmp-dev.bb
+++ b/recipes-kernel/linux/linux-lmp-dev.bb
@@ -9,8 +9,8 @@ python __anonymous() {
         raise bb.parse.SkipRecipe(msg)
 }
 
-FIO_LMP_GIT_URL ?= "source.foundries.io"
-FIO_LMP_GIT_NAMESPACE ?= ""
+FIO_LMP_GIT_URL ?= "github.com"
+FIO_LMP_GIT_NAMESPACE ?= "foundriesio"
 
 LINUX_VERSION ?= "4.19-rc"
 LINUX_VERSION_EXTENSION ?= "-lmpdev-${LINUX_KERNEL_TYPE}"

--- a/recipes-kernel/linux/linux-lmp_git.bb
+++ b/recipes-kernel/linux/linux-lmp_git.bb
@@ -1,7 +1,7 @@
 LINUX_VERSION ?= "4.18.18"
 
-FIO_LMP_GIT_URL ?= "source.foundries.io"
-FIO_LMP_GIT_NAMESPACE ?= ""
+FIO_LMP_GIT_URL ?= "github.com"
+FIO_LMP_GIT_NAMESPACE ?= "foundriesio"
 
 SRCREV_machine = "2835754ba8ec8d71b6eedd6009d23790b5db5983"
 SRCREV_meta = "b15a38120a74e117938321c996e04484567e6e6d"

--- a/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -5,8 +5,8 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 DEPENDS = "boost curl ostree glib-2.0"
 
 SRCREV = "dcc7df7a6c1e1fbc9c1aa62377421ba6b457dfe0"
-FIO_LMP_GIT_URL ?= "source.foundries.io"
-FIO_LMP_GIT_NAMESPACE ?= ""
+FIO_LMP_GIT_URL ?= "github.com"
+FIO_LMP_GIT_NAMESPACE ?= "foundriesio"
 
 SRC_URI = "git://${FIO_LMP_GIT_URL}/${FIO_LMP_GIT_NAMESPACE}lmp-device-register.git;protocol=https"
 


### PR DESCRIPTION
All LMP sources have been moved to GitHub. This updates our defaults
to use the GitHub repositories for building the LMP.

Signed-off-by: Andy Doan <andy@foundries.io>