### PR TITLE
lmp-gateway-image: add jobserv python3 dependencies

### DIFF
--- a/recipes-samples/images/lmp-feature-jobserv.inc
+++ b/recipes-samples/images/lmp-feature-jobserv.inc
@@ -1,0 +1,5 @@
+# Packages required for jobserv compatibility
+CORE_IMAGE_BASE_INSTALL += " \
+    python3-json \
+    python3-multiprocessing \
+"

--- a/recipes-samples/images/lmp-gateway-image.bb
+++ b/recipes-samples/images/lmp-gateway-image.bb
@@ -7,6 +7,7 @@ require lmp-feature-docker.inc
 require lmp-feature-bluetooth.inc
 require lmp-feature-wifi.inc
 require lmp-feature-nat64.inc
+require lmp-feature-jobserv.inc
 require lmp-feature-debug.inc
 require lmp-feature-sbin-path-helper.inc
 require lmp-feature-sysctl-hang-crash-helper.inc


### PR DESCRIPTION
- create lmp-feature-jobserv.inc which contains the jobserv dependencies
- add lmp-feature-jobserv.inc to lmp-gateway-image

Signed-off-by: Michael Scott <mike@foundries.io>