### PR TITLE
base: recipes-sota: aktualizr: remove public sota config as a trigger

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.path
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.path
@@ -4,7 +4,6 @@ ConditionPathExists=!/usr/bin/mbedCloudClient
 
 [Path]
 PathExists=/var/sota/sota.toml
-PathExists=/usr/lib/sota/conf.d/10-lite-public-stream.toml
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Don't worry about starting aktualizr-lite based on public sota config.
  this config will always be in place for public builds and never be there
  for private builds.  No need for a path watcher.

Signed-off-by: Michael Scott <mike@foundries.io>