### PR TITLE
recipes-sota/ostree: install non-native ostree-grub-generator

### DIFF
--- a/recipes-sota/ostree/ostree_%.bbappend
+++ b/recipes-sota/ostree/ostree_%.bbappend
@@ -13,6 +13,10 @@ EXTRA_OECONF += " \
     --with-builtin-grub2-mkconfig \
 "
 
+do_install_append() {
+    create_wrapper ${D}${bindir}/ostree OSTREE_GRUB2_EXEC="${STAGING_LIBDIR_NATIVE}/ostree/ostree-grub-generator"
+}
+
 FILES_${PN} += " \
     ${libdir}/ostree/ostree-grub-generator \
 "


### PR DESCRIPTION
We need to install ostree-grub-generator for all arch otherwise grub
users will fail on updates.

Signed-off-by: Michael Scott <mike@foundries.io>