### PR TITLE
base: docker-ce: Untar images before running docker

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-feature-docker.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-docker.inc
@@ -5,6 +5,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     docker-credential-helper-fio \
     python3-docker \
     python3-docker-compose \
+    docker-image-preload \
 "
 
 EXTRA_USERS_PARAMS += "\

--- a/meta-lmp-base/recipes-support/docker-image-preload/docker-image-preload/docker-image-preload.service
+++ b/meta-lmp-base/recipes-support/docker-image-preload/docker-image-preload/docker-image-preload.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Docker container images preloading
+After=local-fs.target
+Before=docker.service
+ConditionPathExists=/etc/systemd/system/multi-user.target.wants/aktualizr-lite.service
+ConditionPathExists=/var/sota/import/installed_versions
+ConditionPathExistsGlob=/var/sota/import/*.tar
+
+[Service]
+Type=oneshot
+ExecStartPre=mkdir -p /var/lib/docker
+# pre-load container images into the docker data root directory (only works for overlay2 graph driver)
+ExecStart=/bin/sh -c 'for f in `find /var/sota/import -name "*.tar"`; do echo "Compose App: preloading $f" && tar -xf $f -C /var/lib/docker/ --warning=no-timestamp && rm $f; done'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=docker.service

--- a/meta-lmp-base/recipes-support/docker-image-preload/docker-image-preload_0.1.bb
+++ b/meta-lmp-base/recipes-support/docker-image-preload/docker-image-preload_0.1.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Systemd service for preloading of container images"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit allarch systemd
+
+SRC_URI = "file://docker-image-preload.service"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+SYSTEMD_SERVICE_${PN} = "docker-image-preload.service"
+SYSTEMD_AUTO_ENABLE_${PN} = "enable"
+
+do_install() {
+  install -d ${D}${systemd_system_unitdir}
+  install -m 0644 ${WORKDIR}/docker-image-preload.service ${D}${systemd_system_unitdir}
+}
+
+FILES_${PN} += "${systemd_system_unitdir}/docker-image-preload.service"


### PR DESCRIPTION

Systemd service that extracts container images from a tarball into /var/lib/docker so they become 'preloaded'
before running dockerd service.
The tarball is generated and injected into a system image/rootfs (WIC) either by lmp or [container build](https://ci.foundries.io/projects/msul-dev01/lmp/builds/306/assemble-system-image/) or by fioctl (TBD).
This should go with https://github.com/foundriesio/ci-scripts/pull/73 and https://git.foundries.io/development/cloudplatforms/infrastructure/repoz/merge_requests/15


Signed-off-by: Mike Sul <mike.sul@foundries.io>