### PR TITLE
base: aktualizr-lite: bump to 34f8f70

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "master"
-SRCREV_lmp = "edc0f775f441aa939408b00cecc614dad870e66e"
+SRCREV_lmp = "34f8f70f5880d48487fcfb42fe2dc96abb08310a"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
Relevant changes:
- docker-apps: Turn off the docker app pack manager

Signed-off-by: Mike Sul <mike.sul@foundries.io>