### PR TITLE
conf: distro: lmp-mfgtool: allow factory customization

### DIFF
--- a/meta-lmp-base/conf/distro/lmp-mfgtool.conf
+++ b/meta-lmp-base/conf/distro/lmp-mfgtool.conf
@@ -28,3 +28,6 @@ REPRODUCIBLE_TIMESTAMP_ROOTFS ?= "0"
 
 # Machine specific overrides
 include conf/machine/include/lmp-mfgtool-machine-custom.inc
+
+# Factory specific overrides
+include conf/machine/include/lmp-mfgtool-factory-custom.inc


### PR DESCRIPTION
Use lmp-mfgtool-factory-custom.inc as a way of including factory
customizations to lmp-mfgtool builds.

NOTE: We have a similar file: lmp-factory-custom.inc being used
for lmp builds.

Signed-off-by: Michael Scott <mike@foundries.io>