### PR TITLE
meta-lmp-base: aktualizr: move fiovb var to SOTA_EXTRA_CLIENT_FEATURES

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -16,7 +16,7 @@ SRC_URI_append_libc-musl = " \
     file://utils.c-disable-tilde-as-it-is-not-supported-by-musl.patch \
 "
 
-PACKAGECONFIG += "${@bb.utils.filter('SOTA_CLIENT_FEATURES', 'fiovb', d)}"
+PACKAGECONFIG += "${@bb.utils.filter('SOTA_EXTRA_CLIENT_FEATURES', 'fiovb', d)}"
 PACKAGECONFIG[fiovb] = ",,,optee-fiovb aktualizr-fiovb-env-rollback"
 PACKAGECONFIG[dockerapp] = "-DBUILD_DOCKERAPP=ON,-DBUILD_DOCKERAPP=OFF,,docker-app"
 PACKAGECONFIG_append_class-target = " dockerapp"


### PR DESCRIPTION
Using SOTA_CLIENT_FEATURES to store the fiovb feature now causes an
error due to sanity checks performed by the meta-updater layer.

Let's move the feature addition to SOTA_EXTRA_CLIENT_FEATURES.

Signed-off-by: Michael Scott <mike@foundries.io>