### PR TITLE
base: mcumgr: fix build dir permissions

### DIFF
--- a/meta-lmp-base/recipes-devtools/mcumgr/mcumgr_git.bb
+++ b/meta-lmp-base/recipes-devtools/mcumgr/mcumgr_git.bb
@@ -20,6 +20,7 @@ do_compile() {
 	cd ${S}/src/${GO_IMPORT}/mcumgr
 	mkdir -p ${B}/${GO_BUILD_BINDIR}
 	${GO} build -o ${B}/${GO_BUILD_BINDIR}/mcumgr mcumgr.go
+	chmod u+w -R ${B}
 }
 
 RDEPENDS_${PN}-dev += "bash"


### PR DESCRIPTION
- any new build of mcumgr errors out due to read-only directories
  created during the build
- add a manual step to reset these directories to user write so
  they can be deleted

Signed-off-by: Michael Scott <mike@foundries.io>