### PR TITLE
procps: add updated sysctl.conf to fix rp_filter issue

### DIFF
--- a/recipes-extended/procps/procps/sysctl.conf
+++ b/recipes-extended/procps/procps/sysctl.conf
@@ -1,0 +1,64 @@
+# /etc/sysctl.conf - Configuration file for setting system variables
+# See sysctl.conf (5) for information.
+
+# you can have the CD-ROM close when you use it, and open
+# when you are done.
+#dev.cdrom.autoeject = 1
+#dev.cdrom.autoclose = 1
+
+# protection from the SYN flood attack
+net/ipv4/tcp_syncookies=1
+
+# see the evil packets in your log files
+net/ipv4/conf/all/log_martians=1
+
+# makes you vulnerable or not :-)
+net/ipv4/conf/all/accept_redirects=0
+net/ipv4/conf/all/accept_source_route=0
+net/ipv4/icmp_echo_ignore_broadcasts =1
+
+# needed for routing, including masquerading or NAT
+#net/ipv4/ip_forward=1
+
+# sets the port range used for outgoing connections
+#net.ipv4.ip_local_port_range = 32768    61000
+
+# Broken routers and obsolete firewalls will corrupt the window scaling
+# and ECN. Set these values to 0 to disable window scaling and ECN.
+# This may, rarely, cause some performance loss when running high-speed
+# TCP/IP over huge distances or running TCP/IP over connections with high
+# packet loss and modern routers. This sure beats dropped connections.
+#net.ipv4.tcp_ecn = 0
+
+# Swapping too much or not enough? Disks spinning up when you'd
+# rather they didn't? Tweak these.
+#vm.vfs_cache_pressure = 100
+#vm.laptop_mode = 0
+#vm.swappiness = 60
+
+#kernel.printk_ratelimit_burst = 10
+#kernel.printk_ratelimit = 5
+#kernel.panic_on_oops = 0
+
+# Reboot 600 seconds after a panic
+#kernel.panic = 600
+
+# enable SysRq key (note: console security issues)
+#kernel.sysrq = 1
+
+# Change name of core file to start with the command name
+# so you get things like: emacs.core mozilla-bin.core X.core
+#kernel.core_pattern = %e.core
+
+# NIS/YP domain (not always equal to DNS domain)
+#kernel.domainname = example.com
+#kernel.hostname = darkstar
+
+# This limits PID values to 4 digits, which allows tools like ps
+# to save screen space.
+#kernel/pid_max=10000
+
+# Protects against creating or following links under certain conditions
+# See https://www.kernel.org/doc/Documentation/sysctl/fs.txt
+#fs.protected_hardlinks = 1
+#fs.protected_symlinks = 1

--- a/recipes-extended/procps/procps_%.bbappend
+++ b/recipes-extended/procps/procps_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
OE has a very outdated sysctl.conf file in the procps package:
https://git.openembedded.org/openembedded-core/commit/?id=8a9b9a323f4363e27138077e3e3dce8139a36708
(circa 2014)

The origins of this file is quite unknown and it's causing a routing
issue when both wifi and ethernet are enabled due to the following:
- upstream change in NetworkManager during 1.16 cycle removes the
  dynamic rp_filter setting change when more than one interface
  is enabled.
- legacy setting in sysctl.conf sets rp_filter to 1 which blocks
  packets with different inbound and outbound addresses.

Documentation of rp_filter setting from kernel.org:

rp_filter - INTEGER
0 - No source validation.
1 - Strict mode as defined in RFC3704 Strict Reverse Path
    Each incoming packet is tested against the FIB and if the interface
    is not the best reverse path the packet check will fail.
    By default failed packets are discarded.
2 - Loose mode as defined in RFC3704 Loose Reverse Path
    Each incoming packet's source address is also tested against the FIB
    and if the source address is not reachable via any interface
    the packet check will fail.

This patch updates the sysctl.conf file to procps v3.3.15 which doesn't
set the rp_filter mode explicity.

NOTE: The kernel/pid_max=10000 setting has been commented out as this
may not be desired by default.

Signed-off-by: Michael Scott <mike@foundries.io>