### PR TITLE
aktualizr: also add lshw as rdepends of aklite

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -32,3 +32,5 @@ do_install_append() {
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/aktualizr-lite.service ${D}${systemd_system_unitdir}/
 }
+
+RDEPENDS_${PN}-lite = "aktualizr-configs lshw"


### PR DESCRIPTION
lshw is used by both aktualizr and aktualizr-lite.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>