### PR TITLE
aktualizr-lite-public-stream: rename tag variable to AKLITE_TAG

### DIFF
--- a/recipes-sota/config/aktualizr-lite-public-stream.bb
+++ b/recipes-sota/config/aktualizr-lite-public-stream.bb
@@ -12,10 +12,10 @@ S = "${WORKDIR}"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-OTA_LITE_TAG ?= "promoted"
+AKLITE_TAG ?= "promoted"
 
 do_compile() {
-	sed -e 's/@@OTA_LITE_TAG@@/${OTA_LITE_TAG}/' \
+	sed -e 's/@@AKLITE_TAG@@/${AKLITE_TAG}/' \
 		${WORKDIR}/10-lite-public-stream.toml.in > 10-lite-public-stream.toml
 }
 

--- a/recipes-sota/config/files/10-lite-public-stream.toml.in
+++ b/recipes-sota/config/files/10-lite-public-stream.toml.in
@@ -5,4 +5,4 @@ repo_server = "https://api.foundries.io/ota/repo/lmp/api/v1/user_repo/"
 [pacman]
 type = "ostree"
 ostree_server = "https://api.foundries.io/ota/treehub/lmp/api/v2/"
-tags = @@OTA_LITE_TAG@@
+tags = @@AKLITE_TAG@@


### PR DESCRIPTION
OTA_LITE_TAG is currently used by the CI promotion logic, so instead of
reusing that variable let's create one specific to the aktualizr-lite
client to avoid issues.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>