### PR TITLE
base: recipes-sota: aklite.path: depend on aklite.service

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.path
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.path
@@ -1,5 +1,6 @@
 [Unit]
 Description=Aktualizr Lite SOTA Client path monitor
+ConditionPathExists=/etc/systemd/system/multi-user.target.wants/aktualizr-lite.service
 ConditionPathExists=!/usr/bin/mbedCloudClient
 
 [Path]


### PR DESCRIPTION
- Link the path monitor to the aktualizr-lite service when it's enabled
  by checking for the presence of:
  /etc/systemd/system/multi-user.target.wants/aktualizr-lite.service

Signed-off-by: Michael Scott <mike@foundries.io>