### PR TITLE
python3-docker: Add support for our credential helper

### DIFF
--- a/recipes-devtools/python/python3-docker/0001-config-Include-usr-lib-docker-in-search-path.patch
+++ b/recipes-devtools/python/python3-docker/0001-config-Include-usr-lib-docker-in-search-path.patch
@@ -1,0 +1,25 @@
+From 742156db38a81d17155870a9614e52f37fa90d1e Mon Sep 17 00:00:00 2001
+From: Andy Doan <andy@foundries.io>
+Date: Wed, 16 Oct 2019 13:47:30 -0500
+Subject: [PATCH] config: Include /usr/lib/docker in search path
+
+Signed-off-by: Andy Doan <andy@foundries.io>
+---
+ docker/utils/config.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/docker/utils/config.py b/docker/utils/config.py
+index 82a0e2a..d382f52 100644
+--- a/docker/utils/config.py
++++ b/docker/utils/config.py
+@@ -12,6 +12,7 @@ log = logging.getLogger(__name__)
+ 
+ def find_config_file(config_path=None):
+     paths = list(filter(None, [
++        '/usr/lib/docker/config.json', # 0
+         config_path,  # 1
+         config_path_from_environment(),  # 2
+         os.path.join(home_dir(), DOCKER_CONFIG_FILENAME),  # 3
+-- 
+2.23.0
+

--- a/recipes-devtools/python/python3-docker_3.7.3.bb
+++ b/recipes-devtools/python/python3-docker_3.7.3.bb
@@ -8,6 +8,10 @@ inherit pypi setuptools3
 SRC_URI[md5sum] = "a4e1f25103b46853cfcbc4c355cf74fa"
 SRC_URI[sha256sum] = "a062a9f82dff025f79c2097c46f49f143f8898274db7e66041f78cafee66b962"
 
+SRC_URI += " \
+    file://0001-config-Include-usr-lib-docker-in-search-path.patch \
+"
+
 DEPENDS += "${PYTHON_PN}-pip-native"
 
 RDEPENDS_${PN} += " \


### PR DESCRIPTION
Our credential helper configuration for the LMP is stored under
/usr/lib/docker/config.json. This adds the path to the docker API
so that docker-compose can use this helper.

Signed-off-by: Andy Doan <andy@foundries.io>