### PR TITLE
lmp-machine-custom changes for i.MX7ULP

### DIFF
--- a/classes/lmp-machine-custom.bbclass
+++ b/classes/lmp-machine-custom.bbclass
@@ -92,6 +92,7 @@ WKS_FILE_append_intel-corei7-64 = " efidisk-sota.wks"
 # Common for iMX targets
 OSTREE_KERNEL_ARGS_mx6 ?= "console=tty1 console=ttymxc0,115200 ${OSTREE_KERNEL_ARGS_COMMON}"
 OSTREE_KERNEL_ARGS_mx7d ?= "console=tty1 console=ttymxc0,115200 ${OSTREE_KERNEL_ARGS_COMMON}"
+OSTREE_KERNEL_ARGS_mx7ulp ?= "console=tty1 console=ttyLP0,115200 ${OSTREE_KERNEL_ARGS_COMMON}"
 
 # Toradex Colibri iMX7 (support both NAND and eMMC targets with one single image)
 EXTRA_IMAGEDEPENDS_append_colibri-imx7 = " u-boot-script-toradex"

--- a/classes/lmp-machine-custom.bbclass
+++ b/classes/lmp-machine-custom.bbclass
@@ -90,7 +90,8 @@ EFI_PROVIDER_intel-corei7-64 = "grub-efi"
 WKS_FILE_append_intel-corei7-64 = " efidisk-sota.wks"
 
 # Common for iMX targets
-OSTREE_KERNEL_ARGS_imx ?= "console=tty1 console=ttymxc0,115200 ${OSTREE_KERNEL_ARGS_COMMON}"
+OSTREE_KERNEL_ARGS_mx6 ?= "console=tty1 console=ttymxc0,115200 ${OSTREE_KERNEL_ARGS_COMMON}"
+OSTREE_KERNEL_ARGS_mx7d ?= "console=tty1 console=ttymxc0,115200 ${OSTREE_KERNEL_ARGS_COMMON}"
 
 # Toradex Colibri iMX7 (support both NAND and eMMC targets with one single image)
 EXTRA_IMAGEDEPENDS_append_colibri-imx7 = " u-boot-script-toradex"


### PR DESCRIPTION
- Don't set unknown SoCs OSTREE kernel args by default
- Add i.MX7ULP OSTREE kernel arg defaults