### PR TITLE
base: recipes-sota: aktualizr: bugfix path monitoring service

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.path
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.path
@@ -1,6 +1,5 @@
 [Unit]
 Description=Aktualizr Lite SOTA Client path monitor
-After=network.target
 ConditionPathExists=!/usr/bin/mbedCloudClient
 
 [Path]


### PR DESCRIPTION
Systemd is complaining about dependency for target network when
starting monitoring path service for aktualizr-lite.  The reality
is we don't need to have a target for the monitoring service as
the paths it's watching won't be changed until much later in the
boot.  By that time we have the basic network stack available.

Fix by removing: After=network.target

Signed-off-by: Michael Scott <mike@foundries.io>