### PR TITLE
optee-os: imx: psci reset through watchdog

### DIFF
--- a/recipes-security/optee/optee-os/0001-imx-imx7ulp-watchdog-set-into-ready-state-prior-rese.patch
+++ b/recipes-security/optee/optee-os/0001-imx-imx7ulp-watchdog-set-into-ready-state-prior-rese.patch
@@ -1,0 +1,52 @@
+From 29fe1792700218bdb22acff46c385bc3ffddd2de Mon Sep 17 00:00:00 2001
+From: Jorge Ramirez-Ortiz <jorge@foundries.io>
+Date: Fri, 6 Dec 2019 12:38:53 +0100
+Subject: [PATCH] imx: imx7ulp: watchdog: set into ready state prior reset
+
+Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
+---
+ core/drivers/imx_wdog.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/core/drivers/imx_wdog.c b/core/drivers/imx_wdog.c
+index 83f461c2..72c8841b 100644
+--- a/core/drivers/imx_wdog.c
++++ b/core/drivers/imx_wdog.c
+@@ -44,6 +44,24 @@
+ static bool ext_reset;
+ static vaddr_t wdog_base;
+ 
++#ifdef CFG_MX7ULP
++static void imx_wdt_reinit(void)
++{
++	uint32_t val;
++
++	/* unlock the wdog for reconfiguration */
++	io_write32(wdog_base + WDOG_CNT, UNLOCK_SEQ0);
++	io_write32(wdog_base + WDOG_CNT, UNLOCK_SEQ1);
++
++	/* set an initial timeout value in TOVAL */
++	io_write32(wdog_base + WDOG_TOVAL, 1000);
++
++	/* enable 32bit command sequence and reconfigure */
++	val = (1 << 13) | (1 << 8) | (1 << 5);
++	io_write32(wdog_base + WDOG_CS, val);
++}
++#endif
++
+ void imx_wdog_restart(void)
+ {
+ 	uint32_t val;
+@@ -54,6 +72,9 @@ void imx_wdog_restart(void)
+ 	}
+ 
+ #ifdef CFG_MX7ULP
++	/* make sure the wdt is in the ready state */
++	imx_wdt_reinit();
++
+ 	val = io_read32(wdog_base + WDOG_CS);
+ 
+ 	io_write32(wdog_base + WDOG_CNT, UNLOCK);
+-- 
+2.17.1
+

--- a/recipes-security/optee/optee-os_git.bb
+++ b/recipes-security/optee/optee-os_git.bb
@@ -19,6 +19,7 @@ SRC_URI_append_imx = " \
     file://0001-imx-huk-imx7-and-imx7ulp-caam-clock-support.patch \
     file://0001-plat-imx-configure-the-SHMEM-section.patch \
     file://0001-imx-caam-check-if-otpmk-can-be-used-when-producing-h.patch \
+    file://0001-imx-imx7ulp-watchdog-set-into-ready-state-prior-rese.patch \
 "
 
 PV = "3.6.0+git"


### PR DESCRIPTION
the psci system reset is delegated to a watchdog needing external initialization (usually by the linux kernel). Since linux could disable the watchdog at any time before the actual reset sequence (ie, systemd requests), optee needs to guarantee that the watchdog will be ready to process the psci request.
This is achieved by
1) making sure the watchdog clock is active during device init - so no normal world initialization is required.
2) reserving the watchdog via overlay and dtb generation - so the kernel will not probe it and create the device node.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>