### PR TITLE
images/feature-debug: add more debug tools

### DIFF
--- a/recipes-samples/images/lmp-feature-debug.inc
+++ b/recipes-samples/images/lmp-feature-debug.inc
@@ -4,4 +4,8 @@ CORE_IMAGE_BASE_INSTALL += " \
     strace \
     tcpdump \
     vim-tiny \
+    screen \
+    tmux \
+    minicom \
+    devmem2 \
 "


### PR DESCRIPTION
To help with HW bringup and debugging let's add the following
tools to the debug feature:
- screen
- tmux
- minicom
- devmem2

Signed-off-by: Michael Scott <mike@foundries.io>