### PR TITLE
base: aktualizr-lite: bump to 9010446

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "master"
-SRCREV_lmp = "be4532fc1076cca4f198c322e9c0676e3111dd19"
+SRCREV_lmp = "90104462e59eb477e08669fadebc384e2126d90c"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
  Relevant changes:
    - 9010446 apps: make finding of auth endpoint prefix agnostic
    - 24e7e2e aklite: reuse the existing installation finalization

Signed-off-by: Mike Sul <mike.sul@foundries.io>