### PR TITLE
base: recipes-support: fioconfig: add toml helper support

### DIFF
--- a/meta-lmp-base/recipes-support/fioconfig/fioconfig/fioconfig.path
+++ b/meta-lmp-base/recipes-support/fioconfig/fioconfig/fioconfig.path
@@ -1,0 +1,8 @@
+[Unit]
+Description=Foundries.io configuration management path monitor
+
+[Path]
+PathExists=/var/sota/sota.toml
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-lmp-base/recipes-support/fioconfig/fioconfig/fioconfig.service
+++ b/meta-lmp-base/recipes-support/fioconfig/fioconfig/fioconfig.service
@@ -6,6 +6,7 @@ ConditionPathExists=/var/sota/sota.toml
 [Service]
 RestartSec=10
 Restart=always
+ExecStartPre=mkdir -p /var/run/secrets
 ExecStart=/usr/bin/fioconfig daemon
 
 [Install]

--- a/meta-lmp-base/recipes-support/fioconfig/fioconfig_git.bb
+++ b/meta-lmp-base/recipes-support/fioconfig/fioconfig_git.bb
@@ -7,6 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=2a944942e1496af1886903d2
 GO_IMPORT = "github.com/foundriesio/fioconfig"
 SRC_URI = "git://${GO_IMPORT} \
 	file://fioconfig.service \
+	file://fioconfig.path \
 	file://fioconfig-extract.service \
 "
 SRCREV = "1db6a4fdee49a69a64c4c0ac6f92bc2aa84c874f"
@@ -25,12 +26,13 @@ do_compile() {
 }
 
 SYSTEMD_PACKAGES += "${PN}"
-SYSTEMD_SERVICE_${PN} = "fioconfig.service fioconfig-extract.service"
+SYSTEMD_SERVICE_${PN} = "fioconfig.service fioconfig-extract.service fioconfig.path"
 
 
 do_install_append() {
 	install -d ${D}${systemd_system_unitdir}
 	install -m 0644 ${WORKDIR}/fioconfig.service ${D}${systemd_system_unitdir}/
+	install -m 0644 ${WORKDIR}/fioconfig.path ${D}${systemd_system_unitdir}/
 	install -m 0644 ${WORKDIR}/fioconfig-extract.service ${D}${systemd_system_unitdir}/
 	install -d ${D}${datadir}/fioconfig/handlers
 	install -m 0755 ${S}/src/${GO_IMPORT}/contrib/aktualizr-toml-update ${D}${datadir}/fioconfig/handlers
@@ -41,6 +43,7 @@ RDEPENDS_${PN} = "${SOTA_CLIENT}"
 
 FILES_${PN} += " \
 	${systemd_unitdir}/system/fioconfig.service \
+	${systemd_unitdir}/system/fioconfig.path \
 	${systemd_unitdir}/system/fioconfig-extract.service \
 	${datadir}/fioconfig/handlers \
 "

--- a/meta-lmp-base/recipes-support/fioconfig/fioconfig_git.bb
+++ b/meta-lmp-base/recipes-support/fioconfig/fioconfig_git.bb
@@ -9,7 +9,7 @@ SRC_URI = "git://${GO_IMPORT} \
 	file://fioconfig.service \
 	file://fioconfig-extract.service \
 "
-SRCREV = "6d9f25f1c402eaa23bb98c0ce04355cd96e25647"
+SRCREV = "1db6a4fdee49a69a64c4c0ac6f92bc2aa84c874f"
 
 UPSTREAM_CHECK_COMMITS = "1"
 
@@ -27,10 +27,13 @@ do_compile() {
 SYSTEMD_PACKAGES += "${PN}"
 SYSTEMD_SERVICE_${PN} = "fioconfig.service fioconfig-extract.service"
 
+
 do_install_append() {
 	install -d ${D}${systemd_system_unitdir}
 	install -m 0644 ${WORKDIR}/fioconfig.service ${D}${systemd_system_unitdir}/
 	install -m 0644 ${WORKDIR}/fioconfig-extract.service ${D}${systemd_system_unitdir}/
+	install -d ${D}${datadir}/fioconfig/handlers
+	install -m 0755 ${S}/src/${GO_IMPORT}/contrib/aktualizr-toml-update ${D}${datadir}/fioconfig/handlers
 }
 
 # We need aktualizr because we uses its device gateway connectivity and keys
@@ -39,4 +42,5 @@ RDEPENDS_${PN} = "${SOTA_CLIENT}"
 FILES_${PN} += " \
 	${systemd_unitdir}/system/fioconfig.service \
 	${systemd_unitdir}/system/fioconfig-extract.service \
+	${datadir}/fioconfig/handlers \
 "


### PR DESCRIPTION
ficonfig has been updated to include an aktualizr-toml-update
helper script.  By using fioctl devices config updates command,
we can now easily set the docker-apps and tags settings for
aktualizr-lite.

Signed-off-by: Michael Scott <mike@foundries.io>