### PR TITLE
Support for aktualizr-lite/get

### DIFF
--- a/recipes-samples/images/lmp-image-common.inc
+++ b/recipes-samples/images/lmp-image-common.inc
@@ -23,6 +23,7 @@ REQUIRED_DISTRO_FEATURES = "pam systemd"
 
 # Base packages
 CORE_IMAGE_BASE_INSTALL += " \
+    aktualizr-get \
     aktualizr-host-tools \
     bluetooth-attach \
     haveged \

--- a/recipes-samples/images/lmp-image-common.inc
+++ b/recipes-samples/images/lmp-image-common.inc
@@ -24,7 +24,6 @@ REQUIRED_DISTRO_FEATURES = "pam systemd"
 # Base packages
 CORE_IMAGE_BASE_INSTALL += " \
     aktualizr-get \
-    aktualizr-host-tools \
     bluetooth-attach \
     haveged \
     networkmanager \

--- a/recipes-sota/aktualizr/aktualizr/0001-FIO-toup-aktualizr-lite-Mock-OstreeManager-getCurren.patch
+++ b/recipes-sota/aktualizr/aktualizr/0001-FIO-toup-aktualizr-lite-Mock-OstreeManager-getCurren.patch
@@ -1,0 +1,85 @@
+From e7ec79989030f2f8612611a440c4cd8a3dc776d3 Mon Sep 17 00:00:00 2001
+From: Andy Doan <andy@foundries.io>
+Date: Mon, 15 Jul 2019 15:17:05 -0500
+Subject: [PATCH 01/12] [FIO toup] aktualizr-lite: Mock
+ OstreeManager::getCurrent
+
+This allows us to make calls to find the active ostree deployment
+
+Signed-off-by: Andy Doan <andy@foundries.io>
+---
+ src/aktualizr_lite/CMakeLists.txt |  3 ++-
+ src/aktualizr_lite/ostree_mock.cc | 12 ++++++++++++
+ src/aktualizr_lite/test_lite.sh   |  7 ++++---
+ 3 files changed, 18 insertions(+), 4 deletions(-)
+ create mode 100644 src/aktualizr_lite/ostree_mock.cc
+
+diff --git a/src/aktualizr_lite/CMakeLists.txt b/src/aktualizr_lite/CMakeLists.txt
+index b08079bf..408c9546 100644
+--- a/src/aktualizr_lite/CMakeLists.txt
++++ b/src/aktualizr_lite/CMakeLists.txt
+@@ -15,10 +15,11 @@ add_test(test_aktualizr-lite
+         ${PROJECT_SOURCE_DIR}/tests
+         ${RUN_VALGRIND}
+ )
++add_library(t_lite-mock SHARED ostree_mock.cc)
+ 
+ endif(BUILD_OSTREE)
+ 
+ add_aktualizr_test(NAME lite-version SOURCES version_test.cc)
+ 
+-aktualizr_source_file_checks(main.cc version.h version_test.cc)
++aktualizr_source_file_checks(main.cc version.h version_test.cc ostree_mock.cc)
+ # vim: set tabstop=4 shiftwidth=4 expandtab:
+diff --git a/src/aktualizr_lite/ostree_mock.cc b/src/aktualizr_lite/ostree_mock.cc
+new file mode 100644
+index 00000000..71eb5010
+--- /dev/null
++++ b/src/aktualizr_lite/ostree_mock.cc
+@@ -0,0 +1,12 @@
++#include <ostree.h>
++
++extern "C" OstreeDeployment *ostree_sysroot_get_booted_deployment(OstreeSysroot *self) {
++  (void)self;
++  const char *hash = getenv("OSTREE_HASH");
++  return ostree_deployment_new(0, "dummy-os", hash, 1, hash, 1);
++}
++
++extern "C" const char *ostree_deployment_get_csum(OstreeDeployment *self) {
++  (void)self;
++  return getenv("OSTREE_HASH");
++}
+diff --git a/src/aktualizr_lite/test_lite.sh b/src/aktualizr_lite/test_lite.sh
+index a17e68b1..2a07522c 100755
+--- a/src/aktualizr_lite/test_lite.sh
++++ b/src/aktualizr_lite/test_lite.sh
+@@ -7,6 +7,7 @@ akrepo_bin=$2
+ tests_dir=$3
+ #valgrind=$4
+ valgrind=""
++mock_ostree=$(dirname $aklite)/libt_lite-mock.so
+ 
+ dest_dir=$(mktemp -d)
+ 
+@@ -84,7 +85,7 @@ EOF
+ $valgrind $aklite -h | grep "Command to execute: status, list, update"
+ 
+ ## Check that we can do the list command
+-out=$($valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml list)
++out=$(OSTREE_HASH="foobar" LD_PRELOAD=$mock_ostree $valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml list)
+ if [[ ! "$out" =~ "foo1" ]] ; then
+     echo "ERROR: foo1 update missing"
+     exit 1
+@@ -101,7 +102,7 @@ sha=$(echo $update | cut -d\  -f2 | sed 's/\.0$//')
+ echo "Adding new target: $name / $sha"
+ add_target $name $sha
+ 
+-$valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update --update-name $name
++OSTREE_HASH=$sha LD_PRELOAD=$mock_ostree $valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update --update-name $name
+ ostree admin status
+ 
+-$valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update | grep "Updating to: Target(zlast"
++OSTREE_HASH=$sha LD_PRELOAD=$mock_ostree $valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update | grep "Updating to: Target(zlast"
+-- 
+2.22.0
+

