### PR TITLE
base: lmp-device-register: support compose app

### DIFF
--- a/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,16 +4,18 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl glib-2.0"
 
-SRCREV = "5acb69ec648ba99978d985ddda326b31823c421a"
+SRCREV = "c1c57815acc8f56231b90db204421df977cd4b5b"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https"
 
 # Default to master tag
 LMP_DEVICE_REGISTER_TAG ?= "master"
 
+APP_TYPE ?= "${@'DOCKER_COMPOSE_APP' if d.getVar('DOCKER_COMPOSE_APP') == '1' else 'DOCKER_APPS'}"
+
 PACKAGECONFIG ?= "aklitetags dockerapp"
 PACKAGECONFIG[aklitetags] = "-DAKLITE_TAGS=ON -DDEFAULT_TAG=${LMP_DEVICE_REGISTER_TAG},-DAKLITE_TAGS=OFF,"
-PACKAGECONFIG[dockerapp] = "-DDOCKER_APPS=ON,-DDOCKER_APPS=OFF,"
+PACKAGECONFIG[dockerapp] = "-D${APP_TYPE}=ON,-D${APP_TYPE}=OFF,"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
It should go with https://github.com/foundriesio/lmp-device-register/pull/17/files
I'll remove the 'branch' once the lmp-device-register is merged.

Signed-off-by: Mike Sul <mike.sul@foundries.io>