### PR TITLE
bsp: linux-lmp-fslc-imx: patch fix for QCA9377 SDIO hw params

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-FIO-fromtree-ath10k-add-QCA9377-sdio-hw_param-item.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-FIO-fromtree-ath10k-add-QCA9377-sdio-hw_param-item.patch
@@ -1,0 +1,69 @@
+From 4c3cd433d2250ac13768c5c4e95e5bd5948973a7 Mon Sep 17 00:00:00 2001
+From: Erik Stromdahl <erik.stromdahl@gmail.com>
+Date: Thu, 26 Sep 2019 17:24:27 +0300
+Subject: [PATCH] [FIO fromtree] ath10k: add QCA9377 sdio hw_param item
+
+Add hardware parameters for QCA9377 sdio devices, it's now properly supported.
+
+Signed-off-by: Erik Stromdahl <erik.stromdahl@gmail.com>
+Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
+---
+ drivers/net/wireless/ath/ath10k/core.c | 27 ++++++++++++++++++++++++++
+ drivers/net/wireless/ath/ath10k/hw.h   |  3 +++
+ 2 files changed, 30 insertions(+)
+
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index 383d4fa555a88..b2e099af3c8a2 100644
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -538,6 +538,33 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 		.fw_diag_ce_download = true,
+ 		.tx_stats_over_pktlog = false,
+ 	},
++	{
++		.id = QCA9377_HW_1_1_DEV_VERSION,
++		.dev_id = QCA9377_1_0_DEVICE_ID,
++		.bus = ATH10K_BUS_SDIO,
++		.name = "qca9377 hw1.1 sdio",
++		.patch_load_addr = QCA9377_HW_1_0_PATCH_LOAD_ADDR,
++		.uart_pin = 19,
++		.otp_exe_param = 0,
++		.channel_counters_freq_hz = 88000,
++		.max_probe_resp_desc_thres = 0,
++		.cal_data_len = 8124,
++		.fw = {
++			.dir = QCA9377_HW_1_0_FW_DIR,
++			.board = QCA9377_HW_1_0_BOARD_DATA_FILE,
++			.board_size = QCA9377_BOARD_DATA_SZ,
++			.board_ext_size = QCA9377_BOARD_EXT_DATA_SZ,
++		},
++		.hw_ops = &qca6174_ops,
++		.hw_clk = qca6174_clk,
++		.target_cpu_freq = 176000000,
++		.decap_align_bytes = 4,
++		.n_cipher_suites = 8,
++		.num_peers = TARGET_QCA9377_HL_NUM_PEERS,
++		.ast_skid_limit = 0x10,
++		.num_wds_entries = 0x20,
++		.uart_pin_workaround = true,
++	},
+ 	{
+ 		.id = QCA4019_HW_1_0_DEV_VERSION,
+ 		.dev_id = 0,
+diff --git a/drivers/net/wireless/ath/ath10k/hw.h b/drivers/net/wireless/ath/ath10k/hw.h
+index 2ae57c1de7b55..ddb1d23ec6de0 100644
+--- a/drivers/net/wireless/ath/ath10k/hw.h
++++ b/drivers/net/wireless/ath/ath10k/hw.h
+@@ -768,6 +768,9 @@ ath10k_is_rssi_enable(struct ath10k_hw_params *hw,
+ #define TARGET_HL_TLV_AST_SKID_LIMIT		16
+ #define TARGET_HL_TLV_NUM_WDS_ENTRIES		2
+ 
++/* Target specific defines for QCA9377 high latency firmware */
++#define TARGET_QCA9377_HL_NUM_PEERS		15
++
+ /* Diagnostic Window */
+ #define CE_DIAG_PIPE	7
+ 
+-- 
+2.30.1
+

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_git.bb
@@ -17,6 +17,7 @@ SRC_URI = "git://github.com/Freescale/linux-fslc.git;protocol=https;branch=${KBR
     file://0001-FIO-fromtree-tee-add-support-for-session-s-client-UU.patch \
     file://0002-FIO-fromtree-tee-optee-Add-support-for-session-login.patch \
     file://0001-driver-tee-Handle-NULL-pointer-indication-from-clien.patch \
+    file://0001-FIO-fromtree-ath10k-add-QCA9377-sdio-hw_param-item.patch \
 "
 
 KMETA = "kernel-meta"


### PR DESCRIPTION
This patch from mainline adds support for the QCA9377 chip via
ath10k sdio driver.

This chip is present on i.MX8MM EVK.

Signed-off-by: Michael Scott <mike@foundries.io>