### PR TITLE
Base support for u-boot fitimage

### DIFF
--- a/recipes-bsp/u-boot/u-boot-compulab/enable_support_for_fitimage.patch
+++ b/recipes-bsp/u-boot/u-boot-compulab/enable_support_for_fitimage.patch
@@ -1,0 +1,10 @@
+Index: git/configs/cl-som-imx7_defconfig
+===================================================================
+--- git.orig/configs/cl-som-imx7_defconfig
++++ git/configs/cl-som-imx7_defconfig
+@@ -66,3 +66,5 @@ CONFIG_USB_KEYBOARD=y
+ CONFIG_USB_GADGET=y
+ CONFIG_CI_UDC=y
+ CONFIG_OF_LIBFDT=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y

--- a/recipes-bsp/u-boot/u-boot-compulab_2017.07.bb
+++ b/recipes-bsp/u-boot/u-boot-compulab_2017.07.bb
@@ -14,6 +14,7 @@ SRC_URI = "git://git.denx.de/u-boot.git;branch=${SRCBRANCH} \
     file://0001-net-Use-packed-structures-for-networking.patch \
     file://u-boot-2017.07-cl-som-imx7-1.5.patch \
     file://enable_distro_defaults.patch \
+    file://enable_support_for_fitimage.patch \
     file://standard_boot_env.patch \
 "
 

--- a/recipes-bsp/u-boot/u-boot-fslc/0001-mx6cuboxi-enable-FIT.patch
+++ b/recipes-bsp/u-boot/u-boot-fslc/0001-mx6cuboxi-enable-FIT.patch
@@ -1,0 +1,23 @@
+From 5fd07ff3ec6bf12df6eb217e482696a6a8c51773 Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo@foundries.io>
+Date: Mon, 7 Jan 2019 16:57:50 -0200
+Subject: [PATCH] mx6cuboxi: enable FIT
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+---
+ configs/mx6cuboxi_defconfig | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configs/mx6cuboxi_defconfig b/configs/mx6cuboxi_defconfig
+index 6e73a9752c..532de6f829 100644
+--- a/configs/mx6cuboxi_defconfig
++++ b/configs/mx6cuboxi_defconfig
+@@ -41,3 +41,5 @@ CONFIG_USB_KEYBOARD=y
+ CONFIG_VIDEO=y
+ # CONFIG_VIDEO_SW_CURSOR is not set
+ CONFIG_OF_LIBFDT=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
+-- 
+2.17.1
+

--- a/recipes-bsp/u-boot/u-boot-fslc_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fslc_%.bbappend
@@ -4,4 +4,5 @@ RDEPENDS_${PN}_append_sota = " u-boot-ostree-scr"
 
 SRC_URI_append_cubox-i += " \
     file://0001-mx6cuboxi-only-check-for-eMMC-if-som-is-at-least-1.5.patch \
+    file://0001-mx6cuboxi-enable-FIT.patch \
 "

--- a/recipes-bsp/u-boot/u-boot/0001-rpi-prefer-downstream-dtb-files.patch
+++ b/recipes-bsp/u-boot/u-boot/0001-rpi-prefer-downstream-dtb-files.patch
@@ -1,0 +1,44 @@
+From c0b93951869c9ad9520a94a6dce83cb6b6ecfdc3 Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo@foundries.io>
+Date: Tue, 8 Jan 2019 22:49:45 -0200
+Subject: [PATCH] rpi: prefer downstream dtb files
+
+Overlays are compatible only with the downstream dtb files, so prefer
+downstream to avoid breaking rpi users.
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+---
+ board/raspberrypi/rpi/rpi.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/board/raspberrypi/rpi/rpi.c b/board/raspberrypi/rpi/rpi.c
+index 649127c5bf..ff8e690e97 100644
+--- a/board/raspberrypi/rpi/rpi.c
++++ b/board/raspberrypi/rpi/rpi.c
+@@ -122,7 +122,7 @@ static const struct rpi_model rpi_models_new_scheme[] = {
+ 	},
+ 	[0x8] = {
+ 		"3 Model B",
+-		DTB_DIR "bcm2837-rpi-3-b.dtb",
++		DTB_DIR "bcm2710-rpi-3-b.dtb",
+ 		true,
+ 	},
+ 	[0x9] = {
+@@ -137,12 +137,12 @@ static const struct rpi_model rpi_models_new_scheme[] = {
+ 	},
+ 	[0xC] = {
+ 		"Zero W",
+-		DTB_DIR "bcm2835-rpi-zero-w.dtb",
++		DTB_DIR "bcm2708-rpi-0-w.dtb",
+ 		false,
+ 	},
+ 	[0xD] = {
+ 		"3 Model B+",
+-		DTB_DIR "bcm2837-rpi-3-b-plus.dtb",
++		DTB_DIR "bcm2710-rpi-3-b-plus.dtb",
+ 		true,
+ 	},
+ };
+-- 
+2.17.1
+

