### PR TITLE
base: recipes-support: mfgtools: udpate *.img.gz to *.wic.gz

### DIFF
--- a/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files/full_image.uuu.in
+++ b/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files/full_image.uuu.in
@@ -22,7 +22,7 @@ uuu_version 1.0.1
 
 # Rootfs
 #FBK: acmd mmc=`cat /tmp/mmcdev`; gunzip -c | dd of=/dev/mmcblk${mmc} bs=4M iflag=fullblock oflag=direct status=progress
-#FBK: ucp  ../lmp-gateway-image-@@MACHINE@@.img.gz t:-
+#FBK: ucp  ../lmp-gateway-image-@@MACHINE@@.wic.gz t:-
 #FBK: Sync
 
 #FBK: DONE


### PR DESCRIPTION
- Due to artifact renaming the full_tar scripts need the image filename
  updated from *.img.gz -> *.wic.gz

Signed-off-by: Michael Scott <mike@foundries.io>