### PR TITLE
Enable support for HSM via SoftHSMv2

### DIFF
--- a/conf/distro/lmp.conf
+++ b/conf/distro/lmp.conf
@@ -17,6 +17,8 @@ IMAGE_BOOT_FILES_remove_sota = " ${KERNEL_IMAGETYPE}"
 SOTA_CLIENT_PROV ?= ""
 ## Also produce OTA rootfs tarball for additional image support
 BUILD_OTA_TARBALL = "1"
+## Support Aktualizr with HSM by default for secure SOTA
+SOTA_CLIENT_FEATURES_append = " hsm"
 
 # No graphical feature as part of the base platform
 DISTRO_FEATURES_remove = "wayland x11"

--- a/recipes-samples/images/lmp-image-common.inc
+++ b/recipes-samples/images/lmp-image-common.inc
@@ -30,9 +30,10 @@ CORE_IMAGE_BASE_INSTALL += " \
     sudo \
 "
 
-# OTA+ extras (OSF device provisioning)
+# OTA+ extras (e.g. device provisioning)
 CORE_IMAGE_BASE_INSTALL += " \
     lmp-device-register \
+    softhsm \
 "
 
 fakeroot do_populate_rootfs_common_src () {


### PR DESCRIPTION
Aktualizr can use the HSM backend (via PKCS#11) for secure SOTA. Enable HSM support and make softhsm part of the base lmp images for testing purposes.