### PR TITLE
Bump u-boot 2020.04 and optee-os 3.6 SHAs

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2020.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2020.04.bb
@@ -1,4 +1,4 @@
 require u-boot-fio-common.inc
 
-SRCREV = "afd2cfe434cfbc3851512dcd066a52ab652fa798"
+SRCREV = "f5ef084e7cbc4f123124f94cafc3982a2857a90c"
 SRCBRANCH = "2020.04+fio"

--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.6.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.6.0.bb
@@ -7,7 +7,7 @@ SRC_URI += " \
 "
 
 PV = "3.6.0+git"
-SRCREV = "b899c86098b4b7318d7cdebea5cb19f6e095b41d"
+SRCREV = "c67d7defe31a71d96dfd082e7987ecdbf7d3638d"
 SRCBRANCH = "3.6.0+fio"
 
 ALLOW_EMPTY_${PN}-ta-pkcs11 = "1"


### PR DESCRIPTION
- base: u-boot-fio: 2020.04: bump to f5ef084e7cb
- base: optee-os-fio: 3.6: bump to c67d7defe31