### PR TITLE
meta-lmp-base: optee-os: imx7ulp: fix watchdog

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os/0001-imx7ulp-drivers-watchdog-fix-timing-issue.patch
+++ b/meta-lmp-base/recipes-security/optee/optee-os/0001-imx7ulp-drivers-watchdog-fix-timing-issue.patch
@@ -1,0 +1,107 @@
+From f931ecf9551d33844c5ad8a4810d4be2ed3452af Mon Sep 17 00:00:00 2001
+From: Jorge Ramirez-Ortiz <jorge@foundries.io>
+Date: Mon, 16 Dec 2019 10:34:07 +0100
+Subject: [PATCH] imx7ulp: drivers: watchdog: fix timing issue
+
+The new configuration must be programmed to iomem within 128 bus
+clocks after performing the unlock.
+
+Not doing so might result on the watchdog not running.
+
+Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
+---
+ core/drivers/imx_wdog.c         | 49 ++++++++++++++++++++++++++-------
+ core/include/drivers/imx_wdog.h |  1 +
+ 2 files changed, 40 insertions(+), 10 deletions(-)
+
+diff --git a/core/drivers/imx_wdog.c b/core/drivers/imx_wdog.c
+index 83f461c2..d060ff29 100644
+--- a/core/drivers/imx_wdog.c
++++ b/core/drivers/imx_wdog.c
+@@ -44,9 +44,23 @@
+ static bool ext_reset;
+ static vaddr_t wdog_base;
+ 
++#ifdef CFG_MX7ULP
++static inline void __raw_writel(volatile vaddr_t addr, uint32_t val)
++{
++	asm volatile("str %1, %0"
++		     : : "Qo" (*(volatile uint32_t *)addr), "r" (val));
++}
++
++static inline void __raw_writeb(volatile vaddr_t addr, uint8_t val)
++{
++	asm volatile("strb %1, %0"
++		     : : "Qo" (*(volatile uint8_t *)addr), "r" (val));
++}
++#endif
++
+ void imx_wdog_restart(void)
+ {
+-	uint32_t val;
++	uint32_t val __attribute__((unused));
+ 
+ 	if (!wdog_base) {
+ 		EMSG("No wdog mapped\n");
+@@ -54,15 +68,26 @@ void imx_wdog_restart(void)
+ 	}
+ 
+ #ifdef CFG_MX7ULP
+-	val = io_read32(wdog_base + WDOG_CS);
+-
+-	io_write32(wdog_base + WDOG_CNT, UNLOCK);
+-	/* Enable wdog */
+-	io_write32(wdog_base + WDOG_CS, val | WDOG_CS_EN);
+-
+-	io_write32(wdog_base + WDOG_CNT, UNLOCK);
+-	io_write32(wdog_base + WDOG_TOVAL, 1000);
+-	io_write32(wdog_base + WDOG_CNT, REFRESH);
++	dmb();
++	__raw_writel(wdog_base + WDOG_CNT, UNLOCK_SEQ0);
++	__raw_writel(wdog_base + WDOG_CNT, UNLOCK_SEQ1);
++	dmb();
++	/* Wait unlock */
++	while (!(io_read8(wdog_base + WDOG_CS + 1) & BIT(3)));
++
++	/* these sequence must be completed within 128 clock cycles after unlock */
++	dmb();
++	__raw_writel(wdog_base + WDOG_TOVAL, 0x400);
++	__raw_writeb(wdog_base + WDOG_WIN, 0);
++	__raw_writeb(wdog_base + WDOG_CS + 1, BIT(6) | BIT(0));
++	__raw_writeb(wdog_base + WDOG_CS,     BIT(7) | BIT(5));
++	dmb();
++
++	/* this wait for configuration is not necessary since the driver will
++	 * just wait after this operation anyway. However we will leave it here
++	 * for formal purposes
++	 */
++	while (!(io_read32(wdog_base + WDOG_CS) & WDOG_CS_RCS));
+ #else
+ 	if (ext_reset)
+ 		val = 0x14;
+@@ -83,6 +108,10 @@ void imx_wdog_restart(void)
+ 	io_write16(wdog_base + WDT_WCR, val);
+ #endif
+ 
++	/* debug tip: during the while loop is worth checking that the
++	 * watchdog counter is progressing as the clock could have been stopped
++	 * causing the board to wait forever
++	 */
+ 	while (1)
+ 		;
+ }
+diff --git a/core/include/drivers/imx_wdog.h b/core/include/drivers/imx_wdog.h
+index 8665e39d..d0806e47 100644
+--- a/core/include/drivers/imx_wdog.h
++++ b/core/include/drivers/imx_wdog.h
+@@ -43,6 +43,7 @@
+ /* 7ULP */
+ #define WDOG_CNT	0x4
+ #define WDOG_TOVAL	0x8
++#define WDOG_WIN	0xc
+ 
+ #define REFRESH_SEQ0	0xA602
+ #define REFRESH_SEQ1	0xB480
+-- 
+2.17.1
+

--- a/meta-lmp-base/recipes-security/optee/optee-os_git.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os_git.bb
@@ -19,6 +19,7 @@ SRC_URI_append_imx = " \
     file://0001-imx-huk-imx7-and-imx7ulp-caam-clock-support.patch \
     file://0001-plat-imx-configure-the-SHMEM-section.patch \
     file://0001-imx-caam-check-if-otpmk-can-be-used-when-producing-h.patch \
+    file://0001-imx7ulp-drivers-watchdog-fix-timing-issue.patch \
 "
 
 PV = "3.6.0+git"


### PR DESCRIPTION
Rhe imx7ulp watchdog has very stringent timing requirements for its
reconfiguration (128 bus cycles after unlock).

Do our best to comply with that requirement.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>