### PR TITLE
Adding linux-lmp-lts and bumping linux-lmp to 5.8.1

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp-lts_git.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp-lts_git.bb
@@ -1,0 +1,19 @@
+LINUX_VERSION ?= "5.4.58"
+
+FIO_LMP_GIT_URL ?= "github.com"
+FIO_LMP_GIT_NAMESPACE ?= "foundriesio/"
+
+SRCREV_machine = "56d2635849c5ef58f80a62d6067b0e78ec17616f"
+SRCREV_meta = "c348b70767ef1abb7f139ae87874ffa36d6064d7"
+KBRANCH = "linux-v5.4.y"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
+
+SRC_URI = "git://${FIO_LMP_GIT_URL}/${FIO_LMP_GIT_NAMESPACE}linux.git;protocol=https;branch=${KBRANCH};name=machine; \
+    git://${FIO_LMP_GIT_URL}/${FIO_LMP_GIT_NAMESPACE}lmp-kernel-cache.git;protocol=https;type=kmeta;name=meta;branch=${KBRANCH};destsuffix=${KMETA} \
+"
+
+KMETA = "kernel-meta"
+
+require linux-lmp.inc
+include recipes-kernel/linux/linux-lmp-machine-custom.inc

--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp_git.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp_git.bb
@@ -1,13 +1,13 @@
-LINUX_VERSION ?= "5.4.58"
+LINUX_VERSION ?= "5.8.1"
 
 FIO_LMP_GIT_URL ?= "github.com"
 FIO_LMP_GIT_NAMESPACE ?= "foundriesio/"
 
-SRCREV_machine = "56d2635849c5ef58f80a62d6067b0e78ec17616f"
-SRCREV_meta = "c348b70767ef1abb7f139ae87874ffa36d6064d7"
-KBRANCH = "linux-v5.4.y"
+SRCREV_machine = "04de5f0decda01b5a372cbb732d538ea4ba838cd"
+SRCREV_meta = "a64612d40b339d72d349ea9e983e8a3834451e04"
+KBRANCH = "linux-v5.8.y"
 
-LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 SRC_URI = "git://${FIO_LMP_GIT_URL}/${FIO_LMP_GIT_NAMESPACE}linux.git;protocol=https;branch=${KBRANCH};name=machine; \
     git://${FIO_LMP_GIT_URL}/${FIO_LMP_GIT_NAMESPACE}lmp-kernel-cache.git;protocol=https;type=kmeta;name=meta;branch=${KBRANCH};destsuffix=${KMETA} \

--- a/meta-lmp-base/recipes-kernel/wireguard/wireguard-module_1.0.20200712.bb
+++ b/meta-lmp-base/recipes-kernel/wireguard/wireguard-module_1.0.20200712.bb
@@ -28,6 +28,14 @@ MODULE_NAME = "wireguard"
 # with kernel-module-.
 PKG_${PN} = "kernel-module-${MODULE_NAME}"
 
+# Only set default rprovides if kernel is different than linux-lmp, assuming
+# it is older than 5.6 (version in which the module is provided by the kernel)
+python __anonymous() {
+    pn = d.getVar("PN")
+    if d.getVar("PREFERRED_PROVIDER_virtual/kernel") != "linux-lmp":
+        d.appendVar("RPROVIDES_" + pn, "kernel-module-wireguard")
+}
+
 module_do_install() {
     install -d ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/kernel/${MODULE_NAME}
     install -m 0644 ${MODULE_NAME}.ko \

--- a/meta-lmp-base/recipes-kernel/wireguard/wireguard-tools_1.0.20200513.bb
+++ b/meta-lmp-base/recipes-kernel/wireguard/wireguard-tools_1.0.20200513.bb
@@ -5,7 +5,7 @@ SRC_URI = "git://git.zx2c4.com/wireguard-tools"
 
 inherit bash-completion systemd pkgconfig
 
-DEPENDS += "wireguard-module libmnl"
+DEPENDS += "libmnl"
 
 do_install () {
     oe_runmake DESTDIR="${D}" PREFIX="${prefix}" SYSCONFDIR="${sysconfdir}" \
@@ -22,4 +22,4 @@ FILES_${PN} = " \
     ${bindir} \
 "
 
-RDEPENDS_${PN} = "bash"
+RDEPENDS_${PN} = "bash kernel-module-wireguard"


### PR DESCRIPTION
Tested 5.8.1 kernel on qemuarm64, intel-corei7-64, beaglebone-yocto, qemuriscv64, freedom-u540, qemuarm and apalis-imx6.

Kernel meta was also updated with the latest config related changes.