### PR TITLE
Improve default features settings in LMP

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -28,7 +28,7 @@ DISTRO_FEATURES_NATIVESDK_remove = "x11"
 
 # TODO: review default distro features
 DISTRO_FEATURES_append = " pam systemd usrmerge virtualization"
-DISTRO_FEATURES_remove = "3g alsa pcmcia nfc pulseaudio sysvinit"
+DISTRO_FEATURES_remove = "3g alsa pcmcia nfs nfc pulseaudio sysvinit"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 PACKAGECONFIG_append_pn-docker-ce = " seccomp"
 PACKAGECONFIG_append_pn-runc-docker = " seccomp"

--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -22,14 +22,13 @@ PREFERRED_PROVIDER_zlib ?= "zlib"
 PREFERRED_PROVIDER_zlib-native ?= "zlib-native"
 PREFERRED_PROVIDER_nativesdk-zlib ?= "nativesdk-zlib"
 
-# No need for x11 even for native
-DISTRO_FEATURES_NATIVE_remove = "x11"
-DISTRO_FEATURES_NATIVESDK_remove = "x11"
-
-# TODO: review default distro features
+# Default distro features for LMP (can be extended by the user if needed)
+DISTRO_FEATURES_DEFAULT = "acl argp bluetooth ext2 ipv4 ipv6 largefile usbgadget usbhost wifi xattr zeroconf pci vfat"
+DISTRO_FEATURES_BACKFILL_CONSIDERED = "pulseaudio sysvinit"
 DISTRO_FEATURES_append = " pam systemd usrmerge virtualization"
-DISTRO_FEATURES_remove = "3g alsa pcmcia nfs nfc pulseaudio sysvinit"
 VIRTUAL-RUNTIME_init_manager = "systemd"
+
+# Extended packageconfig options for LMP
 PACKAGECONFIG_append_pn-docker-ce = " seccomp"
 PACKAGECONFIG_append_pn-runc-docker = " seccomp"
 # Required because of https://github.com/opencontainers/runc/issues/2008

--- a/meta-lmp-base/conf/distro/lmp-base.conf
+++ b/meta-lmp-base/conf/distro/lmp-base.conf
@@ -6,9 +6,6 @@ DISTRO_NAME = "Linux-microPlatform Base (no ostree)"
 
 IMAGE_LINGUAS ?= "en-us"
 
-# No graphical feature as part of the base platform
-DISTRO_FEATURES_remove = "wayland x11"
-
 # By default we only support initramfs. We don't build live as that
 # pulls in a lot of dependencies for the live image and the installer, like
 # udev, grub, etc.  These pull in gettext, which fails to build with wide

--- a/meta-lmp-base/conf/distro/lmp-mfgtool.conf
+++ b/meta-lmp-base/conf/distro/lmp-mfgtool.conf
@@ -4,9 +4,6 @@ DISTRO_NAME = "Linux-microPlatform for Mfgtool (no ostree)"
 
 IMAGE_LINGUAS ?= "en-us"
 
-# No graphical feature as part of the base platform
-DISTRO_FEATURES_remove = "wayland x11"
-
 # By default we only support initramfs. We don't build live as that
 # pulls in a lot of dependencies for the live image and the installer, like
 # udev, grub, etc.  These pull in gettext, which fails to build with wide

--- a/meta-lmp-base/conf/distro/lmp.conf
+++ b/meta-lmp-base/conf/distro/lmp.conf
@@ -25,8 +25,5 @@ SOTA_CLIENT_FEATURES_append = " hsm"
 ## Sota BSP specific configs are managed by LMP
 SOTA_MACHINE_lmp = "lmp"
 
-# No graphical feature as part of the base platform
-DISTRO_FEATURES_remove = "wayland x11"
-
 # General
 WKS_FILE_DEPENDS_BOOTLOADERS_remove = "syslinux systemd-boot"


### PR DESCRIPTION
* Remove support for nfs (nfs client, not used/required by us)
* Manually added a default set for distro features based on was already available by OE. This will allow our user to add features that were previously removed via "_remove", such as x11 and wayland. 