### PR TITLE
docker-credential-helper: Only run for "get" calls

### DIFF
--- a/recipes-support/docker-credential-helper-fio/files/docker-credential-fio-helper
+++ b/recipes-support/docker-credential-helper-fio/files/docker-credential-fio-helper
@@ -1,3 +1,5 @@
 #!/bin/sh -e
 
-exec /usr/bin/aktualizr-get --loglevel 4 -u https://ota-lite.foundries.io:8443/hub-creds/
+if [ "$1" = "get" ] ; then
+	exec /usr/bin/aktualizr-get --loglevel 4 -u https://ota-lite.foundries.io:8443/hub-creds/
+fi


### PR DESCRIPTION
The credential helper can do more than just authenticate. It can
also do things like "store" credentials. This fixes our helper so
that its only run for "get" calls.

Signed-off-by: Andy Doan <andy@foundries.io>