### PR TITLE
lmp-machine-custom: beaglebone-yocto: use ttyS0 for console

### DIFF
--- a/classes/lmp-machine-custom.bbclass
+++ b/classes/lmp-machine-custom.bbclass
@@ -1,7 +1,7 @@
 # LMP specific configuration
 
 # Beaglebone
-OSTREE_KERNEL_ARGS_append_beaglebone-yocto = " console=ttyO0,115200n8"
+OSTREE_KERNEL_ARGS_append_beaglebone-yocto = " console=ttyS0,115200n8"
 KERNEL_DEVICETREE_append_beaglebone-yocto = " am335x-boneblack-wireless.dtb"
 IMAGE_BOOT_FILES_beaglebone-yocto = "u-boot.img MLO boot.scr uEnv.txt"
 KERNEL_IMAGETYPE_beaglebone-yocto = "fitImage"


### PR DESCRIPTION
Fixes warning in dmesg:
WARNING: Your 'console=ttyO0' has been replaced by 'ttyS0'

Signed-off-by: Michael Scott <mike@foundries.io>