### PR TITLE
base: optee-os: bump revision to 02ffaff

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os_git.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os_git.bb
@@ -9,7 +9,7 @@ DEPENDS = "python3-pycrypto-native python3-pyelftools-native"
 SRC_URI = "git://github.com/foundriesio/optee_os.git;branch=${SRCBRANCH}"
 
 PV = "3.6.0+git"
-SRCREV = "6822534262b11135ad085936fb88fb8468f45897"
+SRCREV = "02ffafff35992429cc505342a7e86f837339916f"
 SRCBRANCH = "3.6.0+fio"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
NXP SE050 HUK / UUID issue

Relevant changes:
- 02ffafff [FIO toup] libnxpse050: core: huk

Signed-off-by: Michael Scott <mike@foundries.io>