### PR TITLE
recipes-devtools: mcumgr: fix binary build

### DIFF
--- a/recipes-devtools/mcumgr/mcumgr_git.bb
+++ b/recipes-devtools/mcumgr/mcumgr_git.bb
@@ -13,5 +13,14 @@ PV = "v0.0.1+git"
 
 inherit go goarch godep
 
+# OE build default do_compile recipe is creating oddly broken binary
+# To fix this, let's use the same as manual build steps
+# NOTE: The binary is much larger than default recipe
+do_compile() {
+	cd ${S}/src/${GO_IMPORT}/mcumgr
+	mkdir -p ${B}/${GO_BUILD_BINDIR}
+	${GO} build -o ${B}/${GO_BUILD_BINDIR}/mcumgr mcumgr.go
+}
+
 RDEPENDS_${PN}-dev += "bash"
 RDEPENDS_${PN}-staticdev += "bash"


### PR DESCRIPTION
The default do_compile() for OE is creating an oddly broken mcumgr
binary.  When attempting to upload a new firmware image, mcumgr will
reach 12.9% and then hang for a few seconds before crashing.

First attempts to fix this issue did not work when setting the
following to avoid stripping the end binary:
INHIBIT_PACKAGE_STRIP = "0"

My manual build step looks something like this:
GOOS=linux GOARM=7 GOARCH=arm go build mcumgr.go

Adjusting the mcumgr recipe to mimic my local build steps fixes the
issue.

NOTE: The resulting binary is quite large (~15mb) compared to the
default build which is 1/2 the size.

Signed-off-by: Michael Scott <mike@foundries.io>