### PR TITLE
lmp: add support for raspberrypi-cm3 machine

### DIFF
--- a/classes/lmp-machine-custom.bbclass
+++ b/classes/lmp-machine-custom.bbclass
@@ -34,10 +34,12 @@ IMAGE_BOOT_FILES_append_rpi = " boot.scr uEnv.txt"
 SOTA_CLIENT_FEATURES_remove_rpi = "ubootenv"
 KERNEL_DEVICETREE_raspberrypi0-wifi = "bcm2708-rpi-0-w.dtb overlays/rpi-ft5406.dtbo overlays/rpi-7inch.dtbo overlays/rpi-7inch-flip.dtbo"
 KERNEL_DEVICETREE_raspberrypi3_sota = "${RPI_KERNEL_DEVICETREE} overlays/vc4-kms-v3d.dtbo overlays/rpi-ft5406.dtbo overlays/rpi-7inch.dtbo overlays/rpi-7inch-flip.dtbo"
+KERNEL_DEVICETREE_raspberrypi-cm3_sota = "${RPI_KERNEL_DEVICETREE} overlays/vc4-kms-v3d.dtbo"
 ## Mimic meta-raspberrypi behavior
 KERNEL_SERIAL_rpi = "${@oe.utils.conditional("ENABLE_UART", "1", "console=ttyS0,115200", "", d)}"
 OSTREE_KERNEL_ARGS_sota_raspberrypi0-wifi = "8250.nr_uarts=1 vc_mem.mem_base=0x1ec00000 vc_mem.mem_size=0x20000000 dwc_otg.lpm_enable=0 console=tty1 ${KERNEL_SERIAL} root=LABEL=otaroot rootfstype=ext4"
 OSTREE_KERNEL_ARGS_sota_raspberrypi3 = "8250.nr_uarts=1 cma=256M vc_mem.mem_base=0x3ec00000 vc_mem.mem_size=0x40000000 dwc_otg.lpm_enable=0 console=tty1 ${KERNEL_SERIAL} root=LABEL=otaroot rootfstype=ext4"
+OSTREE_KERNEL_ARGS_sota_raspberrypi-cm3 = "8250.nr_uarts=1 cma=256M vc_mem.mem_base=0x3ec00000 vc_mem.mem_size=0x40000000 dwc_otg.lpm_enable=0 console=tty1 ${KERNEL_SERIAL} root=LABEL=otaroot rootfstype=ext4"
 ## U-Boot entrypoints for rpi
 UBOOT_DTB_LOADADDRESS_rpi = "0x02600000"
 UBOOT_DTBO_LOADADDRESS_rpi = "0x026d0000"

--- a/recipes-bsp/u-boot/u-boot-ostree-scr/raspberrypi-cm3/uEnv.txt.in
+++ b/recipes-bsp/u-boot/u-boot-ostree-scr/raspberrypi-cm3/uEnv.txt.in
@@ -1,0 +1,5 @@
+dtoverlays=#conf@overlays_vc4-kms-v3d.dtbo
+bootcmd_otenv=load ${devtype} ${devnum}:2 ${loadaddr} /boot/loader/uEnv.txt; env import -t ${loadaddr} ${filesize}
+bootcmd_load_f=load ${devtype} ${devnum}:2 ${ramdisk_addr_r} "/boot"${kernel_image}
+bootcmd_run=setexpr fdtfile gsub '/' '_'; bootm ${ramdisk_addr_r}#conf@${fdtfile}${dtoverlays}
+bootcmd=run bootcmd_otenv; run bootcmd_load_f; run bootcmd_run


### PR DESCRIPTION
Let's add missing Raspberry Pi 3 Compute Module support via the
raspberrypi-cm3 machine.

It is currently a copy of the raspberrypi3* settings (minus a few
overlays).

Signed-off-by: Michael Scott <mike@foundries.io>