### PR TITLE
Initial meta-lmp updates for 57

### DIFF
--- a/recipes-kernel/linux/linux-lmp_git.bb
+++ b/recipes-kernel/linux/linux-lmp_git.bb
@@ -1,9 +1,9 @@
-LINUX_VERSION ?= "5.3.10"
+LINUX_VERSION ?= "5.3.11"
 
 FIO_LMP_GIT_URL ?= "github.com"
 FIO_LMP_GIT_NAMESPACE ?= "foundriesio/"
 
-SRCREV_machine = "4cc16c7e5e9d4c9c988f22adb2d71545e31b60a3"
+SRCREV_machine = "7c888febf2e291c0f23ba9dc8ae5964254b42483"
 SRCREV_meta = "31b65f24e5d6f3a2598225fd58d7c1d0492af1bb"
 KBRANCH = "linux-v5.3.y"
 

--- a/recipes-kernel/linux/linux-lmp_git.bb
+++ b/recipes-kernel/linux/linux-lmp_git.bb
@@ -1,9 +1,9 @@
-LINUX_VERSION ?= "5.3.9"
+LINUX_VERSION ?= "5.3.10"
 
 FIO_LMP_GIT_URL ?= "github.com"
 FIO_LMP_GIT_NAMESPACE ?= "foundriesio/"
 
-SRCREV_machine = "bf425c303683a926ff1b555fbf47c1c187d51986"
+SRCREV_machine = "4cc16c7e5e9d4c9c988f22adb2d71545e31b60a3"
 SRCREV_meta = "31b65f24e5d6f3a2598225fd58d7c1d0492af1bb"
 KBRANCH = "linux-v5.3.y"
 

