### PR TITLE
lmp-device-register: Bump to latest version

### DIFF
--- a/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl ostree glib-2.0"
 
-SRCREV = "ce8af7ab0f1aae6bc73ce493d99c764d807cb063"
+SRCREV = "3f8ed328a1bcc41cfb000ec73ee8be2830c7c314"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https"
 


### PR DESCRIPTION
This pulls in the change that always enables the docker-app pakage
manager

Signed-off-by: Andy Doan <andy@foundries.io>