### PR TITLE
bsp: u-boot scripts: clear environment during rollback

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/beaglebone-yocto/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/beaglebone-yocto/boot.cmd
@@ -1,10 +1,10 @@
 # Default boot type and device
-setenv bootlimit 3
-
+setenv bootcmd_envinit 'setenv bootlimit 3'
 setenv bootcmd_load_f 'ext4load ${devtype} ${devnum}:2 ${addr_fit} "/boot"${kernel_image}'
 setenv bootcmd_run 'bootm ${addr_fit}#conf@${fdtfile}'
 setenv bootcmd_rollbackenv 'setenv kernel_image ${kernel_image2}; setenv bootargs ${bootargs2}'
-setenv bootcmd_set_rollback 'if test ! "${rollback}" = "1"; then setenv rollback 1; setenv upgrade_available 0; saveenv; fi'
+setenv bootcmd_otenv 'ext4load ${devtype} ${devnum}:2 ${loadaddr} /boot/loader/uEnv.txt; env import -t ${loadaddr} ${filesize};'
+setenv bootcmd_set_rollback 'if test ! "${rollback}" = "1"; then env default -a; run bootcmd_envinit; run bootcmd_otenv; setenv rollback 1; setenv upgrade_available 0; saveenv; fi'
 setenv bootostree 'run bootcmd_load_f; run bootcmd_run'
 setenv altbootcmd 'run bootcmd_set_rollback; if test -n "${kernel_image2}"; then run bootcmd_rollbackenv; fi; run bootostree; reset'
 
@@ -17,8 +17,8 @@ setenv bootargs
 setenv kernel_image2
 setenv bootargs2
 
-ext4load ${devtype} ${devnum}:2 ${loadaddr} /boot/loader/uEnv.txt
-env import -t ${loadaddr} ${filesize}
+run bootcmd_envinit
+run bootcmd_otenv
 
 if test "${rollback}" = "1"; then run altbootcmd; else run bootostree; if test ! "${upgrade_available}" = "1"; then setenv upgrade_available 1; saveenv; fi; reset; fi
 

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/qemuarm64/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/qemuarm64/boot.cmd
@@ -1,12 +1,10 @@
 # Default boot type and device
-setenv bootlimit 3
-setenv devtype virtio
-setenv devnum 0
-
+setenv bootcmd_envinit 'setenv bootlimit 3; setenv devtype virtio; setenv devnum 0'
 setenv bootcmd_load_f 'ext4load ${devtype} ${devnum}:2 ${ramdisk_addr_r} "/boot"${kernel_image}'
 setenv bootcmd_run 'bootm ${ramdisk_addr_r}#conf@ ${ramdisk_addr_r}#conf@ ${fdt_addr}'
 setenv bootcmd_rollbackenv 'setenv kernel_image ${kernel_image2}; setenv bootargs ${bootargs2}'
-setenv bootcmd_set_rollback 'if test ! "${rollback}" = "1"; then setenv rollback 1; setenv upgrade_available 0; saveenv; fi'
+setenv bootcmd_otenv 'ext4load ${devtype} ${devnum}:2 ${loadaddr} /boot/loader/uEnv.txt; env import -t ${scriptaddr} ${filesize};'
+setenv bootcmd_set_rollback 'if test ! "${rollback}" = "1"; then env default -a; run bootcmd_envinit; run bootcmd_otenv; setenv rollback 1; setenv upgrade_available 0; saveenv; fi'
 setenv bootostree 'run bootcmd_load_f; run bootcmd_run'
 setenv altbootcmd 'run bootcmd_set_rollback; if test -n "${kernel_image2}"; then run bootcmd_rollbackenv; fi; run bootostree; reset'
 
@@ -22,8 +20,8 @@ setenv bootargs2
 fdt addr ${fdt_addr}
 fdt rm /reserved-memory/optee_core@0xe100000
 
-ext4load ${devtype} ${devnum}:2 ${scriptaddr} /boot/loader/uEnv.txt
-env import -t ${scriptaddr} ${filesize}
+run bootcmd_envinit
+run bootcmd_otenv
 
 if test "${rollback}" = "1"; then run altbootcmd; else run bootostree; if test ! "${upgrade_available}" = "1"; then setenv upgrade_available 1; saveenv; fi; reset; fi
 

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/imx8mmevk/uEnv.txt.in
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/imx8mmevk/uEnv.txt.in
@@ -1,7 +1,4 @@
-bootlimit=3
-devnum=2
-devtype=mmc
-fdtovaddr=0x43600000
+bootcmd_envinit=bootlimit=3; devnum=2; devtype=mmc; fdtovaddr=0x43600000
 bootcmd_load_f=ext4load ${devtype} ${devnum}:2 ${initrd_addr} "/boot"${kernel_image}
 bootcmd_tee_ovy=imxtract ${initrd_addr}#conf@freescale_${fdt_file} fdt@freescale_${fdt_file} ${fdt_addr}; fdt addr ${fdt_addr}; fdt resize 0x1000; fdt apply ${fdtovaddr}
 bootcmd_run=bootm ${initrd_addr}#conf@freescale_${fdt_file} ${initrd_addr}#conf@freescale_${fdt_file} ${fdt_addr}
