### PR TITLE
base: lmp-feature-wayland: add xset when xwayland is enabled

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-feature-wayland.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-wayland.inc
@@ -4,5 +4,5 @@ CORE_IMAGE_BASE_INSTALL += " \
     weston \
     weston-init \
     wayland \
-    ${@bb.utils.contains("DISTRO_FEATURES", "x11 wayland", "weston-xwayland", "", d)} \
+    ${@bb.utils.contains("DISTRO_FEATURES", "x11 wayland", "weston-xwayland xset", "", d)} \
 "


### PR DESCRIPTION
Subscribers may choose to use xset to configure x options, so let's
add that to the build for xwayland users.

Signed-off-by: Michael Scott <mike@foundries.io>