### PR TITLE
meta-lmp: updates for kernel 5.0 and RISC-V

### DIFF
--- a/classes/lmp-machine-custom.bbclass
+++ b/classes/lmp-machine-custom.bbclass
@@ -65,11 +65,23 @@ UBOOT_DTB_LOADADDRESS_rpi = "0x02600000"
 UBOOT_DTBO_LOADADDRESS_rpi = "0x026d0000"
 
 # RISC-V targets
-## QEMU target doesn't support complete disk images
-IMAGE_FSTYPES_remove_qemuriscv64 = "wic wic.gz wic.bmap"
 INITRAMFS_IMAGE_BUNDLE_qemuriscv64 = "1"
 KERNEL_INITRAMFS_qemuriscv64 = '-initramfs'
-RISCV_BBL_PAYLOAD_qemuriscv64 = "${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin"
+PREFERRED_PROVIDER_virtual/bootloader_qemuriscv64 = "u-boot"
+UBOOT_MACHINE_qemuriscv64 = "qemu-riscv64_smode_defconfig"
+IMAGE_BOOT_FILES_qemuriscv64 = "boot.scr uEnv.txt"
+KERNEL_IMAGETYPE_qemuriscv64 = "fitImage"
+KERNEL_CLASSES_qemuriscv64 = " kernel-fitimage "
+OSTREE_KERNEL_qemuriscv64 = "${KERNEL_IMAGETYPE}-${INITRAMFS_IMAGE}-${MACHINE}-${MACHINE}"
+OSTREE_KERNEL_ARGS_append_qemuriscv64 = " earlycon=sbi"
+UBOOT_ENTRYPOINT_qemuriscv64 = "0x80400000"
+UBOOT_RD_LOADADDRESS_qemuriscv64 = "0x81000000"
+EXTRA_IMAGEDEPENDS_append_qemuriscv64 = " opensbi"
+RISCV_SBI_PLAT_qemuriscv64 = "qemu/virt"
+RISCV_SBI_PAYLOAD_qemuriscv64 = "u-boot-${MACHINE}.bin"
+QB_DEFAULT_KERNEL_qemuriscv64 = "fw_payload.elf"
+QB_DRIVE_TYPE_qemuriscv64 = "/dev/vd"
+
 ## Freedom U540 target doesn't yet support standard bootloaders (e.g. u-boot)
 INITRAMFS_IMAGE_BUNDLE_freedom-u540 = "1"
 KERNEL_INITRAMFS_freedom-u540 = '-initramfs'

--- a/recipes-bsp/u-boot/u-boot-ostree-scr/qemuriscv64/boot.cmd
+++ b/recipes-bsp/u-boot/u-boot-ostree-scr/qemuriscv64/boot.cmd
@@ -1,0 +1,9 @@
+if test ${distro_bootpart} != 1
+then
+    echo "Boot partition needs to be the first partition"
+    exit
+fi
+
+fatload ${devtype} ${devnum}:1 $scriptaddr /uEnv.txt
+env import -t $scriptaddr $filesize
+run bootcmd

--- a/recipes-bsp/u-boot/u-boot-ostree-scr/qemuriscv64/uEnv.txt.in
+++ b/recipes-bsp/u-boot/u-boot-ostree-scr/qemuriscv64/uEnv.txt.in
@@ -1,0 +1,4 @@
+bootcmd_otenv=load ${devtype} ${devnum}:2 ${scriptaddr} /boot/loader/uEnv.txt; env import -t ${scriptaddr} ${filesize}
+bootcmd_load_f=load ${devtype} ${devnum}:2 ${ramdisk_addr_r} "/boot"${kernel_image}
+bootcmd_run=bootm ${ramdisk_addr_r}:kernel@1 ${ramdisk_addr_r}:ramdisk@1 ${pxefile_addr_r}
+bootcmd=run bootcmd_otenv; run bootcmd_load_f; run bootcmd_run

--- a/recipes-devtools/riscv-tools/opensbi_%.bbappend
+++ b/recipes-devtools/riscv-tools/opensbi_%.bbappend
@@ -1,0 +1,4 @@
+do_install_append() {
+	# HACK: fix build break by deleting lib/*
+	rm -r ${D}/lib/
+}

--- a/recipes-devtools/riscv-tools/riscv-pk.bbappend
+++ b/recipes-devtools/riscv-tools/riscv-pk.bbappend
@@ -1,1 +1,0 @@
-PROVIDES_freedom-u540 = "virtual/bootloader"

--- a/recipes-kernel/linux/linux-lmp_git.bb
+++ b/recipes-kernel/linux/linux-lmp_git.bb
@@ -1,11 +1,11 @@
-LINUX_VERSION ?= "4.18.18"
+LINUX_VERSION ?= "5.0.6"
 
 FIO_LMP_GIT_URL ?= "github.com"
 FIO_LMP_GIT_NAMESPACE ?= "foundriesio/"
 
-SRCREV_machine = "6a5127911565aa3bfde3716ca4cef31ff122a1c8"
-SRCREV_meta = "3f5aa8971138c3e6f9631f5ec2360c0780c5e148"
-KBRANCH = "linux-v4.18.y"
+SRCREV_machine = "0f04a653b064b7ade09f0aa0cbc70e2820ca1e21"
+SRCREV_meta = "c137cbf6cb00991d177a59895bf44b25ce0ad1e8"
+KBRANCH = "linux-v5.0.y"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 

--- a/recipes-samples/images/lmp-mini-image.bb
+++ b/recipes-samples/images/lmp-mini-image.bb
@@ -4,6 +4,9 @@ require lmp-image-common.inc
 
 IMAGE_FEATURES += "ssh-server-dropbear"
 
+# Enough free space for a full image update
+IMAGE_OVERHEAD_FACTOR = "2.3"
+
 # Extras (for development)
 CORE_IMAGE_BASE_INSTALL += " \
     bash \


### PR DESCRIPTION
- kernel update to 5.0.6
- boot scripts to support u-boot for qemuriscv64
- remove riscv-pk append (bbl is dead)
- opensbi build fix
- lmp-mini-image add more room for OTA update
- lmp-machine move qemuriscv64 target to opensbi/u-boot support (with fitImage for Linux)