### PR TITLE
Add lmp-device-auto-register helper

### DIFF
--- a/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register.bb
+++ b/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register.bb
@@ -1,0 +1,24 @@
+SUMMARY = "A systemd oneshot helper to auto register a device"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+RDEPENDS_lmp-device-auto-register = "lmp-device-register"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI = " \
+	file://lmp-device-auto-register.service \
+	file://lmp-device-auto-register \
+	file://api-token \
+"
+
+inherit systemd
+
+SYSTEMD_SERVICE_${PN} = "lmp-device-auto-register.service"
+
+do_install() {
+	install -d ${D}${systemd_system_unitdir}
+	install -m 0644 ${WORKDIR}/lmp-device-auto-register.service ${D}${systemd_system_unitdir}/
+	install -d ${D}${bindir}
+	install -m 0755 ${WORKDIR}/lmp-device-auto-register ${D}${bindir}/
+	install -d ${D}${sysconfdir}
+	install -m 0755 ${WORKDIR}/api-token ${D}${sysconfdir}/lmp-device-register-token
+}

--- a/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register/lmp-device-auto-register
+++ b/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register/lmp-device-auto-register
@@ -1,0 +1,32 @@
+#!/bin/sh -e
+
+TOKEN_FILE=${TOKEN_FILE-/etc/lmp-device-register-token}
+
+if [ ! -f $TOKEN_FILE ] ; then
+	echo "ERROR: Missing token file $TOKEN_FILE"
+	exit 1
+fi
+
+TOKEN=$(cat $TOKEN_FILE)
+if [ -z $TOKEN ] ; then
+	echo "ERROR: $TOKEN_FILE is empty"
+	exit 1
+fi
+
+if [ -f /var/sota/sql.db ] ; then
+	echo "ERROR: Device appears to already be registered."
+	exit 1
+fi
+
+# Done in 2 parts. This first part will remove trailing \n's and make
+# the output all space separated. The 2nd part makes it comma separated.
+[ -d /var/sota/compose-apps ] && APPS=$(ls /var/sota/compose-apps)
+APPS=$(echo $APPS | tr ' ' ',')
+if [ -n "$APPS" ] ; then
+	echo "Registering with default apps = $APPS"
+	APPS="-a $APPS"
+else
+	echo "Registering with no apps"
+fi
+
+lmp-device-register -T $(cat $TOKEN_FILE) $APPS

--- a/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register/lmp-device-auto-register.service
+++ b/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register/lmp-device-auto-register.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Script to auto-register device into Factory
+Wants=network-online.target time-sync.target systemd-time-wait-sync.service
+After=network-online.target time-sync.target systemd-time-wait-sync.service
+ConditionPathExists=!/var/sota/sql.db
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/bin/lmp-device-auto-register
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This creates a systemd one shot job that will automatically register
a device on first boot (and internet connectivity) when an api-token
file is present with a token from:

 https://app.foundries.io/settings/tokens/

that has the "devices:create" scope.

Signed-off-by: Andy Doan <andy@foundries.io>