### PR TITLE
lmp-device-register: pull in regression fix

### DIFF
--- a/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl ostree glib-2.0"
 
-SRCREV = "e3c224341acfe2765031d78e25e75c4069641b5e"
+SRCREV = "d29847e3aaf9ac707b512a75429cf0b103f4f05d"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https"
 


### PR DESCRIPTION
Fix for non-HSM initialization.