### PR TITLE
aktualizr: relies on nss-lookup.target

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Aktualizr Lite SOTA Client
-After=network.target
+After=network.target nss-lookup.target
 ConditionPathExists=|/var/sota/sota.toml
 ConditionPathExists=|/usr/lib/sota/conf.d/10-lite-public-stream.toml
 


### PR DESCRIPTION
aktualizr-lite.service needs run after nss-lookup.target to ensure DNS
resolving is ready.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>