@@ -9,7 +6,7 @@ bootcmd_ostree=run bootcmd_load_f; run bootcmd_tee_ovy; run bootcmd_run
 bootcmd_create_envfile=if test ! -e ${devtype} ${devnum}:1 uboot.env; then saveenv; fi
 bootcmd_resetvars=setenv kernel_image; setenv bootargs; setenv kernel_image2; setenv bootargs2
 bootcmd_rollbackenv=setenv kernel_image ${kernel_image2}; setenv bootargs ${bootargs2}
-bootcmd_set_rollback=if test ! "${rollback}" = "1"; then setenv rollback 1; setenv upgrade_available 0; saveenv; fi
+bootcmd_set_rollback=if test ! "${rollback}" = "1"; then env default -a; run bootcmd_envinit; run bootcmd_otenv; setenv rollback 1; setenv upgrade_available 0; saveenv; fi
 bootcmd_otenv=run bootcmd_resetvars; ext4load ${devtype} ${devnum}:2 ${loadaddr} /boot/loader/uEnv.txt; env import -t ${loadaddr} ${filesize}
-bootcmd=if test "${rollback}" = "1"; then run altbootcmd; else run bootcmd_create_envfile; run bootcmd_otenv; run bootcmd_ostree; if test ! "${upgrade_available}" = "1"; then setenv upgrade_available 1; saveenv; fi; reset; fi
+bootcmd=run bootcmd_envinit; if test "${rollback}" = "1"; then run altbootcmd; else run bootcmd_create_envfile; run bootcmd_otenv; run bootcmd_ostree; if test ! "${upgrade_available}" = "1"; then setenv upgrade_available 1; saveenv; fi; reset; fi
 altbootcmd=run bootcmd_create_envfile; run bootcmd_otenv; run bootcmd_set_rollback; if test -n "${kernel_image2}"; then run bootcmd_rollbackenv; fi; run bootcmd_ostree; reset

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/raspberrypi-cm3/uEnv.txt.in
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/raspberrypi-cm3/uEnv.txt.in
@@ -1,13 +1,10 @@
-bootlimit=3
-devnum=0
-devtype=mmc
-dtoverlays=#conf@overlays_vc4-kms-v3d.dtbo
+bootcmd_envinit=bootlimit=3; devnum=0; devtype=mmc; dtoverlays=#conf@overlays_vc4-kms-v3d.dtbo
 bootcmd_load_f=load ${devtype} ${devnum}:2 ${ramdisk_addr_r} "/boot"${kernel_image}
 bootcmd_run=setexpr fdtfile gsub '/' '_'; bootm ${ramdisk_addr_r}#conf@${fdtfile}${dtoverlays}
 bootcmd_create_envfile=if test ! -e ${devtype} ${devnum}:1 uboot.env; then saveenv; fi;
 bootcmd_resetvars=setenv kernel_image; setenv bootargs; setenv kernel_image2; setenv bootargs2
 bootcmd_rollbackenv=setenv kernel_image ${kernel_image2}; setenv bootargs ${bootargs2}
-bootcmd_set_rollback=if test ! "${rollback}" = "1"; then setenv rollback 1; setenv upgrade_available 0; saveenv; fi
+bootcmd_set_rollback=if test ! "${rollback}" = "1"; then env default -a; run bootcmd_envinit; run bootcmd_otenv; setenv rollback 1; setenv upgrade_available 0; saveenv; fi
 bootcmd_otenv=run bootcmd_resetvars; load ${devtype} ${devnum}:2 ${loadaddr} /boot/loader/uEnv.txt; env import -t ${loadaddr} ${filesize}
-bootcmd=if test "${rollback}" = "1"; then run altbootcmd; else run bootcmd_create_envfile; run bootcmd_otenv; run bootcmd_load_f; run bootcmd_run; if test ! "${upgrade_available}" = "1"; then setenv upgrade_available 1; saveenv; fi; reset; fi
+bootcmd=run bootcmd_envinit; if test "${rollback}" = "1"; then run altbootcmd; else run bootcmd_create_envfile; run bootcmd_otenv; run bootcmd_load_f; run bootcmd_run; if test ! "${upgrade_available}" = "1"; then setenv upgrade_available 1; saveenv; fi; reset; fi
 altbootcmd=run bootcmd_create_envfile; run bootcmd_otenv; run bootcmd_set_rollback; if test -n "${kernel_image2}"; then run bootcmd_rollbackenv; fi; run bootcmd_load_f; run bootcmd_run; reset

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/raspberrypi3/uEnv.txt.in
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/raspberrypi3/uEnv.txt.in
@@ -1,13 +1,10 @@
-bootlimit=3
-devnum=0
-devtype=mmc
-dtoverlays=#conf@overlays_vc4-kms-v3d.dtbo
+bootcmd_envinit=bootlimit=3; devnum=0; devtype=mmc; dtoverlays=#conf@overlays_vc4-kms-v3d.dtbo
 bootcmd_load_f=load ${devtype} ${devnum}:2 ${ramdisk_addr_r} "/boot"${kernel_image}
 bootcmd_run=setexpr fdtfile gsub '/' '_'; bootm ${ramdisk_addr_r}#conf@${fdtfile}${dtoverlays}
 bootcmd_create_envfile=if test ! -e ${devtype} ${devnum}:1 uboot.env; then saveenv; fi;
 bootcmd_resetvars=setenv kernel_image; setenv bootargs; setenv kernel_image2; setenv bootargs2
 bootcmd_rollbackenv=setenv kernel_image ${kernel_image2}; setenv bootargs ${bootargs2}
