### PR TITLE
docker-credential-helper: Support variable server names

### DIFF
--- a/meta-lmp-base/recipes-support/docker-credential-helper-fio/files/docker-credential-fio-helper
+++ b/meta-lmp-base/recipes-support/docker-credential-helper-fio/files/docker-credential-fio-helper
@@ -2,9 +2,22 @@
 
 # Use stderr for logging err output in libaktualizr
 export LOG_STDERR=1
+SOTA_DIR="${SOTA_DIR-/var/sota}"
 
 LOGLEVEL="${CREDS_LOGLEVEL-4}"
 
 if [ "$1" = "get" ] ; then
-	exec /usr/bin/aktualizr-get --loglevel $LOGLEVEL -u https://ota-lite.foundries.io:8443/hub-creds/
+	if [ $(id -u) != "0" ] ; then
+		echo "ERROR: $0 must be run as root to access $SOTA_DIR"
+		exit 1
+	fi
+	if [ ! -f ${SOTA_DIR}/sota.toml ] ; then
+		echo "ERROR: Device does not appear to be registered under $SOTA_DIR"
+		exit 1
+	fi
+	server=$(grep -m1 ^server ${SOTA_DIR}/sota.toml | cut -d\" -f2)
+	if [ -z $server ] ; then
+		server="https://ota-lite.foundries.io:8443"
+	fi
+	exec /usr/bin/aktualizr-get --loglevel $LOGLEVEL -u ${server}/hub-creds/
 fi


### PR DESCRIPTION
This allows the script to use the configured tls.server to grab
credentials from. This will become important when customers have their
own device gateway urls.

Signed-off-by: Andy Doan <andy@foundries.io>