### PR TITLE
initramfs-framework: drop a sota overrides

### DIFF
--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -2,9 +2,6 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += " \
 	file://ostree \
-"
-
-SRC_URI_append_sota += " \
 	file://run-tmpfs.patch \
 "
 


### PR DESCRIPTION
It does not need a extra explicit _sota overrides since other files in
SRC_URI are all sota specific any way.

Without this change, the run-tmpfs.patch would always be the last patch
in SRC_URI, which could lead to 'patch fuzz' QA warnings for the meta
layers that relying on it.

Signed-off-by: Ming Liu <ming.liu@toradex.com>