### PR TITLE
base: lmp-image-common: only increase overhead factor for QEMU targets

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -13,8 +13,13 @@ SRC_URI = "\
     file://sudoers \
 "
 
-# Enough free space for a full image update
-IMAGE_OVERHEAD_FACTOR = "2.3"
+# In most cases the rootfs will be expanded to fit available storage
+# However, for QEMU targets we need to pre-allocate enough free space
+# for a full image update
+IMAGE_OVERHEAD_FACTOR_qemuriscv64 ?= "2.3"
+IMAGE_OVERHEAD_FACTOR_qemuarm64 ?= "2.3"
+IMAGE_OVERHEAD_FACTOR_qemuarm ?= "2.3"
+IMAGE_OVERHEAD_FACTOR_intel-corei7-64 ?= "2.3"
 
 # let's make sure we have a good image..
 REQUIRED_DISTRO_FEATURES = "pam systemd"


### PR DESCRIPTION
As a part of the LmP common image changes, we run a resize-helper which
expands the rootfs to fill the available space.  This usually takes care
of needing enough space on the rootfs to download a complete OTA image.
(about double the size at a minimum)

QEMU target images are not expanded past their original size during this
process and so we increased the overhead factor for all targets to 2.3.

This has 2 downsides:
1. Subscribers have a hard time overriding this setting
2. non-QEMU target wic images are needlessly larger than they should be
   due to the resize-helper.

By selectively setting an overridable value of 2.3 for QEMU targets,
we solve both of these issues.

Signed-off-by: Michael Scott <mike@foundries.io>