### PR TITLE
Add support for running e2fsck at the initrd

### DIFF
--- a/meta-lmp-base/recipes-core/images/initramfs-ostree-lmp-image.bb
+++ b/meta-lmp-base/recipes-core/images/initramfs-ostree-lmp-image.bb
@@ -1,6 +1,12 @@
 DESCRIPTION = "Linux microPlatform OSTree initramfs image"
 
-PACKAGE_INSTALL = "initramfs-framework-base initramfs-module-udev initramfs-module-rootfs initramfs-module-ostree ${VIRTUAL-RUNTIME_base-utils} udev base-passwd ${ROOTFS_BOOTSTRAP_INSTALL}"
+PACKAGE_INSTALL = "initramfs-framework-base \
+	initramfs-module-udev \
+	initramfs-module-rootfs \
+	initramfs-module-ostree \
+	${VIRTUAL-RUNTIME_base-utils} \
+	udev base-passwd e2fsprogs-e2fsck \
+	${ROOTFS_BOOTSTRAP_INSTALL}"
 
 SYSTEMD_DEFAULT_TARGET = "initrd.target"
 

--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework/rootfs
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework/rootfs
@@ -6,6 +6,21 @@ rootfs_enabled() {
 	return 0
 }
 
+e2fsck_check() {
+	if [ -n "`which e2fsck`" ]; then
+		fsckout=`e2fsck -p -v ${1}`
+		fsckret=$?
+		# Avoid empty newline after summary
+		echo "e2fsck: ${fsckout}" >/dev/kmsg
+		# Return code >= 4 means uncorrected / operational error
+		## TODO: force boot into a recovery mode or similar, as there is really not
+		## much we can do in case the fs is corrupted in a bad way
+		if [ "${fsckret}" -ge "4" ]; then
+			echo "e2fsck: WARNING: file system errors left uncorrected: ret ${fsckret}" >/dev/kmsg
+		fi
+	fi
+}
+
 rootfs_run() {
         if [ -z "$ROOTFS_DIR" ]; then
 		return
@@ -47,6 +62,7 @@ rootfs_run() {
 			fi
 
 			if [ -e "$bootparam_root" ]; then
+				e2fsck_check ${bootparam_root}
 				flags=""
 				if [ -n "$bootparam_ro" ] && ! echo "$bootparam_rootflags" | grep -w -q "ro"; then
 					if [  -n "$bootparam_rootflags" ]; then


### PR DESCRIPTION
This is basically 2 minor changes:
 * Add e2fsck to the initrd (increases ~0.5mb)
 * Run e2fsck before mounting the rootfs

Systemd also provides a job for running fsck on the rootfs, but e2fsck doesn't work correctly on mounted filesystems, which is why it is better and safer to just run at the initrd level instead.