### PR TITLE
bsp: u-boot-fio: imx8mmevk: lmp.cfg: disable SPL_DM_MMC and SPL_BLK

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/imx8mmevk/lmp.cfg
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/imx8mmevk/lmp.cfg
@@ -46,6 +46,8 @@ CONFIG_BOOTCOUNT_ENV=y
 CONFIG_BOOTDELAY=-2
 CONFIG_USE_BOOTCOMMAND=y
 CONFIG_BOOTCOMMAND="fatload mmc 2:1 ${loadaddr} /boot.itb; setenv verify 1; source ${loadaddr}; reset"
+# CONFIG_SPL_DM_MMC is not set
+# CONFIG_SPL_BLK is not set
 # CONFIG_ANDROID_BOOT_IMAGE is not set
 # CONFIG_CMD_NFS is not set
 # CONFIG_CMD_SYSBOOT is not set


### PR DESCRIPTION
Disable SPL_DM_MMC and SPL_BLK, that fixes SD boot issues.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>