--- a/recipes-security/optee/optee-os/0001-imx-caam-check-if-otpmk-can-be-used-when-producing-h.patch
+++ b/recipes-security/optee/optee-os/0001-imx-caam-check-if-otpmk-can-be-used-when-producing-h.patch
@@ -1,0 +1,132 @@
+From e3a72e7dcefc31464cb5e73438d9995f04663217 Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo@foundries.io>
+Date: Tue, 5 Nov 2019 11:08:01 -0300
+Subject: [PATCH] imx: caam: check if otpmk can be used when producing huk
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+---
+ core/arch/arm/plat-imx/drivers/imx_caam.c  | 53 ++++++++++++++++++++++
+ core/arch/arm/plat-imx/drivers/imx_caam.h  |  6 +++
+ core/arch/arm/plat-imx/imx-regs.h          |  6 +++
+ core/arch/arm/plat-imx/registers/imx7ulp.h |  2 +
+ 4 files changed, 67 insertions(+)
+
+diff --git a/core/arch/arm/plat-imx/drivers/imx_caam.c b/core/arch/arm/plat-imx/drivers/imx_caam.c
+index 647c1f36..d0e7d838 100644
+--- a/core/arch/arm/plat-imx/drivers/imx_caam.c
++++ b/core/arch/arm/plat-imx/drivers/imx_caam.c
+@@ -162,11 +162,64 @@ out:
+ 	return ret;
+ }
+ 
++static TEE_Result check_master_key_source_otpmk(void)
++{
++	vaddr_t snvs = core_mmu_get_va(SNVS_BASE, MEM_AREA_IO_SEC);
++	uint32_t val;
++
++	val = io_read32(snvs + SNVS_HPCOMR);
++	val &= BM_SNVS_HPCOMR_MKS_EN;
++
++	/* Check master key source if selected via MASTER_KEY_SEL */
++	if (val) {
++		val = io_read32(snvs + SNVS_LPMKCR);
++		val &= ~BM_SNVS_LP_MKCR_MKS_SEL;
++		if (val != 0) {
++			EMSG("OTPMK is not set as master key");
++			return TEE_ERROR_SECURITY;
++		}
++	}
++
++	DMSG("Master key source is set to OTPMK");
++
++	return TEE_SUCCESS;
++}
++
++static TEE_Result check_caam_mode_trusted(void)
++{
++	vaddr_t caam = core_mmu_get_va(CAAM_BASE, MEM_AREA_IO_SEC);
++	uint32_t val;
++
++	/* We can only read true OTPMK when CAAM is operating in secure
++	 * or trusted mode.
++	 */
++	val = io_read32(caam + SEC_REG_CSTA_OFFSET);
++	switch (val & CSTA_MOO_MASK) {
++	case CSTA_MOO_SECURE:
++		DMSG("CAAM mode of operation: SECURE");
++		break;
++	case CSTA_MOO_TRUSTED:
++		DMSG("CAAM mode of operation: TRUSTED");
++		break;
++	default:
++		EMSG("CAAM not secure/trusted; OTPMK inaccessible");
++		return TEE_ERROR_SECURITY;
++	}
++
++	return TEE_SUCCESS;
++}
++
+ TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
+ {
+ 	int ret = TEE_ERROR_SECURITY;
+ 
+ 	if (!mkvb_retrieved) {
++		ret = check_master_key_source_otpmk();
++		if (ret)
++			return ret;
++		ret = check_caam_mode_trusted();
++		if (ret)
++			return ret;
+ 		ret = caam_get_mkvb(stored_key);
+ 		if (ret)
+ 			return ret;
+diff --git a/core/arch/arm/plat-imx/drivers/imx_caam.h b/core/arch/arm/plat-imx/drivers/imx_caam.h
+index be67122b..8e7b4e5b 100644
+--- a/core/arch/arm/plat-imx/drivers/imx_caam.h
++++ b/core/arch/arm/plat-imx/drivers/imx_caam.h
+@@ -34,6 +34,12 @@ struct imx_caam_job_ring {
+ #define CCM_CCGR0_CAAM_WRAPPER_ACLK	SHIFT_U32(3, 10)
+ #define CCM_CCGR6_EMI_SLOW		SHIFT_U32(3, 10)
+ 
++#define SEC_REG_CSTA_OFFSET		0x0FD4
++#define CSTA_MOO_SHIFT			8
++#define CSTA_MOO_MASK			(0x3 << CSTA_MOO_SHIFT)
++#define CSTA_MOO_SECURE		(0x1 << CSTA_MOO_SHIFT)
++#define CSTA_MOO_TRUSTED		(0x2 << CSTA_MOO_SHIFT)
++
+ /* Descriptor and MKVB Definitions */
+ #define MKVB_SIZE			32
+ #define MKVB_DESC_SEQ_OUT		0xf8000020
+diff --git a/core/arch/arm/plat-imx/imx-regs.h b/core/arch/arm/plat-imx/imx-regs.h
+index 22c536c1..d4c82fae 100644
+--- a/core/arch/arm/plat-imx/imx-regs.h
++++ b/core/arch/arm/plat-imx/imx-regs.h
+@@ -68,6 +68,12 @@
+ #define SNVS_LPCR_DP_EN_MASK		BIT(5)
+ #define SNVS_LPCR_SRTC_ENV_MASK		1
+ 
++#define SNVS_HPCOMR			0x04
++#define BM_SNVS_HPCOMR_MKS_EN		BIT32(13)
++
++#define SNVS_LPMKCR			0x3C
++#define BM_SNVS_LP_MKCR_MKS_SEL		SHIFT_U32(0x3, 0)
++
+ #define WCR_OFF				0
+ 
+ /* GPC V2 */
+diff --git a/core/arch/arm/plat-imx/registers/imx7ulp.h b/core/arch/arm/plat-imx/registers/imx7ulp.h
+index 3305154b..45152328 100644
+--- a/core/arch/arm/plat-imx/registers/imx7ulp.h
++++ b/core/arch/arm/plat-imx/registers/imx7ulp.h
+@@ -22,6 +22,8 @@
+ #define M4_AIPS1_BASE		0x41080000
+ #define M4_AIPS1_SIZE		0x80000
+ 
++#define SNVS_BASE		0x41070000
++
+ #define GPIOC_BASE		0x400f0000
+ #define GPIOD_BASE		0x400f0040
+ #define GPIOE_BASE		0x400f0080
+-- 
+2.24.0
+

--- a/recipes-security/optee/optee-os_git.bb
+++ b/recipes-security/optee/optee-os_git.bb
@@ -43,7 +43,7 @@ OPTEE_ARCH_aarch64 = "arm64"
 
 EXTRA_OEMAKE = "PLATFORM=${OPTEEMACHINE} O=out/arm \
                 CROSS_COMPILE_core=${HOST_PREFIX} \
-                DEBUG=0 LDFLAGS= \
+                CFG_WERROR=y DEBUG=0 LDFLAGS= \
                 LIBGCC_LOCATE_CFLAGS=--sysroot=${STAGING_DIR_HOST} \
                 CFG_TEE_CORE_LOG_LEVEL=2 CFG_TEE_TA_LOG_LEVEL=2 \
 "

--- a/recipes-security/optee/optee-os_git.bb
+++ b/recipes-security/optee/optee-os_git.bb
@@ -18,6 +18,7 @@ SRC_URI_append_imx = " \
     file://0001-Minimal-HUK-implementation-without-full-CAAM-driver.patch \
     file://0001-imx-huk-imx7-and-imx7ulp-caam-clock-support.patch \
     file://0001-plat-imx-configure-the-SHMEM-section.patch \
+    file://0001-imx-caam-check-if-otpmk-can-be-used-when-producing-h.patch \
 "
 
 PV = "3.6.0+git"

--- a/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "2019.9+fio"
-SRCREV_lmp = "428a7aa8e769d21d9596e35d455d7db99e06237e"
+SRCREV_lmp = "ee949de847a353855ed6a0bf85522a1ba1d32cff"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \

--- a/recipes-support/crucible/crucible_git.bb
+++ b/recipes-support/crucible/crucible_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=d1e4913d52e4dda553dcd90e
 SRC_URI = "git://${GO_IMPORT} \
     file://set-default-fusemaps-dir.patch \
 "
-SRCREV = "2b3dcd130b628def42e4306b8950bb3cc6c0dd72"
+SRCREV = "5713dd693f8ceecd175d4e7b9029a2c02c2c89ea"
 UPSTREAM_CHECK_COMMITS = "1"
 PV = "0.1+git${SRCPV}"
 


### PR DESCRIPTION
* linux-lmp kernel stable update
* crucible minor upstream update
* enable cfg werror on optee-os
* update aktualizr to our latest branch revision
* change optee-os to validate otpmk when generating huk