--- a/recipes-sota/aktualizr/aktualizr/0002-FIO-toup-aktualizr-lite-Save-installed-version-targe.patch
+++ b/recipes-sota/aktualizr/aktualizr/0002-FIO-toup-aktualizr-lite-Save-installed-version-targe.patch
@@ -1,0 +1,144 @@
+From 4403a1b7d5770adba59c8fb667d673fcf80a9dfb Mon Sep 17 00:00:00 2001
+From: Andy Doan <andy@foundries.io>
+Date: Wed, 10 Jul 2019 14:33:04 -0500
+Subject: [PATCH 02/12] [FIO toup] aktualizr-lite: Save installed version
+ target
+
+This will help make the getTarget method of the packagemanager work
+which is needed so that daemon mode will know when to do an update.
+
+Signed-off-by: Andy Doan <andy@foundries.io>
+---
+ src/aktualizr_lite/main.cc                  | 67 ++++++++++++++-------
+ src/libaktualizr/primary/sotauptaneclient.h |  1 +
+ 2 files changed, 47 insertions(+), 21 deletions(-)
+
+diff --git a/src/aktualizr_lite/main.cc b/src/aktualizr_lite/main.cc
+index e1569592..0243a62b 100644
+--- a/src/aktualizr_lite/main.cc
++++ b/src/aktualizr_lite/main.cc
+@@ -16,9 +16,25 @@
+ 
+ namespace bpo = boost::program_options;
+ 
+-static std::shared_ptr<SotaUptaneClient> liteClient(Config &config) {
++static void finalizeIfNeeded(INvStorage &storage, const Uptane::Target &curTarget) {
++  std::vector<Uptane::Target> installed_versions;
++  size_t pending_index = SIZE_MAX;
++  storage.loadInstalledVersions("", &installed_versions, nullptr, &pending_index);
++
++  if (pending_index < installed_versions.size()) {
++    const Uptane::Target &target = installed_versions[pending_index];
++    if (curTarget == target) {
++      LOG_INFO << "Marking target install complete for: " << target;
++      storage.saveInstalledVersion("", target, InstalledVersionUpdateMode::kCurrent);
++    }
++  }
++}
++
++static std::shared_ptr<SotaUptaneClient> liteClient(Config &config, std::shared_ptr<INvStorage> storage) {
+   std::string pkey;
+-  auto storage = INvStorage::newStorage(config.storage);
++  if (storage == nullptr) {
++    storage = INvStorage::newStorage(config.storage);
++  }
+   storage->importData(config.import);
+ 
+   EcuSerials ecu_serials;
+@@ -44,7 +60,9 @@ static std::shared_ptr<SotaUptaneClient> liteClient(Config &config) {
+   KeyManager keys(storage, config.keymanagerConfig());
+   keys.copyCertsToCurl(*http_client);
+ 
+-  return std::make_shared<SotaUptaneClient>(config, storage, http_client, bootloader, report_queue);
++  auto client = std::make_shared<SotaUptaneClient>(config, storage, http_client, bootloader, report_queue);
++  finalizeIfNeeded(*storage, client->getCurrent());
++  return client;
+ }
+ 
+ static int status_main(Config &config, const bpo::variables_map &unused) {
+@@ -61,7 +79,7 @@ static int status_main(Config &config, const bpo::variables_map &unused) {
+ 
+ static int list_main(Config &config, const bpo::variables_map &unused) {
+   (void)unused;
+-  auto client = liteClient(config);
++  auto client = liteClient(config, nullptr);
+   Uptane::HardwareIdentifier hwid(config.provision.primary_ecu_hardware_id);
+ 
+   LOG_INFO << "Refreshing target metadata";
+@@ -136,30 +154,22 @@ static std::unique_ptr<Uptane::Target> find_target(const std::shared_ptr<SotaUpt
+   throw std::runtime_error("Unable to find update");
+ }
+ 
+-static int update_main(Config &config, const bpo::variables_map &variables_map) {
+-  auto client = liteClient(config);
+-  Uptane::HardwareIdentifier hwid(config.provision.primary_ecu_hardware_id);
+-
+-  std::string version("latest");
+-  if (variables_map.count("update-name") > 0) {
+-    version = variables_map["update-name"].as<std::string>();
+-  }
+-  LOG_INFO << "Finding " << version << " to update to...";
+-  auto target = find_target(client, hwid, version);
+-  LOG_INFO << "Updating to: " << *target;
+-
+-  std::vector<Uptane::Target> targets{*target};
+-  auto result = client->downloadImages(targets);
++static int do_update(SotaUptaneClient &client, INvStorage &storage, Uptane::Target &target) {
++  std::vector<Uptane::Target> targets{target};
++  auto result = client.downloadImages(targets);
+   if (result.status != result::DownloadStatus::kSuccess &&
+       result.status != result::DownloadStatus::kNothingToDownload) {
+     LOG_ERROR << "Unable to download update: " + result.message;
+     return 1;
+   }
+-  auto iresult = client->PackageInstall(*target);
++
++  auto iresult = client.PackageInstall(target);
+   if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
+     LOG_INFO << "Update complete. Please reboot the device to activate";
+-  } else if (iresult.result_code.num_code != data::ResultCode::Numeric::kOk &&
+-             iresult.result_code.num_code != data::ResultCode::Numeric::kNeedCompletion) {
++    storage.saveInstalledVersion("", target, InstalledVersionUpdateMode::kPending);
++  } else if (iresult.result_code.num_code == data::ResultCode::Numeric::kOk) {
++    storage.saveInstalledVersion("", target, InstalledVersionUpdateMode::kCurrent);
++  } else {
+     LOG_ERROR << "Unable to install update: " << iresult.description;
+     return 1;
+   }
+@@ -167,6 +177,21 @@ static int update_main(Config &config, const bpo::variables_map &variables_map)
+   return 0;
+ }
+ 
++static int update_main(Config &config, const bpo::variables_map &variables_map) {
++  auto storage = INvStorage::newStorage(config.storage);
++  auto client = liteClient(config, storage);
++  Uptane::HardwareIdentifier hwid(config.provision.primary_ecu_hardware_id);
++
++  std::string version("latest");
++  if (variables_map.count("update-name") > 0) {
++    version = variables_map["update-name"].as<std::string>();
++  }
++  LOG_INFO << "Finding " << version << " to update to...";
++  auto target = find_target(client, hwid, version);
++  LOG_INFO << "Updating to: " << *target;
++  return do_update(*client, *storage, *target);
++}
++
+ struct SubCommand {
+   const char *name;
+   int (*main)(Config &, const bpo::variables_map &);
+diff --git a/src/libaktualizr/primary/sotauptaneclient.h b/src/libaktualizr/primary/sotauptaneclient.h
+index 529b8477..12147390 100644
+--- a/src/libaktualizr/primary/sotauptaneclient.h
++++ b/src/libaktualizr/primary/sotauptaneclient.h
+@@ -58,6 +58,7 @@ class SotaUptaneClient {
+   bool isInstallCompletionRequired();
+   void completeInstall();
+   Uptane::LazyTargetsList allTargets();
++  Uptane::Target getCurrent() { return package_manager_->getCurrent(); }
+ 
+   bool updateImagesMeta();  // TODO: make private once aktualizr has a proper TUF API
+   bool checkImagesMetaOffline();
+-- 
+2.22.0
+

--- a/recipes-sota/aktualizr/aktualizr/0003-FIO-toup-aktualizr-lite-Use-current-target-for-statu.patch
+++ b/recipes-sota/aktualizr/aktualizr/0003-FIO-toup-aktualizr-lite-Use-current-target-for-statu.patch
@@ -1,0 +1,111 @@
+From 2b70423942096380486711174d0d714e03983254 Mon Sep 17 00:00:00 2001
+From: Andy Doan <andy@foundries.io>
+Date: Wed, 10 Jul 2019 18:17:26 -0500
+Subject: [PATCH 03/12] [FIO toup] aktualizr-lite: Use current target for
+ status
+
+Now that we are tracking the installed target properly, we can use
+getCurrent to make this easier and more informative.
+
+Signed-off-by: Andy Doan <andy@foundries.io>
+---
+ src/aktualizr_lite/main.cc      | 56 +++++++++++++++++++--------------
+ src/aktualizr_lite/test_lite.sh |  7 +++++
+ 2 files changed, 39 insertions(+), 24 deletions(-)
+
+diff --git a/src/aktualizr_lite/main.cc b/src/aktualizr_lite/main.cc
+index 0243a62b..46bb2402 100644
+--- a/src/aktualizr_lite/main.cc
++++ b/src/aktualizr_lite/main.cc
+@@ -65,14 +65,41 @@ static std::shared_ptr<SotaUptaneClient> liteClient(Config &config, std::shared_
+   return client;
+ }
+ 
++static void log_info_target(const std::string &prefix, const Config &config, const Uptane::Target &t) {
++  auto name = t.filename();
++  if (t.custom_version().length() > 0) {
++    name = t.custom_version();
++  }
++  LOG_INFO << prefix + name << "\tsha256:" << t.sha256Hash();
++  if (config.pacman.type == PackageManager::kOstreeDockerApp) {
++    bool shown = false;
++    auto apps = t.custom_data()["docker_apps"];
++    for (Json::ValueIterator i = apps.begin(); i != apps.end(); ++i) {
++      if (!shown) {
++        shown = true;
++        LOG_INFO << "\tDocker Apps:";
++      }
++      if ((*i).isObject() && (*i).isMember("filename")) {
++        LOG_INFO << "\t\t" << i.key().asString() << " -> " << (*i)["filename"].asString();
++      } else {
++        LOG_ERROR << "\t\tInvalid custom data for docker-app: " << i.key().asString();
++      }
++    }
++  }
++}
++
+ static int status_main(Config &config, const bpo::variables_map &unused) {
+   (void)unused;
+-  GObjectUniquePtr<OstreeSysroot> sysroot_smart = OstreeManager::LoadSysroot(config.pacman.sysroot);
+-  OstreeDeployment *deployment = ostree_sysroot_get_booted_deployment(sysroot_smart.get());
+-  if (deployment == nullptr) {
++  auto target = liteClient(config, nullptr)->getCurrent();
++
++  if (target == Uptane::Target::Unknown()) {
+     LOG_INFO << "No active deployment found";
+   } else {
+-    LOG_INFO << "Active image is: " << ostree_deployment_get_csum(deployment);
++    auto name = target.filename();
++    if (target.custom_version().length() > 0) {
++      name = target.custom_version();
++    }
++    log_info_target("Active image is: ", config, target);
+   }
+   return 0;
+ }
+@@ -95,26 +122,7 @@ static int list_main(Config &config, const bpo::variables_map &unused) {
+   for (auto &t : client->allTargets()) {
+     for (auto const &it : t.hardwareIds()) {
+       if (it == hwid) {
+-        auto name = t.filename();
+-        if (t.custom_version().length() > 0) {
+-          name = t.custom_version();
+-        }
+-        LOG_INFO << name << "\tsha256:" << t.sha256Hash();
+-        if (config.pacman.type == PackageManager::kOstreeDockerApp) {
+-          bool shown = false;
+-          auto apps = t.custom_data()["docker_apps"];
+-          for (Json::ValueIterator i = apps.begin(); i != apps.end(); ++i) {
+-            if (!shown) {
+-              shown = true;
+-              LOG_INFO << "\tDocker Apps:";
+-            }
+-            if ((*i).isObject() && (*i).isMember("filename")) {
+-              LOG_INFO << "\t\t" << i.key().asString() << " -> " << (*i)["filename"].asString();
+-            } else {
+-              LOG_ERROR << "\t\tInvalid custom data for docker-app: " << i.key().asString();
+-            }
+-          }
+-        }
++        log_info_target("", config, t);
+         break;
+       }
+     }
+diff --git a/src/aktualizr_lite/test_lite.sh b/src/aktualizr_lite/test_lite.sh
+index 2a07522c..df57da54 100755
+--- a/src/aktualizr_lite/test_lite.sh
++++ b/src/aktualizr_lite/test_lite.sh
+@@ -106,3 +106,10 @@ OSTREE_HASH=$sha LD_PRELOAD=$mock_ostree $valgrind $aklite --loglevel 1 -c $sota
+ ostree admin status
+ 
+ OSTREE_HASH=$sha LD_PRELOAD=$mock_ostree $valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update | grep "Updating to: Target(zlast"
++
++out=$(OSTREE_HASH="$sha" LD_PRELOAD=$mock_ostree $valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml status)
++if [[ ! "$out" =~ "Active image is: zlast	sha256:$sha" ]] ; then
++    echo "ERROR: status incorrect:"
++    echo $out
++    exit 1
++fi
+-- 
+2.22.0
+

--- a/recipes-sota/aktualizr/aktualizr/0004-FIO-toup-docker-apps-Add-support-for-getCurrent.patch
+++ b/recipes-sota/aktualizr/aktualizr/0004-FIO-toup-docker-apps-Add-support-for-getCurrent.patch
@@ -1,0 +1,131 @@
+From ec1d90ef9000cd9e7fb9329e5ee6aaeef997d533 Mon Sep 17 00:00:00 2001
+From: Andy Doan <andy@foundries.io>
+Date: Sun, 30 Jun 2019 16:16:34 -0500
+Subject: [PATCH 04/12] [FIO toup] docker-apps: Add support for getCurrent
+
+This will be needed for aktualizr-lite so that it can understand
+what version of a docker app is deployed.
+
+Signed-off-by: Andy Doan <andy@foundries.io>
+---
+ .../package_manager/dockerappmanager.cc        | 18 ++++++++++++++++++
+ .../package_manager/dockerappmanager.h         |  4 ++++
+ .../package_manager/dockerappmanager_test.cc   | 14 +++++++++++++-
+ src/libaktualizr/uptane/tuf.h                  |  1 +
+ 4 files changed, 36 insertions(+), 1 deletion(-)
+
+diff --git a/src/libaktualizr/package_manager/dockerappmanager.cc b/src/libaktualizr/package_manager/dockerappmanager.cc
+index 30d83d0e..2eaf9ec6 100644
+--- a/src/libaktualizr/package_manager/dockerappmanager.cc
++++ b/src/libaktualizr/package_manager/dockerappmanager.cc
+@@ -99,6 +99,10 @@ bool DockerAppManager::fetchTarget(const Uptane::Target &target, Uptane::Fetcher
+ 
+ data::InstallationResult DockerAppManager::install(const Uptane::Target &target) const {
+   auto res = OstreeManager::install(target);
++  if (config.docker_apps.empty()) {
++    return res;
++  }
++  Utils::writeFile(config.docker_apps_root / "target_apps", target.custom_data()["docker_apps"], true);
+   auto cb = [this](const std::string &app, const Uptane::Target &app_target) {
+     LOG_INFO << "Installing " << app << " -> " << app_target;
+     std::stringstream ss;
+@@ -114,3 +118,17 @@ data::InstallationResult DockerAppManager::install(const Uptane::Target &target)
+   }
+   return res;
+ }
++
++Uptane::Target DockerAppManager::getCurrent() const {
++  auto target = fakeGetCurrent ? Uptane::Target::Unknown() : OstreeManager::getCurrent();
++  Json::Value apps;
++
++  std::ifstream apps_stream((config.docker_apps_root / ("target_apps")).c_str());
++  if (!apps_stream.fail()) {
++    auto custom = target.custom_data();
++    apps_stream >> custom["docker_apps"];
++    target.updateCustom(custom);
++  }
++  return target;
++}
++bool DockerAppManager::fakeGetCurrent = false;
+diff --git a/src/libaktualizr/package_manager/dockerappmanager.h b/src/libaktualizr/package_manager/dockerappmanager.h
+index a8e5a851..a9f65a87 100644
+--- a/src/libaktualizr/package_manager/dockerappmanager.h
++++ b/src/libaktualizr/package_manager/dockerappmanager.h
+@@ -17,6 +17,9 @@ class DockerAppManager : public OstreeManager {
+                    FetcherProgressCb progress_cb, const api::FlowControlToken *token = nullptr) override;
+   data::InstallationResult install(const Uptane::Target &target) const override;
+   std::string name() const override { return "ostree+docker-app"; }
++  Uptane::Target getCurrent() const override;
++
++  static bool fakeGetCurrent;
+ 
+  private:
+   bool iterate_apps(const Uptane::Target &target, DockerAppCb cb) const;
+@@ -25,4 +28,5 @@ class DockerAppManager : public OstreeManager {
+   // and we just need to construct a dummy one to make the compiler happy.
+   std::shared_ptr<Uptane::Fetcher> fake_fetcher_;
+ };
++
+ #endif  // DOCKERAPPMGR_H_
+diff --git a/src/libaktualizr/package_manager/dockerappmanager_test.cc b/src/libaktualizr/package_manager/dockerappmanager_test.cc
+index be3cd12d..0666372f 100644
+--- a/src/libaktualizr/package_manager/dockerappmanager_test.cc
++++ b/src/libaktualizr/package_manager/dockerappmanager_test.cc
+@@ -5,6 +5,7 @@
+ 
+ #include "config/config.h"
+ #include "http/httpclient.h"
++#include "package_manager/dockerappmanager.h"
+ #include "package_manager/packagemanagerfactory.h"
+ #include "package_manager/packagemanagerinterface.h"
+ #include "primary/sotauptaneclient.h"
+@@ -81,8 +82,12 @@ TEST(DockerAppManager, DockerApp_Fetch) {
+   KeyManager keys(storage, config.keymanagerConfig());
+   auto http = std::make_shared<HttpClient>();
+   auto client = newTestClient(config, storage, http, nullptr);
+-  ASSERT_TRUE(client->updateImagesMeta());
+ 
++  // Make sure we can read an empty target
++  auto current = client->package_manager_->getCurrent();
++  ASSERT_EQ("", current.custom_data()["docker_apps"].asString());
++
++  ASSERT_TRUE(client->updateImagesMeta());
+   std::string targets = Utils::readFile(repo / "repo/image/targets.json");
+   LOG_INFO << "Repo targets " << targets;
+ 
+@@ -100,6 +105,9 @@ TEST(DockerAppManager, DockerApp_Fetch) {
+   client->package_manager_->install(target);
+   std::string content = Utils::readFile(config.pacman.docker_apps_root / "app1/docker-compose.yml");
+   ASSERT_EQ("DOCKER-APP RENDER OUTPUT\nfake contents of a docker app\n", content);
++
++  current = client->package_manager_->getCurrent();
++  ASSERT_EQ("foo.dockerapp", current.custom_data()["docker_apps"]["app1"]["filename"].asString());
+ }
+ 
+ #ifndef __NO_MAIN__
+@@ -127,6 +135,10 @@ int main(int argc, char** argv) {
+ 
+   TestUtils::waitForServer(treehub_server + "/");
+ 
++  // OstreeManager::getCurrent throws an exception because there's not
++  // a real booted deployment.
++  DockerAppManager::fakeGetCurrent = true;
++
+   return RUN_ALL_TESTS();
+ }
+ #endif
+diff --git a/src/libaktualizr/uptane/tuf.h b/src/libaktualizr/uptane/tuf.h
+index 84a35e7d..bb715860 100644
+--- a/src/libaktualizr/uptane/tuf.h
++++ b/src/libaktualizr/uptane/tuf.h
+@@ -236,6 +236,7 @@ class Target {
+   std::vector<HardwareIdentifier> hardwareIds() const { return hwids_; };
+   std::string custom_version() const { return custom_["version"].asString(); }
+   Json::Value custom_data() const { return custom_; }
++  void updateCustom(Json::Value &custom) { custom_ = custom; };
+   std::string correlation_id() const { return correlation_id_; };
+   void setCorrelationId(std::string correlation_id) { correlation_id_ = std::move(correlation_id); };
+   uint64_t length() const { return length_; }
+-- 
+2.22.0
+

--- a/recipes-sota/aktualizr/aktualizr/0005-FIO-toup-aktualizr-lite-Rename-version-to-helpers.patch
+++ b/recipes-sota/aktualizr/aktualizr/0005-FIO-toup-aktualizr-lite-Rename-version-to-helpers.patch
@@ -1,0 +1,79 @@
+From 306cf9df202e2924d225a676d72ebd183c596f55 Mon Sep 17 00:00:00 2001
+From: Andy Doan <andy@foundries.io>
+Date: Wed, 10 Jul 2019 18:38:46 -0500
+Subject: [PATCH 05/12] [FIO toup] aktualizr-lite: Rename version* to helpers*
+
+More stuff can be moved into a helpers file which will also allow
+a bit more unit test coverage.
+
+Signed-off-by: Andy Doan <andy@foundries.io>
+---
+ src/aktualizr_lite/CMakeLists.txt                       | 9 ++++++---
+ src/aktualizr_lite/{version.h => helpers.h}             | 0
+ src/aktualizr_lite/{version_test.cc => helpers_test.cc} | 2 +-
+ src/aktualizr_lite/main.cc                              | 2 +-
+ 4 files changed, 8 insertions(+), 5 deletions(-)
+ rename src/aktualizr_lite/{version.h => helpers.h} (100%)
+ rename src/aktualizr_lite/{version_test.cc => helpers_test.cc} (97%)
+
+diff --git a/src/aktualizr_lite/CMakeLists.txt b/src/aktualizr_lite/CMakeLists.txt
+index 408c9546..92b2f0cd 100644
+--- a/src/aktualizr_lite/CMakeLists.txt
++++ b/src/aktualizr_lite/CMakeLists.txt
+@@ -1,5 +1,8 @@
++set(AKTUALIZR_LITE_SRC main.cc)
++set(AKTUALIZR_LITE_HEADERS helpers.h)
++
+ if(BUILD_OSTREE)
+-add_executable(aktualizr-lite main.cc version.h)
++add_executable(aktualizr-lite ${AKTUALIZR_LITE_SRC})
+ target_link_libraries(aktualizr-lite aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
+ 
+ install(TARGETS aktualizr-lite RUNTIME DESTINATION bin COMPONENT aktualizr-lite)
+@@ -19,7 +22,7 @@ add_library(t_lite-mock SHARED ostree_mock.cc)
+ 
+ endif(BUILD_OSTREE)
+ 
+-add_aktualizr_test(NAME lite-version SOURCES version_test.cc)
++add_aktualizr_test(NAME lite-helpers SOURCES helpers_test.cc)
+ 
+-aktualizr_source_file_checks(main.cc version.h version_test.cc ostree_mock.cc)
++aktualizr_source_file_checks(main.cc ${AKTUALIZR_LITE_SRC} ${AKTUALIZR_LITE_HEADERS} helpers_test.cc ostree_mock.cc)
+ # vim: set tabstop=4 shiftwidth=4 expandtab:
+diff --git a/src/aktualizr_lite/version.h b/src/aktualizr_lite/helpers.h
+similarity index 100%
+rename from src/aktualizr_lite/version.h
+rename to src/aktualizr_lite/helpers.h
+diff --git a/src/aktualizr_lite/version_test.cc b/src/aktualizr_lite/helpers_test.cc
+similarity index 97%
+rename from src/aktualizr_lite/version_test.cc
+rename to src/aktualizr_lite/helpers_test.cc
+index 68ac2fb2..96020ec7 100644
+--- a/src/aktualizr_lite/version_test.cc
++++ b/src/aktualizr_lite/helpers_test.cc
+@@ -1,6 +1,6 @@
+ #include <gtest/gtest.h>
+ 
+-#include "version.h"
++#include "helpers.h"
+ 
+ TEST(version, bad_versions) {
+   ASSERT_TRUE(Version("bar") < Version("foo"));
+diff --git a/src/aktualizr_lite/main.cc b/src/aktualizr_lite/main.cc
+index 46bb2402..b8fb6bdf 100644
+--- a/src/aktualizr_lite/main.cc
++++ b/src/aktualizr_lite/main.cc
+@@ -8,9 +8,9 @@
+ #include <boost/uuid/uuid_io.hpp>
+ 
+ #include "config/config.h"
++#include "helpers.h"
+ #include "package_manager/ostreemanager.h"
+ #include "primary/sotauptaneclient.h"
+-#include "version.h"
+ 
+ #include "utilities/aktualizr_version.h"
+ 
+-- 
+2.22.0
+

--- a/recipes-sota/aktualizr/aktualizr/0006-config-Add-notion-of-tags-to-package-manager.patch
+++ b/recipes-sota/aktualizr/aktualizr/0006-config-Add-notion-of-tags-to-package-manager.patch
@@ -1,0 +1,183 @@
+From 270a0aca06a31cc363dc38890f832931e18a1da8 Mon Sep 17 00:00:00 2001
+From: Andy Doan <andy@foundries.io>
+Date: Fri, 28 Jun 2019 09:36:22 -0500
+Subject: [PATCH 06/12] config: Add notion of "tags" to package manager
+
+The idea here is that the aktualizr lite client can look at tags
+in each target to decide if its applicable to for the device. This
+would allow us to use one TUF repo to support things like premerge
+and release builds.
+
+Signed-off-by: Andy Doan <andy@foundries.io>
+---
+ src/aktualizr_lite/CMakeLists.txt             |  4 +--
+ src/aktualizr_lite/helpers.cc                 | 15 +++++++++
+ src/aktualizr_lite/helpers.h                  |  9 ++++++
+ src/aktualizr_lite/helpers_test.cc            | 31 +++++++++++++++++++
+ src/aktualizr_lite/main.cc                    |  3 ++
+ .../package_manager/packagemanagerconfig.cc   |  7 ++++-
+ .../package_manager/packagemanagerconfig.h    |  1 +
+ 7 files changed, 67 insertions(+), 3 deletions(-)
+ create mode 100644 src/aktualizr_lite/helpers.cc
+
+diff --git a/src/aktualizr_lite/CMakeLists.txt b/src/aktualizr_lite/CMakeLists.txt
+index 92b2f0cd..f8b6b519 100644
+--- a/src/aktualizr_lite/CMakeLists.txt
++++ b/src/aktualizr_lite/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-set(AKTUALIZR_LITE_SRC main.cc)
++set(AKTUALIZR_LITE_SRC main.cc helpers.cc)
+ set(AKTUALIZR_LITE_HEADERS helpers.h)
+ 
+ if(BUILD_OSTREE)
+@@ -22,7 +22,7 @@ add_library(t_lite-mock SHARED ostree_mock.cc)
+ 
+ endif(BUILD_OSTREE)
+ 
+-add_aktualizr_test(NAME lite-helpers SOURCES helpers_test.cc)
++add_aktualizr_test(NAME lite-helpers SOURCES helpers.cc helpers_test.cc)
+ 
+ aktualizr_source_file_checks(main.cc ${AKTUALIZR_LITE_SRC} ${AKTUALIZR_LITE_HEADERS} helpers_test.cc ostree_mock.cc)
+ # vim: set tabstop=4 shiftwidth=4 expandtab:
+diff --git a/src/aktualizr_lite/helpers.cc b/src/aktualizr_lite/helpers.cc
+new file mode 100644
+index 00000000..e14293d3
+--- /dev/null
++++ b/src/aktualizr_lite/helpers.cc
+@@ -0,0 +1,15 @@
++#include "helpers.h"
++
++bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags) {
++  if (!config_tags.empty()) {
++    auto tags = t.custom_data()["tags"];
++    for (Json::ValueIterator i = tags.begin(); i != tags.end(); ++i) {
++      auto tag = (*i).asString();
++      if (std::find(config_tags.begin(), config_tags.end(), tag) != config_tags.end()) {
++        return true;
++      }
++    }
++    return false;
++  }
++  return true;
++}
+diff --git a/src/aktualizr_lite/helpers.h b/src/aktualizr_lite/helpers.h
+index 6c643e8a..81a9d8f9 100644
+--- a/src/aktualizr_lite/helpers.h
++++ b/src/aktualizr_lite/helpers.h
+@@ -1,10 +1,19 @@
++#ifndef AKTUALIZR_LITE_HELPERS
++#define AKTUALIZR_LITE_HELPERS
++
+ #include <string>
+ 
+ #include <string.h>
+ 
++#include "uptane/tuf.h"
++
+ struct Version {
+   std::string raw_ver;
+   Version(std::string version) : raw_ver(std::move(version)) {}
+ 
+   bool operator<(const Version& other) { return strverscmp(raw_ver.c_str(), other.raw_ver.c_str()) < 0; }
+ };
++
++bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
++
++#endif  // AKTUALIZR_LITE_HELPERS
+diff --git a/src/aktualizr_lite/helpers_test.cc b/src/aktualizr_lite/helpers_test.cc
+index 96020ec7..c5fea698 100644
+--- a/src/aktualizr_lite/helpers_test.cc
++++ b/src/aktualizr_lite/helpers_test.cc
+@@ -19,6 +19,37 @@ TEST(version, good_versions) {
+   ASSERT_TRUE(Version("1.9.0") < Version("1.10"));
+ }
+ 
++TEST(version, target_has_tags) {
++  auto t = Uptane::Target::Unknown();
++
++  // No tags defined in target:
++  std::vector<std::string> config_tags;
++  ASSERT_TRUE(target_has_tags(t, config_tags));
++  config_tags.push_back("foo");
++  ASSERT_FALSE(target_has_tags(t, config_tags));
++
++  // Set target tags to: premerge, qa
++  auto custom = t.custom_data();
++  custom["tags"].append("premerge");
++  custom["tags"].append("qa");
++  t.updateCustom(custom);
++
++  config_tags.clear();
++  ASSERT_TRUE(target_has_tags(t, config_tags));
++
++  config_tags.push_back("qa");
++  config_tags.push_back("blah");
++  ASSERT_TRUE(target_has_tags(t, config_tags));
++
++  config_tags.clear();
++  config_tags.push_back("premerge");
++  ASSERT_TRUE(target_has_tags(t, config_tags));
++
++  config_tags.clear();
++  config_tags.push_back("foo");
++  ASSERT_FALSE(target_has_tags(t, config_tags));
++}
++
+ #ifndef __NO_MAIN__
+ int main(int argc, char **argv) {
+   ::testing::InitGoogleTest(&argc, argv);
+diff --git a/src/aktualizr_lite/main.cc b/src/aktualizr_lite/main.cc
+index b8fb6bdf..90b8625c 100644
+--- a/src/aktualizr_lite/main.cc
++++ b/src/aktualizr_lite/main.cc
+@@ -120,6 +120,9 @@ static int list_main(Config &config, const bpo::variables_map &unused) {
+ 
+   LOG_INFO << "Updates available to " << hwid << ":";
+   for (auto &t : client->allTargets()) {
++    if (!target_has_tags(t, config.pacman.tags)) {
++      continue;
++    }
+     for (auto const &it : t.hardwareIds()) {
+       if (it == hwid) {
+         log_info_target("", config, t);
+diff --git a/src/libaktualizr/package_manager/packagemanagerconfig.cc b/src/libaktualizr/package_manager/packagemanagerconfig.cc
+index 53677bd8..c36ef082 100644
+--- a/src/libaktualizr/package_manager/packagemanagerconfig.cc
++++ b/src/libaktualizr/package_manager/packagemanagerconfig.cc
+@@ -33,8 +33,12 @@ void PackageConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt
+   CopyFromConfig(ostree_server, "ostree_server", pt);
+   CopyFromConfig(packages_file, "packages_file", pt);
+   CopyFromConfig(fake_need_reboot, "fake_need_reboot", pt);
+-#ifdef BUILD_DOCKERAPP
+   std::string val;
++  CopyFromConfig(val, "tags", pt);
++  if (val.length() > 0) {
++    boost::split(tags, val, boost::is_any_of(", "), boost::token_compress_on);
++  }
++#ifdef BUILD_DOCKERAPP
+   CopyFromConfig(val, "docker_apps", pt);
+   if (val.length() > 0) {
+     // token_compress_on allows lists like: "foo,bar", "foo, bar", or "foo bar"
+@@ -54,6 +58,7 @@ void PackageConfig::writeToStream(std::ostream& out_stream) const {
+   writeOption(out_stream, ostree_server, "ostree_server");
+   writeOption(out_stream, packages_file, "packages_file");
+   writeOption(out_stream, fake_need_reboot, "fake_need_reboot");
++  writeOption(out_stream, boost::algorithm::join(tags, ","), "tags");
+ #ifdef BUILD_DOCKERAPP
+   writeOption(out_stream, boost::algorithm::join(docker_apps, ","), "docker_apps");
+   writeOption(out_stream, docker_apps_root, "docker_apps_root");
+diff --git a/src/libaktualizr/package_manager/packagemanagerconfig.h b/src/libaktualizr/package_manager/packagemanagerconfig.h
+index d19bdd87..f0f3c9a1 100644
+--- a/src/libaktualizr/package_manager/packagemanagerconfig.h
++++ b/src/libaktualizr/package_manager/packagemanagerconfig.h
+@@ -16,6 +16,7 @@ struct PackageConfig {
+   boost::filesystem::path sysroot;
+   std::string ostree_server;
+   boost::filesystem::path packages_file{"/usr/package.manifest"};
++  std::vector<std::string> tags;
+ 
+ #ifdef BUILD_DOCKERAPP
+   std::vector<std::string> docker_apps;
+-- 
+2.22.0
+

--- a/recipes-sota/aktualizr/aktualizr/0007-aktualizr-lite-Include-ostree-hash-in-request-header.patch
+++ b/recipes-sota/aktualizr/aktualizr/0007-aktualizr-lite-Include-ostree-hash-in-request-header.patch
@@ -1,0 +1,40 @@
+From 429a09179718ba20f12ec659f37a4c432de4a891 Mon Sep 17 00:00:00 2001
+From: Andy Doan <andy@foundries.io>
+Date: Fri, 21 Jun 2019 15:50:47 -0500
+Subject: [PATCH 07/12] aktualizr-lite: Include ostree hash in request headers
+
+This allows the OTA server to passively understand what levels of
+code are being run.
+
+Signed-off-by: Andy Doan <andy@foundries.io>
+---
+ src/aktualizr_lite/main.cc | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/src/aktualizr_lite/main.cc b/src/aktualizr_lite/main.cc
+index 90b8625c..5f8011fc 100644
+--- a/src/aktualizr_lite/main.cc
++++ b/src/aktualizr_lite/main.cc
+@@ -53,7 +53,18 @@ static std::shared_ptr<SotaUptaneClient> liteClient(Config &config, std::shared_
+     storage->storeEcuSerials(ecu_serials);
+   }
+ 
+-  auto http_client = std::make_shared<HttpClient>();
++  std::vector<std::string> headers;
++  GObjectUniquePtr<OstreeSysroot> sysroot_smart = OstreeManager::LoadSysroot(config.pacman.sysroot);
++  OstreeDeployment *deployment = ostree_sysroot_get_booted_deployment(sysroot_smart.get());
++  std::string header("x-ats-ostreehash: ");
++  if (deployment != nullptr) {
++    header += ostree_deployment_get_csum(deployment);
++  } else {
++    header += "?";
++  }
++  headers.push_back(header);
++
++  auto http_client = std::make_shared<HttpClient>(&headers);
+   auto bootloader = std::make_shared<Bootloader>(config.bootloader, *storage);
+   auto report_queue = std::make_shared<ReportQueue>(config, http_client);
+ 
+-- 
+2.22.0
+

--- a/recipes-sota/aktualizr/aktualizr/0008-aktualizr-lite-Add-targets-equal-helper.patch
+++ b/recipes-sota/aktualizr/aktualizr/0008-aktualizr-lite-Add-targets-equal-helper.patch
@@ -1,0 +1,114 @@
+From 36b3a25b22fcf9416e2c33473b02b61d153890eb Mon Sep 17 00:00:00 2001
+From: Andy Doan <andy@foundries.io>
+Date: Tue, 2 Jul 2019 00:03:19 -0500
+Subject: [PATCH 08/12] aktualizr-lite: Add targets equal helper
+
+aktualizr-lite needs to know not just when the ostree hash is the
+same for a target, but also when the dockers apps are the same.
+
+Signed-off-by: Andy Doan <andy@foundries.io>
+---
+ src/aktualizr_lite/helpers.cc      | 25 ++++++++++++++++++
+ src/aktualizr_lite/helpers.h       |  1 +
+ src/aktualizr_lite/helpers_test.cc | 41 ++++++++++++++++++++++++++++++
+ 3 files changed, 67 insertions(+)
+
+diff --git a/src/aktualizr_lite/helpers.cc b/src/aktualizr_lite/helpers.cc
+index e14293d3..c96932ec 100644
+--- a/src/aktualizr_lite/helpers.cc
++++ b/src/aktualizr_lite/helpers.cc
+@@ -13,3 +13,28 @@ bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& co
+   }
+   return true;
+ }
++
++bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps) {
++  // target equality check looks at hashes
++  if (t1 == t2) {
++    if (compareDockerApps) {
++      auto t1_apps = t1.custom_data()["docker_apps"];
++      auto t2_apps = t2.custom_data()["docker_apps"];
++      for (Json::ValueIterator i = t1_apps.begin(); i != t1_apps.end(); ++i) {
++        auto app = i.key().asString();
++        if (!t2_apps.isMember(app)) {
++          return false;  // an app has been removed
++        }
++        if ((*i)["filename"].asString() != t2_apps[app]["filename"].asString()) {
++          return false;  // tuf target filename changed
++        }
++        t2_apps.removeMember(app);
++      }
++      if (t2_apps.size() > 0) {
++        return false;  // an app has been added
++      }
++    }
++    return true;  // docker apps are the same, or there are none
++  }
++  return false;
++}
+diff --git a/src/aktualizr_lite/helpers.h b/src/aktualizr_lite/helpers.h
+index 81a9d8f9..f027bb9c 100644
+--- a/src/aktualizr_lite/helpers.h
++++ b/src/aktualizr_lite/helpers.h
+@@ -15,5 +15,6 @@ struct Version {
+ };
+ 
+ bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
++bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps);
+ 
+ #endif  // AKTUALIZR_LITE_HELPERS
+diff --git a/src/aktualizr_lite/helpers_test.cc b/src/aktualizr_lite/helpers_test.cc
+index c5fea698..a9d946b6 100644
+--- a/src/aktualizr_lite/helpers_test.cc
++++ b/src/aktualizr_lite/helpers_test.cc
+@@ -50,6 +50,47 @@ TEST(version, target_has_tags) {
+   ASSERT_FALSE(target_has_tags(t, config_tags));
+ }
+ 
++TEST(version, targets_eq) {
++  auto t1 = Uptane::Target::Unknown();
++  auto t2 = Uptane::Target::Unknown();
++
++  // t1 should equal t2 when there a no docker-apps
++  ASSERT_TRUE(targets_eq(t1, t2, false));
++  ASSERT_TRUE(targets_eq(t1, t2, true));
++
++  auto custom = t1.custom_data();
++  custom["docker_apps"]["app1"]["filename"] = "app1-v1";
++  t1.updateCustom(custom);
++  ASSERT_TRUE(targets_eq(t1, t2, false));  // still equal, ignoring docker-apps
++  ASSERT_FALSE(targets_eq(t1, t2, true));
++
++  custom = t2.custom_data();
++  custom["docker_apps"]["app1"]["filename"] = "app1-v1";
++  t2.updateCustom(custom);
++  ASSERT_TRUE(targets_eq(t1, t2, true));
++
++  custom["docker_apps"]["app1"]["filename"] = "app1-v2";
++  t2.updateCustom(custom);
++  ASSERT_FALSE(targets_eq(t1, t2, true));  // version has changed
++
++  // Get things the same again
++  custom["docker_apps"]["app1"]["filename"] = "app1-v1";
++  t2.updateCustom(custom);
++
++  custom["docker_apps"]["app2"]["filename"] = "app2-v2";
++  t2.updateCustom(custom);
++  ASSERT_FALSE(targets_eq(t1, t2, true));  // t2 has an app that t1 doesn't
++
++  custom = t1.custom_data();
++  custom["docker_apps"]["app2"]["filename"] = "app2-v1";
++  t1.updateCustom(custom);
++  ASSERT_FALSE(targets_eq(t1, t2, true));  // app2 versions differ
++
++  custom["docker_apps"]["app2"]["filename"] = "app2-v2";
++  t1.updateCustom(custom);
++  ASSERT_TRUE(targets_eq(t1, t2, true));
++}
++
+ #ifndef __NO_MAIN__
+ int main(int argc, char **argv) {
+   ::testing::InitGoogleTest(&argc, argv);
+-- 
+2.22.0
+

--- a/recipes-sota/aktualizr/aktualizr/0009-aktualizr-lite-Add-a-daemon-mode.patch
+++ b/recipes-sota/aktualizr/aktualizr/0009-aktualizr-lite-Add-a-daemon-mode.patch
@@ -1,0 +1,85 @@
+From 5dca8121ae5e17b91c690bad4fbc104b691fb9c9 Mon Sep 17 00:00:00 2001
+From: Andy Doan <andy@foundries.io>
+Date: Tue, 2 Jul 2019 00:06:35 -0500
+Subject: [PATCH 09/12] aktualizr-lite: Add a daemon mode
+
+Signed-off-by: Andy Doan <andy@foundries.io>
+---
+ src/aktualizr_lite/main.cc | 40 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 40 insertions(+)
+
+diff --git a/src/aktualizr_lite/main.cc b/src/aktualizr_lite/main.cc
+index 5f8011fc..37781ec5 100644
+--- a/src/aktualizr_lite/main.cc
++++ b/src/aktualizr_lite/main.cc
+@@ -199,6 +199,13 @@ static int do_update(SotaUptaneClient &client, INvStorage &storage, Uptane::Targ
+   return 0;
+ }
+ 
++#ifdef BUILD_DOCKERAPP
++#define should_compare_docker_apps(config) \
++  (config.pacman.type == PackageManager::kOstreeDockerApp && !config.pacman.docker_apps.empty())
++#else
++#define should_compare_docker_apps(config) (false)
++#endif
++
+ static int update_main(Config &config, const bpo::variables_map &variables_map) {
+   auto storage = INvStorage::newStorage(config.storage);
+   auto client = liteClient(config, storage);
+@@ -214,6 +221,37 @@ static int update_main(Config &config, const bpo::variables_map &variables_map)
+   return do_update(*client, *storage, *target);
+ }
+ 
++static int daemon_main(Config &config, const bpo::variables_map &variables_map) {
++  auto storage = INvStorage::newStorage(config.storage);
++  auto client = liteClient(config, storage);
++  bool compareDockerApps = should_compare_docker_apps(config);
++  Uptane::HardwareIdentifier hwid(config.provision.primary_ecu_hardware_id);
++
++  auto current = client->getCurrent();
++  LOG_INFO << "Active image is: " << current;
++
++  unsigned int interval = 300;
++  if (variables_map.count("interval") > 0) {
++    interval = variables_map["interval"].as<unsigned int>();
++  }
++
++  while (true) {
++    LOG_INFO << "Refreshing target metadata";
++    if (!client->updateImagesMeta()) {
++      LOG_WARNING << "Unable to update latest metadata, using local copy";
++    }
++    auto target = find_target(client, hwid, "latest");
++    if (!targets_eq(*target, current, compareDockerApps)) {
++      LOG_INFO << "Updating base image to: " << *target;
++      if (do_update(*client, *storage, *target) == 0) {
++        // TODO reboot
++      }
++    }
++    sleep(interval);
++  }
++  return 0;
++}
++
+ struct SubCommand {
+   const char *name;
+   int (*main)(Config &, const bpo::variables_map &);
+@@ -222,6 +260,7 @@ static SubCommand commands[] = {
+     {"status", status_main},
+     {"list", list_main},
+     {"update", update_main},
++    {"daemon", daemon_main},
+ };
+ 
+ void check_info_options(const bpo::options_description &description, const bpo::variables_map &vm) {
+@@ -256,6 +295,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
+       ("ostree-server", bpo::value<std::string>(), "url of the ostree repository")
+       ("primary-ecu-hardware-id", bpo::value<std::string>(), "hardware ID of primary ecu")
+       ("update-name", bpo::value<std::string>(), "optional name of the update when running \"update\". default=latest")
++      ("interval", bpo::value<unsigned int>(), "optional interval in seconds to poll for update when in daemon mode. default=300")
+       ("command", bpo::value<std::string>(), subs.c_str());
+   // clang-format on
+ 
+-- 
+2.22.0
+

--- a/recipes-sota/aktualizr/aktualizr/0010-aktualizr-lite-Add-ability-to-reboot-after-an-update.patch
+++ b/recipes-sota/aktualizr/aktualizr/0010-aktualizr-lite-Add-ability-to-reboot-after-an-update.patch
@@ -1,0 +1,62 @@
+From c516da87cdc2b826ed1d145db747b22dce1d6bf8 Mon Sep 17 00:00:00 2001
+From: Andy Doan <andy@foundries.io>
+Date: Wed, 3 Jul 2019 23:10:04 -0500
+Subject: [PATCH 10/12] aktualizr-lite: Add ability to reboot after an update
+
+Signed-off-by: Andy Doan <andy@foundries.io>
+---
+ src/aktualizr_lite/main.cc | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/src/aktualizr_lite/main.cc b/src/aktualizr_lite/main.cc
+index 37781ec5..3a32a879 100644
+--- a/src/aktualizr_lite/main.cc
++++ b/src/aktualizr_lite/main.cc
+@@ -222,6 +222,12 @@ static int update_main(Config &config, const bpo::variables_map &variables_map)
+ }
+ 
+ static int daemon_main(Config &config, const bpo::variables_map &variables_map) {
++  auto rebootCmd = variables_map["reboot-command"].as<boost::filesystem::path>();
++  if (access(rebootCmd.c_str(), X_OK) != 0) {
++    LOG_ERROR << "reboot command: " << rebootCmd << " is not executable";
++    return 1;
++  }
++
+   auto storage = INvStorage::newStorage(config.storage);
+   auto client = liteClient(config, storage);
+   bool compareDockerApps = should_compare_docker_apps(config);
+@@ -244,7 +250,10 @@ static int daemon_main(Config &config, const bpo::variables_map &variables_map)
+     if (!targets_eq(*target, current, compareDockerApps)) {
+       LOG_INFO << "Updating base image to: " << *target;
+       if (do_update(*client, *storage, *target) == 0) {
+-        // TODO reboot
++        if (std::system(rebootCmd.c_str()) != 0) {
++          LOG_ERROR << "Unable to reboot system";
++          return 1;
++        }
+       }
+     }
+     sleep(interval);
+@@ -268,6 +277,11 @@ void check_info_options(const bpo::options_description &description, const bpo::
+     std::cout << description << '\n';
+     exit(EXIT_SUCCESS);
+   }
++  if (vm["command"].as<std::string>() == "daemon" && vm.count("reboot-command") == 0) {
++    std::cout << "ERROR: --reboot-command required when running as daemon\n";
++    std::cout << description << '\n';
++    exit(EXIT_SUCCESS);
++  }
+   if (vm.count("version") != 0) {
+     std::cout << "Current aktualizr version is: " << aktualizr_version() << "\n";
+     exit(EXIT_SUCCESS);
+@@ -296,6 +310,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
+       ("primary-ecu-hardware-id", bpo::value<std::string>(), "hardware ID of primary ecu")
+       ("update-name", bpo::value<std::string>(), "optional name of the update when running \"update\". default=latest")
+       ("interval", bpo::value<unsigned int>(), "optional interval in seconds to poll for update when in daemon mode. default=300")
++      ("reboot-command", bpo::value<boost::filesystem::path>(), "reboot command to call after an update is applied from daemon mode")
+       ("command", bpo::value<std::string>(), subs.c_str());
+   // clang-format on
+ 
+-- 
+2.22.0
+

--- a/recipes-sota/aktualizr/aktualizr/0011-aktualizr-lite-Add-lockfile-for-daemon-mode-updates.patch
+++ b/recipes-sota/aktualizr/aktualizr/0011-aktualizr-lite-Add-lockfile-for-daemon-mode-updates.patch
@@ -1,0 +1,109 @@
+From a9fdfd85d544b1be68de8fc6347d2eef4f1e8a44 Mon Sep 17 00:00:00 2001
+From: Andy Doan <andy@foundries.io>
+Date: Wed, 3 Jul 2019 23:36:27 -0500
+Subject: [PATCH 11/12] aktualizr-lite: Add lockfile for daemon mode updates
+
+This allows a different process to block the aktualizr-lite daemon
+from doing updates (and the reboot) if its doing something important.
+
+Signed-off-by: Andy Doan <andy@foundries.io>
+---
+ src/aktualizr_lite/main.cc | 36 +++++++++++++++++++++++++++++++++---
+ 1 file changed, 33 insertions(+), 3 deletions(-)
+
+diff --git a/src/aktualizr_lite/main.cc b/src/aktualizr_lite/main.cc
+index 3a32a879..8634e961 100644
+--- a/src/aktualizr_lite/main.cc
++++ b/src/aktualizr_lite/main.cc
+@@ -1,3 +1,4 @@
++#include <sys/file.h>
+ #include <unistd.h>
+ #include <iostream>
+ 
+@@ -176,7 +177,22 @@ static std::unique_ptr<Uptane::Target> find_target(const std::shared_ptr<SotaUpt
+   throw std::runtime_error("Unable to find update");
+ }
+ 
+-static int do_update(SotaUptaneClient &client, INvStorage &storage, Uptane::Target &target) {
++static int get_lock(const char *lockfile) {
++  int fd = open(lockfile, O_RDWR | O_CREAT | O_APPEND, 0666);
++  if (fd < 0) {
++    LOG_ERROR << "Unable to open lock file";
++    return -1;
++  }
++  LOG_INFO << "Aquiring lock";
++  if (flock(fd, LOCK_EX) < 0) {
++    LOG_ERROR << "Unable to aquire lock";
++    close(fd);
++    return -1;
++  }
++  return fd;
++}
++
++static int do_update(SotaUptaneClient &client, INvStorage &storage, Uptane::Target &target, const char *lockfile) {
+   std::vector<Uptane::Target> targets{target};
+   auto result = client.downloadImages(targets);
+   if (result.status != result::DownloadStatus::kSuccess &&
+@@ -185,6 +201,11 @@ static int do_update(SotaUptaneClient &client, INvStorage &storage, Uptane::Targ
+     return 1;
+   }
+ 
++  int lockfd = 0;
++  if (lockfile != nullptr && (lockfd = get_lock(lockfile)) < 0) {
++    return 1;
++  }
++
+   auto iresult = client.PackageInstall(target);
+   if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
+     LOG_INFO << "Update complete. Please reboot the device to activate";
+@@ -193,6 +214,8 @@ static int do_update(SotaUptaneClient &client, INvStorage &storage, Uptane::Targ
+     storage.saveInstalledVersion("", target, InstalledVersionUpdateMode::kCurrent);
+   } else {
+     LOG_ERROR << "Unable to install update: " << iresult.description;
++    // let go of the lock since we couldn't update
++    close(lockfd);
+     return 1;
+   }
+   LOG_INFO << iresult.description;
+@@ -218,7 +241,7 @@ static int update_main(Config &config, const bpo::variables_map &variables_map)
+   LOG_INFO << "Finding " << version << " to update to...";
+   auto target = find_target(client, hwid, version);
+   LOG_INFO << "Updating to: " << *target;
+-  return do_update(*client, *storage, *target);
++  return do_update(*client, *storage, *target, nullptr);
+ }
+ 
+ static int daemon_main(Config &config, const bpo::variables_map &variables_map) {
+@@ -227,6 +250,12 @@ static int daemon_main(Config &config, const bpo::variables_map &variables_map)
+     LOG_ERROR << "reboot command: " << rebootCmd << " is not executable";
+     return 1;
+   }
++  const char *lockfile = nullptr;
++  boost::filesystem::path lockfilePath;
++  if (variables_map.count("update-lockfile") > 0) {
++    lockfilePath = variables_map["update-lockfile"].as<boost::filesystem::path>();
++    lockfile = lockfilePath.c_str();
++  }
+ 
+   auto storage = INvStorage::newStorage(config.storage);
+   auto client = liteClient(config, storage);
+@@ -249,7 +278,7 @@ static int daemon_main(Config &config, const bpo::variables_map &variables_map)
+     auto target = find_target(client, hwid, "latest");
+     if (!targets_eq(*target, current, compareDockerApps)) {
+       LOG_INFO << "Updating base image to: " << *target;
+-      if (do_update(*client, *storage, *target) == 0) {
++      if (do_update(*client, *storage, *target, lockfile) == 0) {
+         if (std::system(rebootCmd.c_str()) != 0) {
+           LOG_ERROR << "Unable to reboot system";
+           return 1;
+@@ -311,6 +340,7 @@ bpo::variables_map parse_options(int argc, char *argv[]) {
+       ("update-name", bpo::value<std::string>(), "optional name of the update when running \"update\". default=latest")
+       ("interval", bpo::value<unsigned int>(), "optional interval in seconds to poll for update when in daemon mode. default=300")
+       ("reboot-command", bpo::value<boost::filesystem::path>(), "reboot command to call after an update is applied from daemon mode")
++      ("update-lockfile", bpo::value<boost::filesystem::path>(), "If provided, an flock(2) is applied to this file before performing an update in daemon mode")
+       ("command", bpo::value<std::string>(), subs.c_str());
+   // clang-format on
+ 
+-- 
+2.22.0
+

--- a/recipes-sota/aktualizr/aktualizr/0012-Create-new-aktualizr-get-command.patch
+++ b/recipes-sota/aktualizr/aktualizr/0012-Create-new-aktualizr-get-command.patch
@@ -1,0 +1,214 @@
+From c50443a6a0171e66b65a2b79d31da9458cfdc812 Mon Sep 17 00:00:00 2001
+From: Andy Doan <andy@foundries.io>
+Date: Mon, 29 Jul 2019 13:04:13 -0500
+Subject: [PATCH 12/12] Create new "aktualizr-get" command
+
+I find myself carefully crafting `wget` commands to debug issues
+between my device and device-gateway. This has gotten more complex
+now that my team is using HSMs. This adds a simple tool to work
+a bit like wget.
+
+Signed-off-by: Andy Doan <andy@foundries.io>
+---
+ src/CMakeLists.txt               |  1 +
+ src/aktualizr_get/CMakeLists.txt | 13 ++++++
+ src/aktualizr_get/get.cc         | 18 ++++++++
+ src/aktualizr_get/get.h          |  8 ++++
+ src/aktualizr_get/get_test.cc    | 29 ++++++++++++
+ src/aktualizr_get/main.cc        | 77 ++++++++++++++++++++++++++++++++
+ 6 files changed, 146 insertions(+)
+ create mode 100644 src/aktualizr_get/CMakeLists.txt
+ create mode 100644 src/aktualizr_get/get.cc
+ create mode 100644 src/aktualizr_get/get.h
+ create mode 100644 src/aktualizr_get/get_test.cc
+ create mode 100644 src/aktualizr_get/main.cc
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index e5da11ba..eaf2d751 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -14,5 +14,6 @@ add_subdirectory("aktualizr_repo")
+ add_subdirectory("cert_provider")
+ add_subdirectory("hmi_stub")
+ add_subdirectory("aktualizr_lite")
++add_subdirectory("aktualizr_get")
+ 
+ add_subdirectory("load_tests")
+diff --git a/src/aktualizr_get/CMakeLists.txt b/src/aktualizr_get/CMakeLists.txt
+new file mode 100644
+index 00000000..d815d6cc
+--- /dev/null
++++ b/src/aktualizr_get/CMakeLists.txt
+@@ -0,0 +1,13 @@
++
++add_executable(aktualizr-get main.cc get.cc)
++target_link_libraries(aktualizr-get aktualizr_static_lib ${AKTUALIZR_EXTERNAL_LIBS})
++
++install(TARGETS aktualizr-get RUNTIME DESTINATION bin COMPONENT aktualizr-get)
++
++add_aktualizr_test(NAME aktualizr_get
++                   SOURCES get.cc get_test.cc
++                   PROJECT_WORKING_DIRECTORY)
++
++aktualizr_source_file_checks(main.cc get.cc get.h get_test.cc)
++
++# vim: set tabstop=4 shiftwidth=4 expandtab:
+diff --git a/src/aktualizr_get/get.cc b/src/aktualizr_get/get.cc
+new file mode 100644
+index 00000000..99c709e9
+--- /dev/null
++++ b/src/aktualizr_get/get.cc
+@@ -0,0 +1,18 @@
++#include "get.h"
++#include "crypto/keymanager.h"
++#include "http/httpclient.h"
++
++std::string aktualizrGet(Config &config, const std::string url) {
++  auto storage = INvStorage::newStorage(config.storage);
++  storage->importData(config.import);
++
++  auto client = std_::make_unique<HttpClient>();
++  KeyManager keys(storage, config.keymanagerConfig());
++  keys.copyCertsToCurl(*client);
++  auto resp = client->get(url, HttpInterface::kNoLimit);
++  if (resp.http_status_code != 200) {
++    throw std::runtime_error("Unable to get " + url + ": HTTP_" + std::to_string(resp.http_status_code) + "\n" +
++                             resp.body);
++  }
++  return resp.body;
++}
+diff --git a/src/aktualizr_get/get.h b/src/aktualizr_get/get.h
+new file mode 100644
+index 00000000..c9b54d7e
+--- /dev/null
++++ b/src/aktualizr_get/get.h
+@@ -0,0 +1,8 @@
++#ifndef AKTUALIZR_GET_HELPERS
++#define AKTUALIZR_GET_HELPERS
++
++#include "config/config.h"
++
++std::string aktualizrGet(Config &config, std::string url);
++
++#endif  // AKTUALIZR_GET_HELPERS
+diff --git a/src/aktualizr_get/get_test.cc b/src/aktualizr_get/get_test.cc
+new file mode 100644
+index 00000000..80257297
+--- /dev/null
++++ b/src/aktualizr_get/get_test.cc
+@@ -0,0 +1,29 @@
++#include <gtest/gtest.h>
++
++#include <boost/process.hpp>
++
++#include "get.h"
++#include "test_utils.h"
++
++static std::string server = "http://127.0.0.1:";
++
++TEST(aktualizr_get, good) {
++  Config config;
++  TemporaryDirectory dir;
++  config.storage.path = dir.Path();
++
++  std::string body = aktualizrGet(config, server + "/path/1/2/3");
++  EXPECT_EQ("{\"path\": \"/path/1/2/3\"}", body);
++}
++
++#ifndef __NO_MAIN__
++int main(int argc, char **argv) {
++  ::testing::InitGoogleTest(&argc, argv);
++
++  std::string port = TestUtils::getFreePort();
++  server += port;
++  boost::process::child server_process("tests/fake_http_server/fake_test_server.py", port);
++  TestUtils::waitForServer(server + "/");
++  return RUN_ALL_TESTS();
++}
++#endif
+diff --git a/src/aktualizr_get/main.cc b/src/aktualizr_get/main.cc
+new file mode 100644
+index 00000000..1e106d39
+--- /dev/null
++++ b/src/aktualizr_get/main.cc
+@@ -0,0 +1,77 @@
++#include <unistd.h>
++#include <iostream>
++
++#include <openssl/ssl.h>
++#include <boost/filesystem.hpp>
++#include <boost/program_options.hpp>
++
++#include "config/config.h"
++#include "get.h"
++
++#include "utilities/aktualizr_version.h"
++
++namespace bpo = boost::program_options;
++
++bpo::variables_map parse_options(int argc, char *argv[]) {
++  bpo::options_description description("aktualizr-get command line options");
++  // clang-format off
++  // Try to keep these options in the same order as Config::updateFromCommandLine().
++  // The first three are commandline only.
++  description.add_options()
++      ("help,h", "print usage")
++      ("version,v", "Current aktualizr version")
++      ("config,c", bpo::value<std::vector<boost::filesystem::path> >()->composing(), "configuration file or directory")
++      ("loglevel", bpo::value<int>(), "set log level 0-5 (trace, debug, info, warning, error, fatal)")
++      ("url,u", bpo::value<std::string>(), "url to get");
++  // clang-format on
++
++  bpo::variables_map vm;
++  std::vector<std::string> unregistered_options;
++  try {
++    bpo::basic_parsed_options<char> parsed_options = bpo::command_line_parser(argc, argv).options(description).run();
++    bpo::store(parsed_options, vm);
++    bpo::notify(vm);
++    if (vm.count("help") != 0) {
++      std::cout << description << '\n';
++      exit(EXIT_SUCCESS);
++    }
++
++  } catch (const bpo::required_option &ex) {
++    // print the error and append the default commandline option description
++    std::cout << ex.what() << std::endl << description;
++    exit(EXIT_FAILURE);
++  } catch (const bpo::error &ex) {
++    std::cout << ex.what() << std::endl;
++    std::cout << description;
++    exit(EXIT_FAILURE);
++  }
++
++  return vm;
++}
++
++int main(int argc, char *argv[]) {
++  logger_init(isatty(1) == 1);
++  logger_set_threshold(boost::log::trivial::info);
++
++  bpo::variables_map commandline_map = parse_options(argc, argv);
++
++  int r = EXIT_FAILURE;
++  try {
++    if (geteuid() != 0) {
++      LOG_WARNING << "\033[31mRunning as non-root and may not work as expected!\033[0m\n";
++    }
++
++    Config config(commandline_map);
++    if (config.logger.loglevel <= boost::log::trivial::debug) {
++      SSL_load_error_strings();
++    }
++
++    std::string body = aktualizrGet(config, commandline_map["url"].as<std::string>());
++    std::cout << body;
++
++    r = EXIT_SUCCESS;
++  } catch (const std::exception &ex) {
++    LOG_ERROR << ex.what();
++  }
++  return r;
++}
+-- 
+2.22.0
+

--- a/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service
+++ b/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Aktualizr Lite SOTA Client
+After=network.target
+ConditionPathExists=/var/sota/sota.toml
+
+[Service]
+RestartSec=180
+Restart=always
+ExecStart=/usr/bin/aktualizr-lite --update-lockfile /run/lock/aktualizr-lite-update --reboot-command /usr/sbin/reboot daemon
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,10 +1,34 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI_append = " \
+SRC_URI_append_lmp = " \
     file://Move-default-sota-config-from-usr-lib-to-var.patch \
+    file://0001-FIO-toup-aktualizr-lite-Mock-OstreeManager-getCurren.patch \
+    file://0002-FIO-toup-aktualizr-lite-Save-installed-version-targe.patch \
+    file://0003-FIO-toup-aktualizr-lite-Use-current-target-for-statu.patch \
+    file://0004-FIO-toup-docker-apps-Add-support-for-getCurrent.patch \
+    file://0005-FIO-toup-aktualizr-lite-Rename-version-to-helpers.patch \
+    file://0006-config-Add-notion-of-tags-to-package-manager.patch \
+    file://0007-aktualizr-lite-Include-ostree-hash-in-request-header.patch \
+    file://0008-aktualizr-lite-Add-targets-equal-helper.patch \
+    file://0009-aktualizr-lite-Add-a-daemon-mode.patch \
+    file://0010-aktualizr-lite-Add-ability-to-reboot-after-an-update.patch \
+    file://0011-aktualizr-lite-Add-lockfile-for-daemon-mode-updates.patch \
+    file://0012-Create-new-aktualizr-get-command.patch \
+    file://aktualizr-lite.service \
     file://increase-restartsec-service.patch;patchdir=.. \
 "
 
 SRC_URI_append_libc-musl = " \
     file://utils.c-disable-tilde-as-it-is-not-supported-by-musl.patch \
 "
+
+PACKAGECONFIG[dockerapp] = "-DBUILD_DOCKERAPP=ON,-DBUILD_DOCKERAPP=OFF,"
+PACKAGECONFIG += "dockerapp"
+
+SYSTEMD_PACKAGES += "${PN}-lite"
+SYSTEMD_SERVICE_${PN}-lite = "aktualizr-lite.service"
+
+do_install_append() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/aktualizr-lite.service ${D}${systemd_system_unitdir}/
+}

--- a/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -13,3 +13,7 @@ S = "${WORKDIR}/git"
 inherit cmake
 
 RDEPENDS_${PN} += "openssl-bin"
+
+EXTRA_OECMAKE += "\
+    ${@oe.utils.conditional('SOTA_CLIENT', 'aktualizr-lite', '-DDEVICE_API=https://api.foundries.io/ota/devices/', '', d)} \
+"

--- a/recipes-support/curl/curl_%.bbappend
+++ b/recipes-support/curl/curl_%.bbappend
@@ -1,0 +1,3 @@
+EXTRA_OECONF_append_sota = " \
+    --with-ca-path=${sysconfdir}/ssl/certs \
+"


### PR DESCRIPTION
Include the wip patches required for supporting aktualizr-lite and aktualizr-get.

Aktualizr-lite can be used by default by simply setting SOTA_CLIENT = "aktualizr-lite" in conf/local.conf.