### PR TITLE
bsp: mfgtool-files: change extra depends to soc level

### DIFF
--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files_%.bbappend
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files_%.bbappend
@@ -2,14 +2,15 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 # Machine specific dependencies
 def get_do_deploy_depends(d):
-    machine = d.getVar('MACHINE')
-    if machine == 'imx8mmevk':
+    imxboot_families = ['mx8']
+    cur_families = (d.getVar('MACHINEOVERRIDES') or '').split(':')
+    if any(map(lambda x: x in cur_families, imxboot_families)):
         return "imx-boot:do_deploy"
     return ""
 
 do_deploy[depends] += "${@get_do_deploy_depends(d)}"
 
-do_deploy_prepend_imx8mmevk() {
+do_deploy_prepend_mx8() {
     install -d ${DEPLOYDIR}/${PN}
     install -m 0644 ${DEPLOY_DIR_IMAGE}/imx-boot ${DEPLOYDIR}/${PN}/imx-boot-mfgtool
 }


### PR DESCRIPTION
imx-boot is a generic dependency for mx8-based targets, so change the
extra machine dependencies to be soc-based and not machine, in order to
cover a wider range of targets.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>