### PR TITLE
bsp: recipes-kernel: wireguard: add option to opt-out of ext module

### DIFF
--- a/meta-lmp-base/recipes-kernel/wireguard/wireguard-module_%.bbappend
+++ b/meta-lmp-base/recipes-kernel/wireguard/wireguard-module_%.bbappend
@@ -3,6 +3,6 @@
 python __anonymous() {
     pn = d.getVar("PN")
     pprovider = d.getVar("PREFERRED_PROVIDER_virtual/kernel")
-    if pprovider != "linux-lmp" and pprovider != "linux-lmp-rt":
+    if pprovider != "linux-lmp" and pprovider != "linux-lmp-rt" and d.getVar("KERNEL_BUILTIN_WIREGUARD") != "1":
         d.appendVar("RPROVIDES_" + pn, "kernel-module-wireguard")
 }


### PR DESCRIPTION
Currently, only linux-lmp and linux-lmp-rt (both 5.10.y atm) opt out of
building the external wireguard module which applies to kernels < 5.6.y.

Let's provide a way for edge case kernels to also opt-out of the module:
KERNEL_BUILTIN_WIREGUARD = "1"

Signed-off-by: Michael Scott <mike@foundries.io>