### PR TITLE
base: aktualizr-lite: bump to 0d050b4

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "master"
-SRCREV_lmp = "3c2aa5b493d83e4f82b2a4ea11ea21ab223d2e57"
+SRCREV_lmp = "0d050b4641e1ef1b01e26b0d8b9da31bf14f7927"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
Relevant changes:
 - 60d05a2 Wait for the 'interval' if metadata update fails
 - ba44d20 Use `bare` mode instead of `bare-user` for apps
 - 67a3b91 Use a composite ref/uri to ostree commit
 - 0b57972 Handle non-regular files for ostree
 - b1ded7c Use ostree-based Compose Apps
 - 20b549d Introduce basic an ostree repo management funct

Signed-off-by: Mike Sul <mike.sul@foundries.io>