### PR TITLE
lmp-device-register: bump to the latest git rev

### DIFF
--- a/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -2,9 +2,9 @@ SUMMARY = "Linux microPlatform OSF OTA+ device registration tool"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
-DEPENDS = "boost curl ostree glib-2.0"
+DEPENDS = "boost curl glib-2.0"
 
-SRCREV = "13f65a2756331b157e3aecdedcc734e60b80311c"
+SRCREV = "5acb69ec648ba99978d985ddda326b31823c421a"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https"
 


### PR DESCRIPTION
Relevant changes:
- 5acb69e Remove dependency on ostree
- 464218b Make the former '-s' option hidden
- 9979b15 Add ability to specify a factory via an env var
- bf32ca1 Replace the 'stream' option with 'factory' one
- 74189cf Fix DEVICE_API default value

Signed-off-by: Mike Sul <mike.sul@foundries.io>