### PR TITLE
gcc-8.3: add patch to change linker to use systemlibs dir on riscv

### DIFF
--- a/recipes-devtools/gcc/files/riscv-Use-SYSTEMLIBS_DIR-replacement-instead-of-hardcoding.patch
+++ b/recipes-devtools/gcc/files/riscv-Use-SYSTEMLIBS_DIR-replacement-instead-of-hardcoding.patch
@@ -1,0 +1,29 @@
+From 61e79e6ef92f130a783b48d2f7b0018a31af3bbb Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo@foundries.io>
+Date: Thu, 10 May 2018 18:16:06 -0300
+Subject: [PATCH] Use SYSTEMLIBS_DIR replacement instead of hardcoding
+ base_libdir
+
+Upstream-Status: Inappropriate [OE-Specific]
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+---
+ gcc/config/riscv/linux.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gcc/config/riscv/linux.h b/gcc/config/riscv/linux.h
+index 4b2f7b6e1fd..690fe98e716 100644
+--- a/gcc/config/riscv/linux.h
++++ b/gcc/config/riscv/linux.h
+@@ -22,7 +22,7 @@ along with GCC; see the file COPYING3.  If not see
+     GNU_USER_TARGET_OS_CPP_BUILTINS();				\
+   } while (0)
+ 
+-#define GLIBC_DYNAMIC_LINKER "/lib/ld-linux-riscv" XLEN_SPEC "-" ABI_SPEC ".so.1"
++#define GLIBC_DYNAMIC_LINKER SYSTEMLIBS_DIR "ld-linux-riscv" XLEN_SPEC "-" ABI_SPEC ".so.1"
+ 
+ #define MUSL_ABI_SUFFIX \
+   "%{mabi=ilp32:-sf}" \
+-- 
+2.17.0
+

--- a/recipes-devtools/gcc/gcc-cross_8.3.bbappend
+++ b/recipes-devtools/gcc/gcc-cross_8.3.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+	file://riscv-Use-SYSTEMLIBS_DIR-replacement-instead-of-hardcoding.patch \
+"

--- a/recipes-devtools/gcc/gcc-runtime_8.3.bbappend
+++ b/recipes-devtools/gcc/gcc-runtime_8.3.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+	file://riscv-Use-SYSTEMLIBS_DIR-replacement-instead-of-hardcoding.patch \
+"

--- a/recipes-devtools/gcc/gcc-source_8.3.bbappend
+++ b/recipes-devtools/gcc/gcc-source_8.3.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+	file://riscv-Use-SYSTEMLIBS_DIR-replacement-instead-of-hardcoding.patch \
+"

--- a/recipes-devtools/gcc/gcc_8.3.bbappend
+++ b/recipes-devtools/gcc/gcc_8.3.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+	file://riscv-Use-SYSTEMLIBS_DIR-replacement-instead-of-hardcoding.patch \
+"

--- a/recipes-devtools/gcc/libgcc-initial_8.3.bbappend
+++ b/recipes-devtools/gcc/libgcc-initial_8.3.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+	file://riscv-Use-SYSTEMLIBS_DIR-replacement-instead-of-hardcoding.patch \
+"

--- a/recipes-devtools/gcc/libgcc_8.3.bbappend
+++ b/recipes-devtools/gcc/libgcc_8.3.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+	file://riscv-Use-SYSTEMLIBS_DIR-replacement-instead-of-hardcoding.patch \
+"


### PR DESCRIPTION
Upstream dropped the riscv linker change with the gcc 8.3 update. Add it
back until the fix lands upstream again.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>