### PR TITLE
base: recipes-containers: docker-ce: use journald log driver

### DIFF
--- a/meta-lmp-base/recipes-containers/docker/docker-ce/daemon.json
+++ b/meta-lmp-base/recipes-containers/docker/docker-ce/daemon.json
@@ -1,7 +1,3 @@
 {
-  "log-driver": "json-file",
-  "log-opts": {
-    "max-size": "10m",
-    "max-file": "3"
-  }
+  "log-driver": "journald"
 }


### PR DESCRIPTION
swap from json-file log driver to journald:
- easier to manage consistent log storage settings across the whole
  platform
- possible I/O improvements when reading logs

Signed-off-by: Michael Scott <mike@foundries.io>