### PR TITLE
aktualizr: lite: fix incorrect storing of ecu hwid

### DIFF
--- a/recipes-sota/aktualizr/aktualizr/0013-aktualizr-lite-Fix-incorrect-storing-of-ecu-hwid.patch
+++ b/recipes-sota/aktualizr/aktualizr/0013-aktualizr-lite-Fix-incorrect-storing-of-ecu-hwid.patch
@@ -1,0 +1,26 @@
+From f17fff85d59e885acf50d95548a1bd0d2537d43a Mon Sep 17 00:00:00 2001
+From: Andy Doan <andy@foundries.io>
+Date: Wed, 14 Aug 2019 14:12:37 -0500
+Subject: [PATCH 13/13] aktualizr-lite: Fix incorrect storing of ecu hwid
+
+Signed-off-by: Andy Doan <andy@foundries.io>
+---
+ src/aktualizr_lite/main.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/aktualizr_lite/main.cc b/src/aktualizr_lite/main.cc
+index 8634e961..6cf36d07 100644
+--- a/src/aktualizr_lite/main.cc
++++ b/src/aktualizr_lite/main.cc
+@@ -50,7 +50,7 @@ static std::shared_ptr<SotaUptaneClient> liteClient(Config &config, std::shared_
+       boost::uuids::uuid tmp = boost::uuids::random_generator()();
+       serial = boost::uuids::to_string(tmp);
+     }
+-    ecu_serials.emplace_back(Uptane::EcuSerial(serial), Uptane::HardwareIdentifier(serial));
++    ecu_serials.emplace_back(Uptane::EcuSerial(serial), Uptane::HardwareIdentifier(hwid));
+     storage->storeEcuSerials(ecu_serials);
+   }
+ 
+-- 
+2.22.0
+

--- a/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -14,6 +14,7 @@ SRC_URI_append_lmp = " \
     file://0010-aktualizr-lite-Add-ability-to-reboot-after-an-update.patch \
     file://0011-aktualizr-lite-Add-lockfile-for-daemon-mode-updates.patch \
     file://0012-Create-new-aktualizr-get-command.patch \
+    file://0013-aktualizr-lite-Fix-incorrect-storing-of-ecu-hwid.patch \
     file://aktualizr-lite.service \
     file://increase-restartsec-service.patch;patchdir=.. \
 "


### PR DESCRIPTION
Upstream PR: https://github.com/advancedtelematic/aktualizr/pull/1298

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>