### PR TITLE
bsp: mfgtool-files: imx6ullevk: fix erase offset

### DIFF
--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx6ullevk/bootloader.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx6ullevk/bootloader.uuu.in
@@ -7,7 +7,8 @@ SDP: jump -f SPL-mfgtool -ivt
 
 FB: ucmd if mmc dev 0; then setenv flash_dev 0; setenv emmc_partconf "mmc partconf ${flash_dev} ${emmc_ack} 1 0"; else setenv flash_dev 1; setenv emmc_partconf "true"; fi;
 FB: ucmd setenv fastboot_dev mmc
-FB: ucmd mmc dev ${flash_dev} 1; mmc erase 0 0x2000
+FB: ucmd mmc dev ${flash_dev}
+FB: ucmd mmc dev ${flash_dev} 1; mmc erase 2 0x1FFE
 FB: flash bootloader ../SPL-@@MACHINE@@
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
 FB: ucmd if env exist emmc_partconf; then run emmc_partconf; fi;

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx6ullevk/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx6ullevk/full_image.uuu.in
@@ -9,7 +9,7 @@ FB: ucmd if mmc dev 0; then setenv flash_dev 0; setenv emmc_partconf "mmc partco
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd mmc dev ${flash_dev}
 FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
-FB: ucmd mmc dev ${flash_dev} 1; mmc erase 0 0x2000
+FB: ucmd mmc dev ${flash_dev} 1; mmc erase 2 0x1FFE
 FB: flash bootloader ../SPL-@@MACHINE@@
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
 FB: ucmd if env exist emmc_partconf; then run emmc_partconf; fi;


### PR DESCRIPTION
There is no eMMC device available by default on imx6ullevk, so taking
into account the partition layout and correct offset when erasing the
bootloader area.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>