-bootcmd_set_rollback=if test ! "${rollback}" = "1"; then setenv rollback 1; setenv upgrade_available 0; saveenv; fi
+bootcmd_set_rollback=if test ! "${rollback}" = "1"; then env default -a; run bootcmd_envinit; run bootcmd_otenv; setenv rollback 1; setenv upgrade_available 0; saveenv; fi
 bootcmd_otenv=run bootcmd_resetvars; load ${devtype} ${devnum}:2 ${loadaddr} /boot/loader/uEnv.txt; env import -t ${loadaddr} ${filesize}
-bootcmd=if test "${rollback}" = "1"; then run altbootcmd; else run bootcmd_create_envfile; run bootcmd_otenv; run bootcmd_load_f; run bootcmd_run; if test ! "${upgrade_available}" = "1"; then setenv upgrade_available 1; saveenv; fi; reset; fi
+bootcmd=run bootcmd_envinit; if test "${rollback}" = "1"; then run altbootcmd; else run bootcmd_create_envfile; run bootcmd_otenv; run bootcmd_load_f; run bootcmd_run; if test ! "${upgrade_available}" = "1"; then setenv upgrade_available 1; saveenv; fi; reset; fi
 altbootcmd=run bootcmd_create_envfile; run bootcmd_otenv; run bootcmd_set_rollback; if test -n "${kernel_image2}"; then run bootcmd_rollbackenv; fi; run bootcmd_load_f; run bootcmd_run; reset

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/raspberrypi4/uEnv.txt.in
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/raspberrypi4/uEnv.txt.in
@@ -1,12 +1,10 @@
-bootlimit=3
-devnum=0
-devtype=mmc
+bootcmd_envinit=bootlimit=3; devnum=0; devtype=mmc
 bootcmd_load_f=load ${devtype} ${devnum}:2 ${ramdisk_addr_r} "/boot"${kernel_image}
 bootcmd_run=bootm ${ramdisk_addr_r}:kernel@1 ${ramdisk_addr_r}:ramdisk@1 ${fdt_addr}
 bootcmd_create_envfile=if test ! -e ${devtype} ${devnum}:1 uboot.env; then saveenv; fi;
 bootcmd_resetvars=setenv kernel_image; setenv bootargs; setenv kernel_image2; setenv bootargs2
 bootcmd_rollbackenv=setenv kernel_image ${kernel_image2}; setenv bootargs ${bootargs2}
-bootcmd_set_rollback=if test ! "${rollback}" = "1"; then setenv rollback 1; setenv upgrade_available 0; saveenv; fi
+bootcmd_set_rollback=if test ! "${rollback}" = "1"; then env default -a; run bootcmd_envinit; run bootcmd_otenv; setenv rollback 1; setenv upgrade_available 0; saveenv; fi
 bootcmd_otenv=run bootcmd_resetvars; load ${devtype} ${devnum}:2 ${loadaddr} /boot/loader/uEnv.txt; env import -t ${loadaddr} ${filesize}
-bootcmd=if test "${rollback}" = "1"; then run altbootcmd; else run bootcmd_create_envfile; run bootcmd_otenv; run bootcmd_load_f; run bootcmd_run; if test ! "${upgrade_available}" = "1"; then setenv upgrade_available 1; saveenv; fi; reset; fi
+bootcmd=run bootcmd_envinit; if test "${rollback}" = "1"; then run altbootcmd; else run bootcmd_create_envfile; run bootcmd_otenv; run bootcmd_load_f; run bootcmd_run; if test ! "${upgrade_available}" = "1"; then setenv upgrade_available 1; saveenv; fi; reset; fi
 altbootcmd=run bootcmd_create_envfile; run bootcmd_otenv; run bootcmd_set_rollback; if test -n "${kernel_image2}"; then run bootcmd_rollbackenv; fi; run bootcmd_load_f; run bootcmd_run; reset


### PR DESCRIPTION
Refactor boot scripts to allow clearing the environment on a rollback.

Signed-off-by: Michael Scott <mike@foundries.io>