### PR TITLE
bluez-firmware-rpidistro: update bluez-firmware

### DIFF
--- a/recipes-kernel/bluez-firmware-rpidistro/bluez-firmware-rpidistro_git.bbappend
+++ b/recipes-kernel/bluez-firmware-rpidistro/bluez-firmware-rpidistro_git.bbappend
@@ -1,3 +1,3 @@
 # Known to work revision for Raspberry Pi specific firmware (from meta-raspberrypi)
 # Upstream-bug: https://github.com/RPi-Distro/bluez-firmware/issues/4
-SRCREV_rpi = "e28cd7ee8615de33aa7ec2b41d556af61a4a2707"
+SRCREV_rpi = "96eefffcccc725425fd83be5e0704a5c32b79e54"


### PR DESCRIPTION
Latest bluez-firmware release updates BCM4345C0.hcd to
003.001.025.0156.0280, restoring LE scan capability.

Upstream pull-request:
https://github.com/agherzan/meta-raspberrypi/pull/379

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>