### PR TITLE
lmp-feature-factory: add docker-cli-config

### DIFF
--- a/recipes-samples/images/lmp-feature-factory.inc
+++ b/recipes-samples/images/lmp-feature-factory.inc
@@ -1,4 +1,5 @@
 # FoundriesFactory related packages
 CORE_IMAGE_BASE_INSTALL += " \
+    docker-cli-config \
     lmp-device-register \
 "


### PR DESCRIPTION
hub.foundries.io docker cli configuration is required for factory users.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>