### PR TITLE
ostree-pending-reboot: change to use the upstream aktualizr flag file

### DIFF
--- a/recipes-samples/images/configs/ostree-pending-reboot.service
+++ b/recipes-samples/images/configs/ostree-pending-reboot.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Aktualizr OSTree Update Automatic Reboot
-ConditionPathExists=/run/aktualizr/ostree-pending-update
+ConditionPathExists=/var/run/aktualizr-session/need_reboot
 
 [Service]
 Type=simple


### PR DESCRIPTION
Aktualizr creates /var/run/aktualizr-session/need_reboot after applying
the update, so change the service file to use the upstream solution
instead.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>