### PR TITLE
base: lmp.bbclass: app images preload

### DIFF
--- a/meta-lmp-base/classes/lmp.bbclass
+++ b/meta-lmp-base/classes/lmp.bbclass
@@ -23,4 +23,19 @@ IMAGE_CMD_ota_append () {
 		${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/sota/import/installed_versions \
 			${GARAGE_TARGET_NAME}-${target_version}
 	fi
+
+	if [ "${DOCKER_COMPOSE_APP_PRELOAD}" = "1" ]; then
+		if [ -n "${APP_IMAGES_PRELOADER}" ]; then
+			bbplain "Preloading container images of the given target's apps"
+
+			mkdir -p ${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/lib/docker
+
+			${APP_IMAGES_PRELOADER} \
+				${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/sota/import/installed_versions \
+				${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/lib/docker \
+				${TARGET_ARCH}
+		else
+			bbwarn "Compose app preloading is turned on but an app preloader is not specified"
+		fi
+	fi
 }


### PR DESCRIPTION
Preload compose app images into the target rootfs (var/lib/docker) if DOCKER_COMPOSE_APP_PRELOAD is set to "1" provided that the images were dumped before during container build for the corresponding Target.

depends on https://github.com/foundriesio/ci-scripts/pull/71

Signed-off-by: Mike Sul <mike.sul@foundries.io>