### PR TITLE
base: recipes-sota: aktualizr: move to master branch

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-BRANCH_lmp = "2020.4"
-SRCREV_lmp = "38251e646e5196ada6069bdb30a4e740d2da5c4f"
+BRANCH_lmp = "master"
+SRCREV_lmp = "647e29366a9aea6468c5953dda0792ce6a6d5c11"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
NOTE: This includes a SHA update of aktualizr

aktualizr-lite related changes:
- 647e2936 aktualizr: Bump version
- 19bf79a9 add gitignore and README
- 5bf612e0 Merge pull request #3 from doanac/unit-test-fixes
- 72091d86 Fix broken integration test
- c8c8755d Fix tests for latest aktualizr

aktualizr related changes:
- 852f43be [fio extras] bootloader: add support to fio verified boot

Signed-off-by: Michael Scott <mike@foundries.io>