### PR TITLE
recipes-bsp: u-boot: include same patches for u-boot-tools

### DIFF
--- a/recipes-bsp/u-boot/u-boot-lmp-common.inc
+++ b/recipes-bsp/u-boot/u-boot-lmp-common.inc
@@ -1,0 +1,18 @@
+SRC_URI_append = " \
+    file://0001-fat-check-for-buffer-size-before-reading-blocks.patch \
+"
+
+SRC_URI_append_qemuarm64 = " \
+    file://0001-qemuarm64-enable-support-for-fitimage.patch \
+    file://0001-qemuarm64-make-u-boot-an-ATF-payload.patch \
+"
+
+SRC_URI_append_rpi = " \
+    file://0001-rpi-set-CONFIG_SYS_BOOTM_LEN-to-32M.patch \
+    file://0001-rpi_defconfig-enable-support-for-FIT.patch \
+    file://0001-rpi-prefer-downstream-dtb-files.patch \
+"
+
+SRC_URI_append_beaglebone-yocto = " \
+    file://beaglebone-extend-usb-ether.patch \
+"

--- a/recipes-bsp/u-boot/u-boot-tools_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-tools_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot:"
+
+include u-boot-lmp-common.inc

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -3,21 +3,4 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 RDEPENDS_${PN}_append_sota = " u-boot-ostree-scr"
 DEPENDS_remove_rpi = "rpi-u-boot-scr"
 
-SRC_URI_append = " \
-    file://0001-fat-check-for-buffer-size-before-reading-blocks.patch \
-"
-
-SRC_URI_append_qemuarm64 = " \
-    file://0001-qemuarm64-enable-support-for-fitimage.patch \
-    file://0001-qemuarm64-make-u-boot-an-ATF-payload.patch \
-"
-
-SRC_URI_append_rpi = " \
-    file://0001-rpi-set-CONFIG_SYS_BOOTM_LEN-to-32M.patch \
-    file://0001-rpi_defconfig-enable-support-for-FIT.patch \
-    file://0001-rpi-prefer-downstream-dtb-files.patch \
-"
-
-SRC_URI_append_beaglebone-yocto = " \
-    file://beaglebone-extend-usb-ether.patch \
-"
+include u-boot-lmp-common.inc


### PR DESCRIPTION
To make sure our mkimage patches stay in sync with the u-boot patches
we need to apply them to both u-boot and u-boot-tools packages.

This way other layers can expect certain changes to be in place.

Signed-off-by: Michael Scott <mike@foundries.io>