### PR TITLE
lmp-device-register: bump rev to c8d9af9

### DIFF
--- a/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl ostree glib-2.0"
 
-SRCREV = "704d1b5a58964f45a352fac602924152d981d390"
+SRCREV = "c8d9af9c1c9390764f590f4a0049afe965814890"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https"
 
@@ -20,4 +20,6 @@ RDEPENDS_${PN} += "openssl-bin"
 
 EXTRA_OECMAKE += "\
     ${@oe.utils.conditional('SOTA_CLIENT', 'aktualizr-lite', '-DDEVICE_API=https://api.foundries.io/ota/devices/', '', d)} \
+    -DGIT_COMMIT=${SRCREV} \
+    -DHARDWARE_ID=${MACHINE} \
 "


### PR DESCRIPTION
Also enable the new GIT_COMMIT and HARDWARE_ID build flags.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>