### PR TITLE
aktualizr: bump for uptane.polling_sec support

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "2019.8+fio"
-SRCREV_lmp = "9644558b81289acb31f3b091083d51a3585520aa"
+SRCREV_lmp = "eb5e8b5bc0106ce45450d894c846f1aecbd6191f"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr;branch=${BRANCH} \
     file://aktualizr.service \


### PR DESCRIPTION
Relevant changes:
- eb5e8b5b [fio extras] Use uptane.polling_sec for interval configuration

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>