### PR TITLE
Adding initial u-boot-fio/u-boot-fio-imx recipes based on 2020.04

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
@@ -1,0 +1,26 @@
+HOMEPAGE = "http://www.denx.de/wiki/U-Boot/WebHome"
+DESCRIPTION = "U-Boot, a boot loader for Embedded boards based on PowerPC, \
+ARM, MIPS and several other processors, which can be installed in a boot \
+ROM and used to initialize and test the hardware or to download and run \
+application code."
+SECTION = "bootloaders"
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
+DEPENDS += "flex-native bison-native bc-native dtc-native"
+
+SRC_URI = "git://github.com/foundriesio/u-boot.git;branch=${SRCBRANCH} \
+    file://fw_env.config \
+    file://lmp.cfg \
+"
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
+do_configure[cleandirs] = "${B}"
+
+require recipes-bsp/u-boot/u-boot.inc
+
+# Support additional u-boot classes such as u-boot-fitimage
+UBOOT_CLASSES ?= ""
+inherit ${UBOOT_CLASSES}
+
+PROVIDES += "u-boot"

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-imx_2020.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-imx_2020.04.bb
@@ -1,0 +1,7 @@
+# Share fw_env and lmp.cfg with u-boot-fio
+FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot-fio:"
+
+require u-boot-fio-common.inc
+
+SRCREV = "4979a99482f7e04a3c1f4fb55e3182395ee8f710"
+SRCBRANCH = "2020.04+fio-imx"

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-mfgtool.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-mfgtool.bb
@@ -2,7 +2,7 @@ SUMMARY = "Produces a Manufacturing Tool compatible U-Boot"
 DESCRIPTION = "U-Boot recipe that produces a Manufacturing Tool compatible \
 binary to be used in updater environment"
 
-require recipes-bsp/u-boot/u-boot-fio_git.bb
+require recipes-bsp/u-boot/u-boot-fio_2019.10.bb
 
 # Environment config is not required for mfgtool
 SRC_URI_remove = "file://fw_env.config"

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2019.10.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2019.10.bb
@@ -16,8 +16,6 @@ SRC_URI = "git://github.com/foundriesio/u-boot.git;branch=${SRCBRANCH} \
     file://lmp.cfg \
 "
 
-PV = "v2019.10+git${SRCPV}"
-
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
 do_configure[cleandirs] = "${B}"

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2019.10.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2019.10.bb
@@ -1,29 +1,4 @@
-HOMEPAGE = "http://www.denx.de/wiki/U-Boot/WebHome"
-DESCRIPTION = "U-Boot, a boot loader for Embedded boards based on PowerPC, \
-ARM, MIPS and several other processors, which can be installed in a boot \
-ROM and used to initialize and test the hardware or to download and run \
-application code."
-SECTION = "bootloaders"
-LICENSE = "GPLv2+"
-LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
-DEPENDS += "flex-native bison-native bc-native dtc-native"
+require u-boot-fio-common.inc
 
 SRCREV = "954fb028d9afc04cfb4e50d0755fe21a6f3cd417"
 SRCBRANCH = "2019.10+fio"
-
-SRC_URI = "git://github.com/foundriesio/u-boot.git;branch=${SRCBRANCH} \
-    file://fw_env.config \
-    file://lmp.cfg \
-"
-
-S = "${WORKDIR}/git"
-B = "${WORKDIR}/build"
-do_configure[cleandirs] = "${B}"
-
-require recipes-bsp/u-boot/u-boot.inc
-
-# Support additional u-boot classes such as u-boot-fitimage
-UBOOT_CLASSES ?= ""
-inherit ${UBOOT_CLASSES}
-
-PROVIDES += "u-boot"

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2020.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2020.04.bb
@@ -1,0 +1,6 @@
+require u-boot-fio-common.inc
+
+SRCREV = "36fec02b1f90b92cf51ec531564f9284eae27ab4"
+SRCBRANCH = "2020.04+fio"
+
+DEFAULT_PREFERENCE = "-1"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio-imx_%.bbappend
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio-imx_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot-fio:"


### PR DESCRIPTION
Not enabled by default yet, but recipes useful for early development.