### PR TITLE
base: kernel-lmp-fitimage: generate config even without dtb

### DIFF
--- a/meta-lmp-base/classes/kernel-lmp-fitimage.bbclass
+++ b/meta-lmp-base/classes/kernel-lmp-fitimage.bbclass
@@ -265,6 +265,8 @@ fitimage_assemble() {
 			fi
 			i=`expr ${i} + 1`
 		done
+	else
+		fitimage_emit_section_config ${1} "${kernelcount}" "" "${ramdiskcount}" "${setupcount}" "${fpgacount}" ""
 	fi
 
 	fitimage_emit_section_maint ${1} sectend


### PR DESCRIPTION
Generate a default fit configuration even when no dtb is provided by the
kernel/board, as it gets used to verify all the other components (hash
and signature).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>