### PR TITLE
ostree: use /usr/sbin/reboot to reboot the system

### DIFF
--- a/meta-lmp-base/recipes-support/ostree-pending-reboot/ostree-pending-reboot/ostree-pending-reboot.service
+++ b/meta-lmp-base/recipes-support/ostree-pending-reboot/ostree-pending-reboot/ostree-pending-reboot.service
@@ -4,4 +4,4 @@ ConditionPathExists=/var/run/aktualizr-session/need_reboot
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/systemctl --force reboot
+ExecStart=/usr/sbin/reboot


### PR DESCRIPTION
A flaw was observed that sometimes the reboot procedure after updating
is very slow with the message showing on console:
```
[  523.527840] systemd-shutdown[1]: Waiting for process: rngd
```

this is caused by "systemctl --force reboot" being used in
ostree-pending-reboot.service, changing to a regular /sbin/reboot would
be much faster.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>