### PR TITLE
docker-auto-prune: add recipe for auto docker prune timer

### DIFF
--- a/recipes-support/docker-auto-prune/docker-auto-prune/docker-auto-prune.service
+++ b/recipes-support/docker-auto-prune/docker-auto-prune/docker-auto-prune.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Automatic Docker Prune
+After=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/docker system prune --force

--- a/recipes-support/docker-auto-prune/docker-auto-prune/docker-auto-prune.timer.in
+++ b/recipes-support/docker-auto-prune/docker-auto-prune/docker-auto-prune.timer.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=Automatic Docker Prune Timer
+
+[Timer]
+OnCalendar=@@DOCKER_PRUNE_ONCALENDAR@@
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/recipes-support/docker-auto-prune/docker-auto-prune_0.1.bb
+++ b/recipes-support/docker-auto-prune/docker-auto-prune_0.1.bb
@@ -1,0 +1,30 @@
+SUMMARY = "Automatic Docker System Prune service for removal of unused data"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit allarch systemd
+
+SRC_URI = "file://docker-auto-prune.service \
+    file://docker-auto-prune.timer.in \
+"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+# Allow build time customizations by the user
+DOCKER_PRUNE_ONCALENDAR ?= "daily"
+
+SYSTEMD_SERVICE_${PN} = "docker-auto-prune.timer"
+SYSTEMD_AUTO_ENABLE_${PN} = "enable"
+
+do_compile() {
+	sed -e 's/@@DOCKER_PRUNE_ONCALENDAR@@/${DOCKER_PRUNE_ONCALENDAR}/' \
+		${WORKDIR}/docker-auto-prune.timer.in > docker-auto-prune.timer
+}
+
+do_install() {
+	install -d ${D}${systemd_system_unitdir}
+	install -m 0644 ${WORKDIR}/docker-auto-prune.service ${D}${systemd_system_unitdir}
+	install -m 0644 ${B}/docker-auto-prune.timer ${D}${systemd_system_unitdir}
+}
+
+FILES_${PN} += "${systemd_system_unitdir}/docker-auto-prune.service"


### PR DESCRIPTION
Systemd service and timer for automatically calling docker prune.

DOCKER_PRUNE_ONCALENDAR can be set as described at https://www.freedesktop.org/software/systemd/man/systemd.timer.html, default is daily. 

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>