### PR TITLE
fiovb host

### DIFF
--- a/recipes-security/optee/optee-fiovb_git.bb
+++ b/recipes-security/optee/optee-fiovb_git.bb
@@ -26,5 +26,7 @@ EXTRA_OEMAKE = "OPTEE_CLIENT_EXPORT=${OPTEE_CLIENT_EXPORT} \
 
 do_install () {
     install -d ${D}${bindir}
-    install -m 0755 ${S}/out/ca/fiovb ${D}${bindir}
+    install -m 0755 ${S}/out/ca/fiovb ${D}${bindir}/fiovb
+    ln -sf fiovb ${D}${bindir}/fiovb_printenv
+    ln -sf fiovb ${D}${bindir}/fiovb_setenv
 }

--- a/recipes-security/optee/optee-fiovb_git.bb
+++ b/recipes-security/optee/optee-fiovb_git.bb
@@ -10,7 +10,7 @@ inherit pythonnative
 SRC_URI = "git://github.com/foundriesio/optee-fiovb.git"
 
 PV = "0.1"
-SRCREV = "c7f80c69861628b1958ec35214afa2e0a0ae576d"
+SRCREV = "316b996089dffece836abbb1db9dbd24f3b81fb5"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Use fiovb_printenv and fiovb_setenv to access the secure functionality (just as fw_printenv and fw_sentenv).

This PR also creates the necessary symlinks during the install phase

requires actualzr update.