### PR TITLE
bsp: u-boot-ostree-src: remove unused imx6ullevk settings

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/imx6ullevk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/imx6ullevk/boot.cmd
@@ -1,3 +1,0 @@
-fatload mmc 1:1 ${loadaddr} /uEnv.txt
-env import -t ${loadaddr} ${filesize}
-run bootcmd

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/imx6ullevk/uEnv.txt.in
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/imx6ullevk/uEnv.txt.in
@@ -1,7 +1,0 @@
-devtype=mmc
-devnum=1
-fit_addr=0x84000000
-bootcmd_otenv=load ${devtype} ${devnum}:2 ${loadaddr} /boot/loader/uEnv.txt; env import -t ${loadaddr} ${filesize}
-bootcmd_load_f=load ${devtype} ${devnum}:2 ${fit_addr} "/boot"${kernel_image}
-bootcmd_run=bootm ${fit_addr}#conf@${fdt_file}
-bootcmd=run bootcmd_otenv; run bootcmd_load_f; run bootcmd_run


### PR DESCRIPTION
imx6ullevk now uses the u-boot-ostree-scr-fit recipe

Signed-off-by: Michael Scott <mike@foundries.io>