### PR TITLE
modemmanager: Upgrade 1.10.6 -> 1.10.8

### DIFF
--- a/recipes-connectivity/modemmanager/modemmanager_1.10.8.bb
+++ b/recipes-connectivity/modemmanager/modemmanager_1.10.8.bb
@@ -1,0 +1,57 @@
+SUMMARY = "ModemManager is a daemon controlling broadband devices/connections"
+DESCRIPTION = "ModemManager is a DBus-activated daemon which controls mobile broadband (2G/3G/4G) devices and connections"
+HOMEPAGE = "http://www.freedesktop.org/wiki/Software/ModemManager/"
+LICENSE = "GPL-2.0 & LGPL-2.1"
+LIC_FILES_CHKSUM = " \
+    file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c \
+"
+
+inherit gnomebase gettext systemd vala gobject-introspection bash-completion
+
+DEPENDS = "glib-2.0 libgudev intltool-native libxslt-native"
+
+SRC_URI = "http://www.freedesktop.org/software/ModemManager/ModemManager-${PV}.tar.xz \
+           "
+
+SRC_URI[md5sum] = "c05ac4246c81cc15d617c4a129232988"
+SRC_URI[sha256sum] = "cbe174078dbdf3f746a55f0004353d3c27da2a31da553036d90fc7dc34a0169a"
+
+S = "${WORKDIR}/ModemManager-${PV}"
+
+PACKAGECONFIG ??= "mbim qmi \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'systemd polkit', d)} \
+"
+
+PACKAGECONFIG[systemd] = "--with-systemdsystemunitdir=${systemd_unitdir}/system/,,"
+PACKAGECONFIG[polkit] = "--with-polkit=yes,--with-polkit=no,polkit"
+# Support WWAN modems and devices which speak the Mobile Interface Broadband Model (MBIM) protocol.
+PACKAGECONFIG[mbim] = "--with-mbim,--without-mbim,libmbim"
+# Support WWAN modems and devices which speak the Qualcomm MSM Interface (QMI) protocol.
+PACKAGECONFIG[qmi] = "--with-qmi,--without-qmi,libqmi"
+
+EXTRA_OECONF = " \
+    --with-udev-base-dir=${nonarch_base_libdir}/udev \
+"
+EXTRA_OECONF_append_toolchain-clang = " --enable-more-warnings=no"
+
+FILES_${PN} += " \
+    ${datadir}/icons \
+    ${datadir}/polkit-1 \
+    ${datadir}/dbus-1 \
+    ${datadir}/ModemManager \
+    ${libdir}/ModemManager \
+    ${systemd_unitdir}/system \
+"
+
+FILES_${PN}-dev += " \
+    ${libdir}/ModemManager/*.la \
+"
+
+FILES_${PN}-staticdev += " \
+    ${libdir}/ModemManager/*.a \
+"
+
+FILES_${PN}-dbg += "${libdir}/ModemManager/.debug"
+
+SYSTEMD_SERVICE_${PN} = "ModemManager.service"


### PR DESCRIPTION
Use newer ModemManager to address "denied" registration issue fixed in
commit:
https://cgit.freedesktop.org/ModemManager/ModemManager/commit/?h=1.10.8&id=47fd8a1e55cac0b0b45812e1dda826f38c264d1b

NOTE: Will revert when upstream merges 1.10.8.

Signed-off-by: Michael Scott <mike@foundries.io>