### PR TITLE
meta-lmp-base: optee-os: imx7ulp: fix incorrect register setting

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os/0001-imx7ulp-drivers-watchdog-fix-timing-issue.patch
+++ b/meta-lmp-base/recipes-security/optee/optee-os/0001-imx7ulp-drivers-watchdog-fix-timing-issue.patch
@@ -67,7 +67,7 @@ index 83f461c2..d060ff29 100644
 +	dmb();
 +	__raw_writel(wdog_base + WDOG_TOVAL, 0x400);
 +	__raw_writeb(wdog_base + WDOG_WIN, 0);
-+	__raw_writeb(wdog_base + WDOG_CS + 1, BIT(6) | BIT(0));
++	__raw_writeb(wdog_base + WDOG_CS + 1, BIT(5) | BIT(0));
 +	__raw_writeb(wdog_base + WDOG_CS,     BIT(7) | BIT(5));
 +	dmb();
 +


### PR DESCRIPTION
During the previous patch preparation we incorrectly wrote to BIT(6) -
interrupt status flag - instead of BIT(5) (enable support for 32bit
timers)

Upon stress testing this was causing that "sometimes" reset requests
would act inmediately instead of via countdown (perhaps due to a
violation in writing to this register).

This commit fixes the situation generated by our previous commit.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>