### PR TITLE
optee-os: added Foundries.IO Verified Boot recipe

### DIFF
--- a/recipes-security/optee/optee-fiovb_git.bb
+++ b/recipes-security/optee/optee-fiovb_git.bb
@@ -1,0 +1,30 @@
+SUMMARY = "OP-TEE Foundries.IO Verified Boot Client Application"
+HOMEPAGE = "https://github.com/foundriesio/optee-fiovb"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=92d506fc36dda404ceb608cdc34b7a99"
+
+DEPENDS = "optee-client virtual/optee-os python-pycrypto-native"
+
+inherit pythonnative
+
+SRC_URI = "git://github.com/foundriesio/optee-fiovb.git"
+
+PV = "0.1"
+SRCREV = "c7f80c69861628b1958ec35214afa2e0a0ae576d"
+
+S = "${WORKDIR}/git"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+OPTEE_CLIENT_EXPORT = "${STAGING_DIR_HOST}${prefix}"
+TEEC_EXPORT         = "${STAGING_DIR_HOST}${prefix}"
+
+EXTRA_OEMAKE = "OPTEE_CLIENT_EXPORT=${OPTEE_CLIENT_EXPORT} \
+                TEEC_EXPORT=${TEEC_EXPORT} \
+                HOST_CROSS_COMPILE=${TARGET_PREFIX} \
+"
+
+do_install () {
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/out/ca/fiovb ${D}${bindir}
+}


### PR DESCRIPTION
Add the fiovb host binary to the rootfs. 

This binary interfaces to the fiovb TA to read and write persistent values for RPMB and control the rollback counters.

- Notice that rollback counters MUST be specified in hex 
- Also notice that to use the current fiovb binary you need to use symbolic links named fw_printenv and fw_setenv. 
Perhaps we should change that so the application just checks for "fw_print" and "fw_set" strings when routing so the links could be more specific.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>