### PR TITLE
base: u-boot-fio: 2020.04: bump to dbb9acc4eb

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2020.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2020.04.bb
@@ -1,4 +1,4 @@
 require u-boot-fio-common.inc
 
-SRCREV = "c8e17fe08747e680d0ef5b550adcee831a26c42a"
+SRCREV = "dbb9acc4ebd2f646832caf0de05bbc011724a942"
 SRCBRANCH = "2020.04+fio"


### PR DESCRIPTION
Relevant changes:
- dbb9acc4eb [FIO internal] ARM: imx8mq: add define for PERSIST_SECONDARY_BOOT bit

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>