### PR TITLE
Update softhsm and libp11 to latest

### DIFF
--- a/recipes-support/libp11/libp11_git.bb
+++ b/recipes-support/libp11/libp11_git.bb
@@ -1,0 +1,40 @@
+SUMMARY = "Library for using PKCS"
+DESCRIPTION = "\
+Libp11 is a library implementing a small layer on top of PKCS \
+make using PKCS"
+HOMEPAGE = "http://www.opensc-project.org/libp11"
+SECTION = "Development/Libraries"
+LICENSE = "LGPLv2+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=fad9b3332be894bab9bc501572864b29"
+DEPENDS = "libtool openssl"
+RDEPENDS_${PN} += " opensc"
+
+SRC_URI = "git://github.com/OpenSC/libp11.git"
+SRCREV = "57ca68ff67efa08e3be1f26dec6d23bf5bb977f2"
+
+PV = "0.4.9+git${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+inherit autotools pkgconfig
+
+# Currently, Makefile dependencies are incorrectly defined which causes build errors
+# if the number of jobs is high
+# See https://github.com/OpenSC/libp11/issues/94
+PARALLEL_MAKE = ""
+EXTRA_OECONF = "--disable-static"
+
+do_install_append () {
+    rm -rf ${D}${libdir}/*.la
+    rm -rf ${D}${docdir}/${BPN}
+}
+
+FILES_${PN} = "${libdir}/engines*/pkcs11.so \
+               ${libdir}/engines*/libpkcs11${SOLIBS} \
+               ${libdir}/libp11${SOLIBS}"
+
+FILES_${PN}-dev = " \
+                   ${libdir}/engines*/libpkcs11${SOLIBSDEV} \
+                   ${libdir}/libp11${SOLIBSDEV} \
+                   ${libdir}/pkgconfig/libp11.pc \
+                   /usr/include"

--- a/recipes-support/softhsm/softhsm_git.bb
+++ b/recipes-support/softhsm/softhsm_git.bb
@@ -1,0 +1,26 @@
+SUMMARY = "HSM emulator"
+HOMEPAGE = "https://www.opendnssec.org/softhsm/"
+LICENSE = "BSD-2-Clause & ISC"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ef3f77a3507c3d91e75b9f2bdaee4210"
+
+DEPENDS = "openssl"
+
+SRC_URI = "git://github.com/opendnssec/SoftHSMv2.git;branch=master"
+SRCREV = "369df0383d101bc8952692c2a368ac8bc887d1b4"
+
+PV = "2.5.0"
+
+S = "${WORKDIR}/git"
+
+inherit autotools pkgconfig
+
+# EdDSA requires OpenSSL >= 1.1.1
+EXTRA_OECONF = "--enable-eddsa --disable-gost"
+
+do_configure_prepend() {
+    (
+        cd ${S}
+        unset docdir
+        sh ./autogen.sh
+    )
+}


### PR DESCRIPTION
Changes also proposed to meta-updater, available at https://github.com/advancedtelematic/meta-updater/pull/459.