### PR TITLE
base: classes: kernel-fit-image: fix DTB iteration variable

### DIFF
--- a/meta-lmp-base/classes/kernel-lmp-fitimage.bbclass
+++ b/meta-lmp-base/classes/kernel-lmp-fitimage.bbclass
@@ -317,15 +317,15 @@ fitimage_assemble() {
 	fitimage_emit_section_maint ${1} confstart
 
 	if [ -n "${DTBS}" ]; then
-		i=1
+		n=1
 		for DTB in ${DTBS}; do
 			dtb_ext=${DTB##*.}
 			if [ "${dtb_ext}" = "dtbo" ]; then
-				fitimage_emit_section_config ${1} "" "${DTB}" "" "" "" "${FIT_LOADABLES}" "`expr ${i} = ${dtbcount}`"
+				fitimage_emit_section_config ${1} "" "${DTB}" "" "" "" "${FIT_LOADABLES}" "`expr ${n} = ${dtbcount}`"
 			else
-				fitimage_emit_section_config ${1} "${kernelcount}" "${DTB}" "${ramdiskcount}" "${setupcount}" "${fpgacount}" "${FIT_LOADABLES}" "`expr ${i} = ${dtbcount}`"
+				fitimage_emit_section_config ${1} "${kernelcount}" "${DTB}" "${ramdiskcount}" "${setupcount}" "${fpgacount}" "${FIT_LOADABLES}" "`expr ${n} = ${dtbcount}`"
 			fi
-			i=`expr ${i} + 1`
+			n=`expr ${n} + 1`
 		done
 	else
 		fitimage_emit_section_config ${1} "${kernelcount}" "" "${ramdiskcount}" "${setupcount}" "${fpgacount}" "${FIT_LOADABLES}" ""


### PR DESCRIPTION
When we use variable "i" to count iteratation through DTBS in
fitimage_assemble.  However, during each loop, we also call
fitimage_emit_section_config which also uses a variable "i" to
count loops when processing LOADABLES.  This causes the value
of "i" in the fitimage_assemble loop to seemingly stay the same
or randomly change in odd ways.

Let's fix the fitimage_assemble iteration count by renaming the
variable to "n" which is not used elsewhere.

Signed-off-by: Michael Scott <mike@foundries.io>