### PR TITLE
conf/distro: introduce lmp-base distro configuration

### DIFF
--- a/conf/distro/lmp-base.conf
+++ b/conf/distro/lmp-base.conf
@@ -1,0 +1,20 @@
+require conf/distro/include/lmp.inc
+
+DISTRO = "lmp-base"
+DISTROOVERRIDES = "lmp:lmp-base"
+DISTRO_NAME = "Linux-microPlatform Base (no ostree)"
+
+IMAGE_LINGUAS ?= "en-us"
+
+# No graphical feature as part of the base platform
+DISTRO_FEATURES_remove = "wayland x11"
+
+# By default we only support initramfs. We don't build live as that
+# pulls in a lot of dependencies for the live image and the installer, like
+# udev, grub, etc.  These pull in gettext, which fails to build with wide
+# character support.
+IMAGE_FSTYPES = "cpio.gz"
+QB_DEFAULT_FSTYPE = "${IMAGE_FSTYPES}"
+
+# By default we don't have any extra machine dependencies
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS = ""


### PR DESCRIPTION
The LmP base distro should be used when no ostree/aktualizr functionality
is needed by an image build.

Example of this would be for manufacturing tools, etc.

Signed-off-by: Michael Scott <mike@foundries.io>