### PR TITLE
u-boot-fio: bump srcrev for udpates to mx7ulpea-ucom

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fio_git.bb
+++ b/recipes-bsp/u-boot/u-boot-fio_git.bb
@@ -6,7 +6,7 @@ DEPENDS += "flex-native bison-native bc-native dtc-native"
 
 require recipes-bsp/u-boot/u-boot.inc
 
-SRCREV = "96e3e686a31baf729c9086b0099908f4126f0f7b"
+SRCREV = "e47d650f53262acff0c5d73981fb84c2731006ca"
 SRCBRANCH = "2019.10+fio"
 
 SRC_URI = "git://github.com/foundriesio/u-boot.git;branch=${SRCBRANCH}"


### PR DESCRIPTION
Relevant commits:
e47d650 [FIO extras] mx7ulpea-ucom-mfgtool_defconfig: add ext4load support
b89ecaa [FIO extras] imx7ulpea: dts: enable DM QSPI flash
88abee6 [FIO extras] sf: Add Macronix MX25U3235F SPI flash

Signed-off-by: Michael Scott <mike@foundries.io>