### PR TITLE
bsp: machine: add support for qemuarm

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -112,6 +112,24 @@ QB_DRIVE_TYPE_qemuarm64 = "/dev/vdb"
 ## Bios/bl1.bin is ATF, which requires semihosting for the remaining boot artifacts
 QB_OPT_APPEND_qemuarm64 = "-no-acpi -bios bl1.bin -d unimp -semihosting-config enable,target=native"
 
+# QEMU ARM
+PREFERRED_PROVIDER_virtual/bootloader_qemuarm = "u-boot-fio"
+PREFERRED_PROVIDER_u-boot_qemuarm = "u-boot-fio"
+WKS_FILE_DEPENDS_append_qemuarm = " u-boot-default-script"
+PREFERRED_PROVIDER_u-boot-default-script_qemuarm = "u-boot-ostree-scr-fit"
+SOTA_CLIENT_FEATURES_append_qemuarm = " ubootenv"
+UBOOT_MACHINE_qemuarm = "qemu_arm_defconfig"
+IMAGE_BOOT_FILES_qemuarm = "boot.itb"
+KERNEL_IMAGETYPE_qemuarm = "fitImage"
+KERNEL_CLASSES_qemuarm = " kernel-lmp-fitimage "
+OSTREE_KERNEL_qemuarm = "${KERNEL_IMAGETYPE}-${INITRAMFS_IMAGE}-${MACHINE}-${MACHINE}"
+OSTREE_KERNEL_ARGS_qemuarm ?= "console=ttyAMA0 ${OSTREE_KERNEL_ARGS_COMMON}"
+UBOOT_ENTRYPOINT_qemuarm = "0x40080000"
+QB_DRIVE_TYPE_qemuarm = "/dev/vdb"
+## Currently support u-boot -> Linux boot
+## will add more security later
+QB_OPT_APPEND_qemuarm = "-no-acpi -bios u-boot.bin -d unimp"
+
 # Intel
 OSTREE_BOOTLOADER_intel-corei7-64 ?= "grub"
 OSTREE_KERNEL_ARGS_intel-corei7-64 ?= "console=ttyS0,115200 ${OSTREE_KERNEL_ARGS_COMMON}"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/qemuarm/fw_env.config
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/qemuarm/fw_env.config
@@ -1,0 +1,1 @@
+/mnt/boot/uboot.env     0x0000          0x40000

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/qemuarm/lmp.cfg
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/qemuarm/lmp.cfg
@@ -1,0 +1,11 @@
+CONFIG_FIT=y
+CONFIG_FIT_VERBOSE=y
+CONFIG_ENV_IS_IN_FAT=y
+CONFIG_ENV_FAT_INTERFACE="virtio"
+CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
+CONFIG_BOOTDELAY=-2
+CONFIG_USE_BOOTCOMMAND=y
+CONFIG_BOOTCOMMAND="fatload virtio 0:1 ${scriptaddr} /boot.itb; source ${scritaddr}; reset"
+# CONFIG_ENV_IS_IN_FLASH is not set
+# CONFIG_MTD is not set
+# CONFIG_MTD_NOR_FLASH is not set

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/qemuarm/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/qemuarm/boot.cmd
@@ -1,0 +1,28 @@
+# Default boot type and device
+setenv bootlimit 3
+setenv devtype virtio
+setenv devnum 0
+
+setenv bootcmd_load_f 'ext4load ${devtype} ${devnum}:2 ${ramdisk_addr_r} "/boot"${kernel_image}'
+setenv bootcmd_run 'bootm ${ramdisk_addr_r}#conf@ ${ramdisk_addr_r}#conf@ ${fdt_addr}'
+setenv bootcmd_rollbackenv 'setenv kernel_image ${kernel_image2}; setenv bootargs ${bootargs2}'
+setenv bootcmd_set_rollback 'if test ! "${rollback}" = "1"; then setenv rollback 1; setenv upgrade_available 0; saveenv; fi'
+setenv bootostree 'run bootcmd_load_f; run bootcmd_run'
+setenv altbootcmd 'run bootcmd_set_rollback; if test -n "${kernel_image2}"; then run bootcmd_rollbackenv; fi; run bootostree; reset'
+
+if test ! -e ${devtype} ${devnum}:1 uboot.env; then saveenv; fi
+
+# Reset ostree related vars (for rollback)
+setenv kernel_image
+setenv bootargs
+setenv kernel_image2
+setenv bootargs2
+
+fdt addr ${fdt_addr}
+
+ext4load ${devtype} ${devnum}:2 ${scriptaddr} /boot/loader/uEnv.txt
+env import -t ${scriptaddr} ${filesize}
+
+if test "${rollback}" = "1"; then run altbootcmd; else run bootostree; if test ! "${upgrade_available}" = "1"; then setenv upgrade_available 1; saveenv; fi; reset; fi
+
+reset

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/qemuarm/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/qemuarm/fstab
@@ -1,0 +1,8 @@
+/dev/root            /                    auto       defaults              1  1
+proc                 /proc                proc       defaults              0  0
+devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
+tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
+tmpfs                /var/volatile        tmpfs      defaults              0  0
+
+# boot partition
+/dev/vda1            /mnt/boot            vfat       noatime,sync          0  0


### PR DESCRIPTION
- Enable basic build options for qemuarm machine
- U-boot recipe is the standard u-boot-fio
- Kernel recipe is the standard linux-lmp
- Enable support for fitImage with boot.itb script support

Signed-off-by: Michael Scott <mike@foundries.io>