### PR TITLE
add TI am64xx sk support (v2)

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.4.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.4.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.4.y"
-KERNEL_META_COMMIT ?= "58c846dfd52b7dd33aebb7cae7055c151ace963c"
+KERNEL_META_COMMIT ?= "71b6bbf223ba510a6c24c62418dfbcc939deb1d6"

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -353,6 +353,19 @@ LMP_FLASHLAYOUT_stm32mp1-eval = "FlashLayout_emmc_stm32mp157a-ev1-trusted.tsv"
 # Xilinx
 USE_XSCT_TARBALL_zynqmp = "1"
 
+# TI AM64x
+PREFERRED_PROVIDER_virtual/kernel_am64xx-sk ?= "linux-lmp-ti-staging"
+PREFERRED_PROVIDER_u-boot-fw-utils_am64xx-sk = "libubootenv"
+PREFERRED_RPROVIDER_u-boot-fw-utils_am64xx-sk = "libubootenv"
+# only need boot script for sota builds
+WKS_FILE_DEPENDS_append_sota_am64xx-sk = " u-boot-default-script"
+PREFERRED_PROVIDER_u-boot-default-script_sota_am64xx-sk = "u-boot-ostree-scr"
+KERNEL_IMAGETYPE_sota_am64xx-sk = "fitImage"
+KERNEL_CLASSES_sota_am64xx-sk = " kernel-lmp-fitimage "
+IMAGE_BOOT_FILES_am64xx-sk = "tiboot3.bin tispl.bin u-boot.img boot.scr uEnv.txt"
+UBOOT_ENTRYPOINT_am64xx-sk = "0x82000000"
+UBOOT_LOADADDRESS_am64xx-sk = "0x82000000"
+
 # Cross machines / BSPs
 ## iMX targets should use the u-boot release based on the NXP BSP
 PREFERRED_VERSION_u-boot-fio_imx ?= "2020.04"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/am64xx-sk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/am64xx-sk/boot.cmd
@@ -1,0 +1,8 @@
+setenv loadaddr 0x90000000
+setenv devtype mmc
+setenv devnum ${mmcdev}
+run findfdt
+load ${devtype} ${devnum}:2 ${loadaddr} /boot/loader/uEnv.txt
+env import -t ${loadaddr} ${filesize}
+load ${devtype} ${devnum}:2 ${loadaddr} ${kernel_image}
+bootm ${loadaddr}#conf@ti_${fdtfile}

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/am64xx-sk/uEnv.txt.in
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr/am64xx-sk/uEnv.txt.in
@@ -1,0 +1,4 @@
+bootcmd_dtb=fatload ${devtype} ${devnum}:1 ${fdt_addr_r} ${fdtfile}
+bootcmd_load_k=fatload ${devtype} ${devnum}:1 ${loadaddr} ${boot_file}
+bootcmd_run=booti ${loadaddr} - ${fdt_addr_r}
+bootcmd=run bootcmd_dtb; run setup; run bootcmd_load_k; run bootcmd_run

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ti-staging/am64xx-sk/0001-am64xx-sk-set-bootm-len-to-64.patch
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ti-staging/am64xx-sk/0001-am64xx-sk-set-bootm-len-to-64.patch
@@ -1,0 +1,35 @@
+From f3b4bb7c19a74543a62560a7765a99ae48dc4336 Mon Sep 17 00:00:00 2001
+From: Tim Anderson <tim.anderson@foundries.io>
+Date: Fri, 19 Feb 2021 11:54:40 -0700
+Subject: [PATCH] am64xx-sk: set bootm len to 64
+
+Allow larger bootm images (required by LmP);
+
+Fixes:
+   Uncompressing Kernel Image
+Error: inflate() returned -5
+Image too large: increase CONFIG_SYS_BOOTM_LEN
+Must RESET board to recover
+
+Signed-off-by: Tim Anderson <tim.anderson@foundries.io>
+---
+ include/configs/am64x_evm.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/include/configs/am64x_evm.h b/include/configs/am64x_evm.h
+index 4550259f04..e2273dc965 100644
+--- a/include/configs/am64x_evm.h
++++ b/include/configs/am64x_evm.h
+@@ -16,6 +16,9 @@
+ /* DDR Configuration */
+ #define CONFIG_SYS_SDRAM_BASE1		0x880000000
+ 
++/* bootmem size */
++#define CONFIG_SYS_BOOTM_LEN		SZ_64M
++
+ #ifdef CONFIG_SYS_K3_SPL_ATF
+ #define CONFIG_SPL_FS_LOAD_PAYLOAD_NAME	"tispl.bin"
+ #endif
+-- 
+2.17.1
+

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append_am64xx-sk = " \
+    file://0001-am64xx-sk-set-bootm-len-to-64.patch \
+"
+
+PACKAGECONFIG[optee] = "TEE=${STAGING_DIR_HOST}${nonarch_base_libdir}/firmware/tee-pager_v2.bin,,optee-os-fio"

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-ti-staging_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-ti-staging_git.bb
@@ -1,0 +1,30 @@
+include recipes-kernel/linux/kmeta-linux-lmp-5.4.y.inc
+
+LINUX_VERSION ?= "5.4.93"
+KBRANCH = "ti-linux-5.4.y"
+SRCREV_machine = "87c0425824b4169e4d697c4f6219243249a8c08b"
+SRCREV_meta = "${KERNEL_META_COMMIT}"
+
+TI_DEFCONFIG_BUILDER_TARGET ?= "ti_sdk_arm64_release"
+KBUILD_DEFCONFIG ?= "${TI_DEFCONFIG_BUILDER_TARGET}_defconfig"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
+
+# add device-tree to rootfs
+RDEPENDS_${KERNEL_PACKAGE_NAME}-base_append_lmp-base = " kernel-devicetree"
+
+SRC_URI = "git://git.ti.com/git/ti-linux-kernel/ti-linux-kernel.git;protocol=https;branch=${KBRANCH};name=machine; \
+    ${KERNEL_META_REPO};protocol=${KERNEL_META_REPO_PROTOCOL};type=kmeta;name=meta;branch=${KERNEL_META_BRANCH};destsuffix=${KMETA} \
+    file://0001-FIO-fromtree-tee-add-support-for-session-s-client-UU.patch \
+    file://0002-FIO-fromtree-tee-optee-Add-support-for-session-login.patch \
+    file://0001-driver-tee-Handle-NULL-pointer-indication-from-clien.patch \
+"
+
+KMETA = "kernel-meta"
+
+do_kernel_metadata_prepend() {
+    cd ${S}
+    ti_config_fragments/defconfig_builder.sh -t ${TI_DEFCONFIG_BUILDER_TARGET}
+}
+
+include recipes-kernel/linux/linux-lmp.inc


### PR DESCRIPTION
- new linux-lmp-ti-staging kernel recipe to support TI's kernel build using defconfig_builder.sh + kmeta data
- u-boot script for u-boot-ostree-scr
- uboot-ti-staging patch to raise CONFIG_SYS_BOOTM_LEN to 64MB
- LmP board settings for am64xx-sk
- bump kmeta-linux-lmp-5.4.y SHA to 71b6bbf223ba510a6c24c62418dfbcc939deb1d6