### PR TITLE
u-boot: qemuriscv64: copy QEMU loaded DTB to safe area (fdt_addr_r)

### DIFF
--- a/recipes-bsp/u-boot/u-boot-ostree-scr/qemuriscv64/boot.cmd
+++ b/recipes-bsp/u-boot/u-boot-ostree-scr/qemuriscv64/boot.cmd
@@ -4,6 +4,12 @@ then
     exit
 fi
 
+# Recent kernel commit in 5.3:
+# https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/arch/riscv/kernel?h=v5.3&id=671f9a3e2e24cdeb2d2856abee7422f093e23e29
+# changed page table setup which now crushes the qemu loaded DTB.
+# Let's copy the DTB to the established load addr instead where it's safe.
+cp ${fdt_addr} ${fdt_addr_r} 1000
+
 fatload ${devtype} ${devnum}:1 $scriptaddr /uEnv.txt
 env import -t $scriptaddr $filesize
 run bootcmd

--- a/recipes-bsp/u-boot/u-boot-ostree-scr/qemuriscv64/uEnv.txt.in
+++ b/recipes-bsp/u-boot/u-boot-ostree-scr/qemuriscv64/uEnv.txt.in
@@ -1,4 +1,4 @@
 bootcmd_otenv=load ${devtype} ${devnum}:2 ${scriptaddr} /boot/loader/uEnv.txt; env import -t ${scriptaddr} ${filesize}
 bootcmd_load_f=load ${devtype} ${devnum}:2 ${ramdisk_addr_r} "/boot"${kernel_image}
-bootcmd_run=bootm ${ramdisk_addr_r}:kernel@1 - ${fdt_addr}
+bootcmd_run=bootm ${ramdisk_addr_r}:kernel@1 - ${fdt_addr_r}
 bootcmd=run bootcmd_otenv; run bootcmd_load_f; run bootcmd_run


### PR DESCRIPTION
Recent kernel commit in 5.3 changed page table setup which now
crushes the QEMU loaded DTB:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/arch/riscv/kernel?h=v5.3&id=671f9a3e2e24cdeb2d2856abee7422f093e23e29

Let's copy the DTB to the established load addr (fdt_addr_r) instead
where it's safe.

Signed-off-by: Michael Scott <mike@foundries.io>