### PR TITLE
lmp-auto-hostname: add recipe for automatic hostname configuration

### DIFF
--- a/recipes-support/lmp-auto-hostname/lmp-auto-hostname/lmp-auto-hostname.service.in
+++ b/recipes-support/lmp-auto-hostname/lmp-auto-hostname/lmp-auto-hostname.service.in
@@ -1,0 +1,14 @@
+[Unit]
+Description=Linux microPlatform Auto Hostname Update
+DefaultDependencies=no
+Before=network-pre.target avahi-daemon.service
+After=local-fs.target dbus.service
+
+[Service]
+Environment=MACHINE=@@LMP_HOSTNAME_MACHINE@@ MODE=@@LMP_HOSTNAME_MODE@@ NETDEVICE=@@LMP_HOSTNAME_NETDEVICE@@
+ExecStart=/usr/bin/lmp-update-hostname
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-support/lmp-auto-hostname/lmp-auto-hostname/lmp-update-hostname.sh
+++ b/recipes-support/lmp-auto-hostname/lmp-auto-hostname/lmp-update-hostname.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2019, Foundries.io Ltd.
+
+# Default machine name and network interface from environment
+MACHINE=${MACHINE}
+NETDEVICE=${NETDEVICE}
+
+# Default mode used to fetch the hardware specific data
+# Supported modes: mac (requires netdevice), serial
+MODE=${MODE}
+
+# Set default mode to serial if not provided by the user
+[ -n "$MODE" ] || MODE="serial"
+# Set Default network device to eth0 if not provided
+[ -n "$NETDEVICE" ] || NETDEVICE="eth0"
+
+# Extract data from device-tree if available
+if [ -d /proc/device-tree ]; then
+	if [ -f /proc/device-tree/model ]; then
+		# Lowercase and no spaces (can generate bad values with special chars)
+		MODEL=$(sed -e 's/.*/\L&/' -e 's/ /-/g' -e 's/+/plus/g' /proc/device-tree/model | tr -d '\0')
+	fi
+	if [ -f /proc/device-tree/serial-number ]; then
+		# Remove leading zeros
+		SERIAL=$(sed -e 's/^0*//' /proc/device-tree/serial-number | tr -d '\0')
+	fi
+fi
+# Network device mac address
+if [ -f /sys/class/net/${NETDEVICE}/address ]; then
+	MACADDRESS=$(sed -e 's/://g' /sys/class/net/${NETDEVICE}/address)
+fi
+
+[ -n "$MODEL" ] || MODEL="unknown"
+[ -n "$MACADDRESS" ] || MACADDRESS="unknown"
+[ -n "$SERIAL" ] || SERIAL="unknown"
+
+# Prefer machine name if given by the user
+[ -n "$MACHINE" ] && MODEL=${MACHINE}
+
+if [ "$MODE" = "mac" ]; then
+	NEW_HOSTNAME="${MODEL}-${MACADDRESS}"
+else
+	NEW_HOSTNAME="${MODEL}-${SERIAL}"
+fi
+
+echo "Updating system hostname to ${NEW_HOSTNAME}"
+/usr/bin/hostnamectl --static --transient set-hostname ${NEW_HOSTNAME}

--- a/recipes-support/lmp-auto-hostname/lmp-auto-hostname_0.1.bb
+++ b/recipes-support/lmp-auto-hostname/lmp-auto-hostname_0.1.bb
@@ -1,0 +1,43 @@
+SUMMARY = "Automatic hostname update based on hardware specific information"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit allarch systemd
+
+RDEPENDS_${PN} = "systemd"
+
+SRC_URI = "file://lmp-auto-hostname.service.in \
+    file://lmp-update-hostname.sh \
+"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+# Allow build time customizations by the user
+LMP_HOSTNAME_MACHINE ?= "${MACHINE}"
+LMP_HOSTNAME_MODE ?= "serial"
+LMP_HOSTNAME_NETDEVICE ?= ""
+
+SYSTEMD_SERVICE_${PN} = "lmp-auto-hostname.service"
+SYSTEMD_AUTO_ENABLE_${PN} = "enable"
+
+do_compile() {
+	sed -e 's/@@LMP_HOSTNAME_MACHINE@@/${LMP_HOSTNAME_MACHINE}/' \
+		-e 's/@@LMP_HOSTNAME_MODE@@/${LMP_HOSTNAME_MODE}/' \
+		-e 's/@@LMP_HOSTNAME_NETDEVICE@@/${LMP_HOSTNAME_NETDEVICE}/' \
+		${WORKDIR}/lmp-auto-hostname.service.in > lmp-auto-hostname.service
+
+	# Force job to wait for the network interface to show up if used
+	if [ "${LMP_HOSTNAME_MODE}" = "mac" -a -n "${LMP_HOSTNAME_NETDEVICE}" ]; then
+		sed -i -e '/^After=.*/a After=sys-subsystem-net-devices-${LMP_HOSTNAME_NETDEVICE}.device' \
+			-e '/^After=.*/a Wants=sys-subsystem-net-devices-${LMP_HOSTNAME_NETDEVICE}.device' \
+			lmp-auto-hostname.service
+	fi
+}
+
+do_install() {
+	install -d ${D}${bindir}
+	install -m 0755 ${WORKDIR}/lmp-update-hostname.sh ${D}${bindir}/lmp-update-hostname
+
+	install -d ${D}${systemd_system_unitdir}
+	install -m 0644 ${B}/lmp-auto-hostname.service ${D}${systemd_system_unitdir}
+}


### PR DESCRIPTION
Recipe used to automatically update the target hostname based on device
specific configuration such as mac address and serial number.

Can be customized by the user via the following variables:
LMP_HOSTNAME_MACHINE -> fixed or empty for dt device model
LMP_HOSTNAME_MODE -> mac or serial
LMP_HOSTNAME_NETDEVICE -> interface used by mac mode

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>