### PR TITLE
python3-docker: fix a fetch issue

### DIFF
--- a/meta-lmp-base/recipes-devtools/python/python3-docker_%.bbappend
+++ b/meta-lmp-base/recipes-devtools/python/python3-docker_%.bbappend
@@ -1,2 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
 # Add in LMP credential helper
 SRC_URI += "file://0001-config-Include-usr-lib-docker-in-search-path.patch"


### PR DESCRIPTION
We need ensure python3-docker directory is in FILESEXTRAPATHS, or else
the LMP patch could not be found in do_fetch.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>