### PR TITLE
WIP: base: docker: turn on 'live restore' feature

### DIFF
--- a/meta-lmp-base/recipes-containers/docker/files/daemon.json.in
+++ b/meta-lmp-base/recipes-containers/docker/files/daemon.json.in
@@ -1,5 +1,6 @@
 {
   "log-driver": "journald",
   "max-concurrent-downloads": @@MAX_CONCURRENT_DOWNLOADS@@,
-  "max-download-attempts": @@MAX_DOWNLOAD_ATTEMPTS@@
+  "max-download-attempts": @@MAX_DOWNLOAD_ATTEMPTS@@,
+  "live-restore": true
 }


### PR DESCRIPTION
The 'live restore' feature makes a docker daemon not to stop running
containers during its shutdown or restart. The given feature can be
useful for an ostree based image update, i.e. after an image update is
checked out, a docker daemon restart is required, to make it 'see' the
updated images and we don't want to stop/restart running containers,
images of which haven't been updated.

Signed-off-by: Mike Sul <mike.sul@foundries.io>