### PR TITLE
base: fioconfig: Add environment file to configure interval

### DIFF
--- a/meta-lmp-base/recipes-support/fioconfig/fioconfig/fioconfig.service
+++ b/meta-lmp-base/recipes-support/fioconfig/fioconfig/fioconfig.service
@@ -4,6 +4,7 @@ After=network.target
 ConditionPathExists=/var/sota/sota.toml
 
 [Service]
+EnvironmentFile=-/etc/default/fioconfig
 RestartSec=10
 Restart=always
 ExecStartPre=mkdir -p /var/run/secrets


### PR DESCRIPTION
fioconfig runs in a default interval of 300 seconds. This change will allow interval modifications by changing the environment file.