### PR TITLE
lmp-device-register: Bump version

### DIFF
--- a/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl glib-2.0"
 
-SRCREV = "b59e76abb303fbaf85d1621426c5523536e21d20"
+SRCREV = "b0c700e9a9c55dec6da1514004df14214770fb09"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https"
 


### PR DESCRIPTION
New version allows DEVICE_API to be overridden via an environment
variable.

Signed-off-by: Andy Doan <andy@foundries.io>