### PR TITLE
optee: switch to 3.12 version

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.12.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.12.0.bb
@@ -1,7 +1,7 @@
 require optee-os-fio.inc
 
 PV = "3.12.0+git"
-SRCREV = "05517fbc0d732ea9a50d14569b1711b058e2d818"
+SRCREV = "dfcce199d6b9e5acf61d409bb1828d2034b4bae7"
 SRCBRANCH = "3.12+fio"
 
 DEFAULT_PREFERENCE = "-1"

--- a/meta-lmp-bsp/recipes-security/optee/optee-os-fio-mfgtool_3.12.0.bbappend
+++ b/meta-lmp-bsp/recipes-security/optee/optee-os-fio-mfgtool_3.12.0.bbappend
@@ -1,15 +1,11 @@
 OPTEEMACHINE_apalis-imx6 = "imx-mx6qapalis"
-OPTEEMACHINE_qemuarm64 = "vexpress-qemu_armv8a"
 OPTEEMACHINE_imx6ullevk = "imx-mx6ullevk"
 OPTEEMACHINE_imx8mqevk = "imx-mx8mqevk"
 OPTEEMACHINE_imx8mmevk = "imx-mx8mmevk"
-OPTEEMACHINE_uz = "zynqmp-zcu102"
 
-EXTRA_OEMAKE_append_qemuarm64 = " \
-    CFG_RPMB_FS=y CFG_RPMB_WRITE_KEY=y \
-"
 EXTRA_OEMAKE_append_imx = " \
     CFG_CAAM_DBG=0x001 \
+    CFG_NXP_WORKAROUND_CAAM_LOCKED_BY_HAB=y \
 "
 EXTRA_OEMAKE_append_apalis-imx6 = " \
     CFG_NXP_CAAM=y CFG_IMX_CAAM=n \
@@ -29,9 +25,4 @@ EXTRA_OEMAKE_append_imx8mqevk = " \
 EXTRA_OEMAKE_append_imx8mmevk = " \
     CFG_NXP_CAAM=y CFG_RNG_PTA=y \
     CFG_DT=y CFG_EXTERNAL_DTB_OVERLAY=y CFG_DT_ADDR=0x43200000 \
-"
-EXTRA_OEMAKE_append_uz = " \
-    CFG_TZDRAM_START=0x7e000000 CFG_TZDRAM_SIZE=0x1c00000 \
-    CFG_SHMEM_START=0x7fc00000 CFG_SHMEM_SIZE=0x400000 \
-    CFG_DT=y CFG_EXTERNAL_DTB_OVERLAY=y CFG_DT_ADDR=0x22000000 \
 "


### PR DESCRIPTION
```
Switch optee-os-fio/optee-client/optee-test to 3.12 version.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>
```