### PR TITLE
Switch aklite to aktualizr 2020.7

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "master"
-SRCREV_lmp = "6cdc9779556764927f38e8fb346bc5c91204b3b1"
+SRCREV_lmp = "91c2e6a75adc7671823c2059a62f93f91465b8dd"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
! depends on meta-updater 35240e670e811d149d4765e4a6a8fceae7d642df

- switch to 2020.7+fio
    - adjust aktualizr-lite to aktualizr 2020.7
      - changes in PackageManagerInterface::fetchTarget signature
      - added symlink to clang-tidy-wrapper.sh