### PR TITLE
base: aktualizr-lite: bump to edc0f77

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "master"
-SRCREV_lmp = "56f83579d26aa8fd89e7d85c64015fc005550bc7"
+SRCREV_lmp = "edc0f775f441aa939408b00cecc614dad870e66e"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
Relevant changes:
- switch to 2020.8+fio
- Fix sorting of the "list" subcommand
- compose-apps: Keep trying to update apps

Signed-off-by: Mike Sul <mike.sul@foundries.io>