### PR TITLE
base: aktualizr-lite: bump to 699d6af

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "master"
-SRCREV_lmp = "90104462e59eb477e08669fadebc384e2126d90c"
+SRCREV_lmp = "699d6afb1e4350b7cc18cb767a96e9dc1c3bb0af"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
Relevant changes:
 - 699d6af fixup!: add x-ats-target header at http client instantiation
 - b17d48d apps: introduce App Engine interface
 - a0e804d test: app engine mock and basic app update tests

Signed-off-by: Mike Sul <mike.sul@foundries.io>