### PR TITLE
base: preload: remove useless 'arch' param

### DIFF
--- a/meta-lmp-base/classes/lmp.bbclass
+++ b/meta-lmp-base/classes/lmp.bbclass
@@ -32,8 +32,7 @@ IMAGE_CMD_ota_append () {
 
 			${APP_IMAGES_PRELOADER} \
 				${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/sota/import/installed_versions \
-				${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/lib/docker \
-				${TARGET_ARCH}
+				${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/lib/docker
 		else
 			bbwarn "Compose app preloading is turned on but an app preloader is not specified"
 		fi


### PR DESCRIPTION
Just a really tiny cleanup.
Corresponding changes to ci-scripts has been made https://github.com/foundriesio/ci-scripts/commit/7b7c8fcfc464acd4485f0da5c4de5101bce7a667

Signed-off-by: Mike Sul <mike.sul@foundries.io>