### PR TITLE
Update to newer version with HSM support

### DIFF
--- a/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl ostree glib-2.0"
 
-SRCREV = "927a262d872e60c74226a4612a16ae14e7f01260"
+SRCREV = "e3c224341acfe2765031d78e25e75c4069641b5e"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https"
 


### PR DESCRIPTION
Bring in changes which allow PKCS#11-based provisioning using an HSM.

Signed-off-by: Marti Bolivar <marti@foundries.io>