### PR TITLE
recipes-support: mfgtool-files: allow full_image flash filename override

### DIFF
--- a/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files/full_image.uuu.in
+++ b/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files/full_image.uuu.in
@@ -22,7 +22,7 @@ uuu_version 1.0.1
 
 # Rootfs
 #FBK: acmd mmc=`cat /tmp/mmcdev`; gunzip -c | dd of=/dev/mmcblk${mmc} bs=4M iflag=fullblock oflag=direct status=progress
-#FBK: ucp  ../lmp-gateway-image-@@MACHINE@@.wic.gz t:-
+#FBK: ucp  ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz t:-
 #FBK: Sync
 
 #FBK: DONE

--- a/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb
+++ b/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb
@@ -9,6 +9,7 @@ INITRAMFS_IMAGE = "fsl-image-mfgtool-initramfs"
 DEPENDS = "${INITRAMFS_IMAGE}"
 
 UUU_RELEASE = "1.3.154"
+MFGTOOL_FLASH_IMAGE ?= "lmp-base-console-image"
 
 SRC_URI = " \
     https://github.com/NXPmicro/mfgtools/releases/download/uuu_${UUU_RELEASE}/uuu;name=Linux \
@@ -28,7 +29,9 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 do_compile() {
     sed -e 's/@@MACHINE@@/${MACHINE}/' ${S}/bootloader.uuu.in > bootloader.uuu
-    sed -e 's/@@MACHINE@@/${MACHINE}/' ${S}/full_image.uuu.in > full_image.uuu
+    sed -e 's/@@MACHINE@@/${MACHINE}/' \
+        -e 's/@@MFGTOOL_FLASH_IMAGE@@/${MFGTOOL_FLASH_IMAGE}/' \
+        ${S}/full_image.uuu.in > full_image.uuu
 }
 
 # Board specific SPL/U-Boot should be deployed via bbappend

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6/full_image.uuu.in
@@ -16,7 +16,7 @@ SDPV: jump -addr 0x12000000
 FB: ucmd if mmc dev 0; then setenv flash_dev 0; setenv emmc_partconf "mmc partconf ${flash_dev} 1 1 0"; else setenv flash_dev 1; setenv emmc_partconf "true"; fi;
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd mmc dev ${flash_dev}
-FB: flash -raw2sparse all ../lmp-factory-image-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
 FB: flash bootloader ../SPL
 FB: flash bootloader2 ../u-boot.itb
 FB: ucmd if env exist emmc_partconf; then run emmc_partconf; fi;

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx8/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx8/full_image.uuu.in
@@ -10,7 +10,7 @@ CFG: FB: -vid 0x0525 -pid 0x4031
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd setenv mmcdev 0
 FB: ucmd mmc dev 0
-FB: flash -raw2sparse all ../lmp-factory-image-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
 FB: flash bootloader ../imx-boot
 FB: ucmd mmc partconf 0 0 1 0
 FB: done

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx6ullevk/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx6ullevk/full_image.uuu.in
@@ -8,7 +8,7 @@ SDP: jump -f SPL-mfgtool -ivt
 FB: ucmd if mmc dev 0; then setenv flash_dev 0; setenv emmc_partconf "mmc partconf ${flash_dev} ${emmc_ack} 1 0"; else setenv flash_dev 1; setenv emmc_partconf "true"; fi;
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd mmc dev ${flash_dev}
-FB: flash -raw2sparse all ../lmp-factory-image-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
 FB: flash bootloader ../SPL
 FB: flash bootloader2 ../u-boot.itb
 FB: ucmd if env exist emmc_partconf; then run emmc_partconf; fi;

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx7ulpea-ucom/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx7ulpea-ucom/full_image.uuu.in
@@ -43,7 +43,7 @@ FBK: ucmd mmc=`cat /tmp/mmcdev`; mmc bootpart enable 1 1 /dev/mmcblk${mmc}
 
 # rootfs
 FBK: acmd mmc=`cat /tmp/mmcdev`; gunzip -c | dd of=/dev/mmcblk${mmc} bs=4M iflag=fullblock oflag=direct status=progress
-FBK: ucp  ../lmp-factory-image-@@MACHINE@@.wic.gz t:-
+FBK: ucp  ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz t:-
 FBK: Sync
 
 FBK: DONE

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mmevk/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mmevk/full_image.uuu.in
@@ -17,7 +17,7 @@ SDPV: jump
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd setenv mmcdev ${emmc_dev}
 FB: ucmd mmc dev ${emmc_dev}
-FB: flash -raw2sparse all ../lmp-factory-image-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
 FB: flash bootloader ../imx-boot
 FB: ucmd if env exists emmc_ack; then ; else setenv emmc_ack 0; fi;
 FB: ucmd mmc partconf ${emmc_dev} ${emmc_ack} 1 0

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mqevk/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mqevk/full_image.uuu.in
@@ -16,7 +16,7 @@ SDPV: jump
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd setenv mmcdev ${emmc_dev}
 FB: ucmd mmc dev ${mmcdev}
-FB: flash -raw2sparse all ../lmp-factory-image-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
 FB: flash bootloader ../imx-boot
 FB: ucmd if env exists emmc_ack; then ; else setenv emmc_ack 0; fi;
 FB: ucmd mmc partconf ${mmcdev} ${emmc_ack} 1 0


### PR DESCRIPTION
Let's add an OE var: MFGTOOL_FLASH_IMAGE to be used by the flash scripts for
building the .wic filename.

Default to: lmp-base-console-image

Signed-off-by: Michael Scott <mike@foundries.io>