### PR TITLE
libubootenv: fix some packaging issues

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/libubootenv_%.bbappend
+++ b/meta-lmp-base/recipes-bsp/u-boot/libubootenv_%.bbappend
@@ -2,6 +2,10 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI_append = " file://fw_env.config"
 
+FILES_${PN}-bin += "${sysconfdir}/fw_env.config"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 do_install_append () {
 	install -d ${D}${sysconfdir}
 	install -m 0644 ${WORKDIR}/fw_env.config ${D}${sysconfdir}/fw_env.config


### PR DESCRIPTION
libubootenv-bin is the RPROVIDER of u-boot-fw-utils, so the
${sysconfdir}/fw_env.config should be in that package instead of being
put in libubootenv package as it is right now.

And ${sysconfdir}/fw_env.config is a machine specific file, so if we
want bundle it to libubootenv recipe, then libubootenv itself should be
a machine package rather than a arch package.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>