### PR TITLE
bsp: fsl-image-mfgtool-initramfs: inherit nopackages

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-fsl/images/fsl-image-mfgtool-initramfs.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-fsl/images/fsl-image-mfgtool-initramfs.bbappend
@@ -2,3 +2,5 @@
 IMAGE_FSTYPES_lmp = "cpio.gz"
 DEPENDS_remove = "u-boot-mfgtool linux-mfgtool"
 DEPENDS_append = " virtual/bootloader virtual/kernel"
+
+inherit nopackages


### PR DESCRIPTION
With fitimage support there is no need to generate packages for
initramfs, which can confuse the package metadata generation for
dependencies such as imx-boot.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>