### PR TITLE
u-boot-fio: bump srcrev for updates to mx7ulpea-ucom / M4 verified boot

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fio_git.bb
+++ b/recipes-bsp/u-boot/u-boot-fio_git.bb
@@ -6,7 +6,7 @@ DEPENDS += "flex-native bison-native bc-native dtc-native"
 
 require recipes-bsp/u-boot/u-boot.inc
 
-SRCREV = "e47d650f53262acff0c5d73981fb84c2731006ca"
+SRCREV = "fe1cffb9155cabc2b3741f3accff91ae61fb3bbb"
 SRCBRANCH = "2019.10+fio"
 
 SRC_URI = "git://github.com/foundriesio/u-boot.git;branch=${SRCBRANCH}"


### PR DESCRIPTION
Relevant commits:
fe1cffb [FIO ext] configs: mx7ulpea-mfgtool-ucom: enable IMX_FPGA
06d3735 [FIO ext] configs: mx7ulpea-ucom: enable IMX_FPGA
3c4d5c7 [FIO toup] fpga: imx_m4: boot M4
a5ff21e [FIO internal] common: foundries.io verified boot utility
3115e18 [FIO toup] drivers: rpmb: use cache aligned buffers on route commands
daf7fa2 [FIO toup] drivers: rpmb: replicate linux mmc configuration
9737e86 [FIO toup] drivers: optee: rpmb: fix returning CID to TEE
bc56664 [FIO toup] mmc: fsl_esdhc_imx: initialize data for imx7ulp

Signed-off-by: Michael Scott <mike@foundries.io>