### PR TITLE
aktualizr-lite: drop reboot-command from service file

### DIFF
--- a/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service
+++ b/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service
@@ -7,7 +7,7 @@ ConditionPathExists=|/usr/lib/sota/conf.d/10-lite-public-stream.toml
 [Service]
 RestartSec=180
 Restart=always
-ExecStart=/usr/bin/aktualizr-lite --update-lockfile /run/lock/aktualizr-lite-update --reboot-command /usr/sbin/reboot daemon
+ExecStart=/usr/bin/aktualizr-lite --update-lockfile /run/lock/aktualizr-lite-update daemon
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Not required anymore as it is now able to reuse the reboot_command
defined by aktualizr (which defaults to /sbin/reboot).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>