--- a/recipes-bsp/u-boot/u-boot/0001-rpi-set-CONFIG_SYS_BOOTM_LEN-to-32M.patch
+++ b/recipes-bsp/u-boot/u-boot/0001-rpi-set-CONFIG_SYS_BOOTM_LEN-to-32M.patch
@@ -1,0 +1,27 @@
+From aa06eb847885d1fb80f35b3fdb4fbc890882fb61 Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo@foundries.io>
+Date: Wed, 19 Dec 2018 20:44:06 -0200
+Subject: [PATCH] rpi: set CONFIG_SYS_BOOTM_LEN to 32M
+
+Allow kernel size up to 32M.
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+---
+ include/configs/rpi.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/configs/rpi.h b/include/configs/rpi.h
+index 9ce41767a9..bfdab9d88f 100644
+--- a/include/configs/rpi.h
++++ b/include/configs/rpi.h
+@@ -52,6 +52,7 @@
+ 					 CONFIG_SYS_SDRAM_SIZE - \
+ 					 GENERATED_GBL_DATA_SIZE)
+ #define CONFIG_SYS_MALLOC_LEN		SZ_4M
++#define CONFIG_SYS_BOOTM_LEN		SZ_32M
+ #define CONFIG_SYS_MEMTEST_START	0x00100000
+ #define CONFIG_SYS_MEMTEST_END		0x00200000
+ #define CONFIG_LOADADDR			0x00200000
+-- 
+2.17.1
+

--- a/recipes-bsp/u-boot/u-boot/0001-rpi_defconfig-enable-support-for-FIT.patch
+++ b/recipes-bsp/u-boot/u-boot/0001-rpi_defconfig-enable-support-for-FIT.patch
@@ -1,0 +1,34 @@
+From 107b16c709865d9048921a26ff487ab2a212cd0b Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo@foundries.io>
+Date: Wed, 19 Dec 2018 18:49:25 -0200
+Subject: [PATCH] rpi_defconfig: enable support for FIT
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+---
+ configs/rpi_0_w_defconfig | 2 ++
+ configs/rpi_3_defconfig   | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/configs/rpi_0_w_defconfig b/configs/rpi_0_w_defconfig
+index 66b0de31b6..bfc0c4841c 100644
+--- a/configs/rpi_0_w_defconfig
++++ b/configs/rpi_0_w_defconfig
+@@ -39,3 +39,5 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_PHYS_TO_BUS=y
+ CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
+diff --git a/configs/rpi_3_defconfig b/configs/rpi_3_defconfig
+index 54b6303c2d..eac1255f5e 100644
+--- a/configs/rpi_3_defconfig
++++ b/configs/rpi_3_defconfig
+@@ -42,3 +42,5 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_PHYS_TO_BUS=y
+ CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
+-- 
+2.17.1
+

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -3,6 +3,11 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 RDEPENDS_${PN}_append_sota = " u-boot-ostree-scr"
 DEPENDS_remove_rpi = "rpi-u-boot-scr"
 
+SRC_URI_append_rpi = " \
+    file://0001-rpi-set-CONFIG_SYS_BOOTM_LEN-to-32M.patch \
+    file://0001-rpi_defconfig-enable-support-for-FIT.patch \
+"
+
 SRC_URI_append_beaglebone-yocto = " \
     file://beaglebone-extend-usb-ether.patch \
 "

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -6,6 +6,7 @@ DEPENDS_remove_rpi = "rpi-u-boot-scr"
 SRC_URI_append_rpi = " \
     file://0001-rpi-set-CONFIG_SYS_BOOTM_LEN-to-32M.patch \
     file://0001-rpi_defconfig-enable-support-for-FIT.patch \
+    file://0001-rpi-prefer-downstream-dtb-files.patch \
 "
 
 SRC_URI_append_beaglebone-yocto = " \

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -3,12 +3,12 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 RDEPENDS_${PN}_append_sota = " u-boot-ostree-scr"
 DEPENDS_remove_rpi = "rpi-u-boot-scr"
 
-SRC_URI_append_beaglebone-yocto += " \
+SRC_URI_append_beaglebone-yocto = " \
     file://beaglebone-extend-usb-ether.patch \
 "
 
 # DB410c specific changes
-SRC_URI_append_dragonboard-410c += " \
+SRC_URI_append_dragonboard-410c = " \
     file://config-db410c-remove-qcom-dir-from-fdtf.patch \
     file://0001-HACK-disable-emmc.patch \
     file://0002-db410c-config-updates.patch \
@@ -16,7 +16,7 @@ SRC_URI_append_dragonboard-410c += " \
 "
 
 # DB820c specific changes
-SRC_URI_append_dragonboard-820c += " \
+SRC_URI_append_dragonboard-820c = " \
     file://config-db820c-remove-qcom-dir-from-fdtf.patch \
     file://0003-db820c-config-updates.patch \
     file://fix_load_addr_db820c.patch \


### PR DESCRIPTION
Before we officially transition to fitimage for all u-boot compatible targets, enable fitimage support in u-boot for early testing.