### PR TITLE
recipes-support: mfgtool-files: udpate uuu to 1.3.154 release

### DIFF
--- a/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb
+++ b/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb
@@ -8,21 +8,19 @@ inherit deploy
 INITRAMFS_IMAGE = "fsl-image-mfgtool-initramfs"
 DEPENDS = "${INITRAMFS_IMAGE}"
 
-UUU_RELEASE = "1.3.102"
+UUU_RELEASE = "1.3.154"
 
-SRC_URI = "https://github.com/foundriesio/mfgtools/releases/download/uuu_fio_${UUU_RELEASE}/uuu;name=Linux \
-    https://github.com/foundriesio/mfgtools/releases/download/uuu_fio_${UUU_RELEASE}/uuu.exe;name=Windows \
-    https://github.com/foundriesio/mfgtools/releases/download/uuu_fio_${UUU_RELEASE}/uuu-static.exe;name=Windows-static \
+SRC_URI = " \
+    https://github.com/NXPmicro/mfgtools/releases/download/uuu_${UUU_RELEASE}/uuu;name=Linux \
+    https://github.com/NXPmicro/mfgtools/releases/download/uuu_${UUU_RELEASE}/uuu.exe;name=Windows \
     file://bootloader.uuu.in \
     file://full_image.uuu.in \
 "
 
-SRC_URI[Linux.md5sum] = "49388339c48960f16d3dbb816f861496"
-SRC_URI[Linux.sha256sum] = "0d69734557b64f7eb4049dda9e2b558666352a85062e3753cc67a9694f40cc6e"
-SRC_URI[Windows.md5sum] = "c6c52b4a0d9602a7028f60181345e311"
-SRC_URI[Windows.sha256sum] = "7f4bf859eecb871b569b920ff03010673f3c88dfa64cf75cab2f680271db6c48"
-SRC_URI[Windows-static.md5sum] = "5191241f11a9ec9674e1aa27ef43ab4b"
-SRC_URI[Windows-static.sha256sum] = "7ba8ebe62c5925b01dcdfdf6eaf34c065a5328aad08cd0638c1dcc1b4ac36cee"
+SRC_URI[Linux.md5sum] = "e402adfbe3b142388fcd196ae5e0a74d"
+SRC_URI[Linux.sha256sum] = "c09616f43e096683a5c4ad12a6e5684ac15a0f745758cd98a0a73d63faf071c7"
+SRC_URI[Windows.md5sum] = "c2d7ca8e5367ce5d5ef8a54bf76449f3"
+SRC_URI[Windows.sha256sum] = "958e894920a69d3fac60e09c602d4292b32f5eda5a50c1a1fa9a235bea18da51"
 
 S = "${WORKDIR}"
 
@@ -38,7 +36,6 @@ do_deploy() {
     install -d ${DEPLOYDIR}/${PN}
     install -m 0755 ${WORKDIR}/uuu ${DEPLOYDIR}/${PN}
     install -m 0644 ${WORKDIR}/uuu.exe ${DEPLOYDIR}/${PN}
-    install -m 0644 ${WORKDIR}/uuu-static.exe ${DEPLOYDIR}/${PN}
     install -m 0644 ${WORKDIR}/bootloader.uuu ${DEPLOYDIR}/${PN}
     install -m 0644 ${WORKDIR}/full_image.uuu ${DEPLOYDIR}/${PN}
 


### PR DESCRIPTION
Related changes:
- Drop custom Foundries release in favor of upstream:
  https://github.com/NXPmicro/mfgtools
- Drop static Windows binary not supported by upstream

Signed-off-by: Michael Scott <mike@foundries.io>