### PR TITLE
u-boot-fitImage: pass the machine name in the SPL fit

### DIFF
--- a/meta-lmp-base/classes/uboot-fitimage.bbclass
+++ b/meta-lmp-base/classes/uboot-fitimage.bbclass
@@ -129,7 +129,7 @@ EOF
 	configurations {
 		default = "config-1";
 		config-1 {
-			description = "OP-TEE with U-Boot in normal world";
+			description = "OP-TEE with U-Boot in normal world for ${MACHINE}";
 			firmware = "${config_firmware}";
 			loadables = ${config_loadables};
 			fdt = "ubootfdt";


### PR DESCRIPTION
SPL will then be able to string match properly during
board_fit_config_name_match (CONFIG_SPL_LOAD_FIT)

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>