### PR TITLE
meta-lmp-bsp: dynamic: flashlayout fix bug in deploy script

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/flashlayouts-stm32mp1/flashlayouts-stm32mp1.bb
+++ b/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/flashlayouts-stm32mp1/flashlayouts-stm32mp1.bb
@@ -30,7 +30,7 @@ do_compile() {
 # deploy a .tar.gz file of artifacts
 do_deploy() {
     install -d ${DEPLOYDIR}/${PN}
-    install -m 0755 ${DEPLOYDIR}/*.tsv ${DEPLOYDIR}/${PN}
+    install -m 0755 ${WORKDIR}/*.tsv ${DEPLOYDIR}/${PN}
     install -m 0755 ${DEPLOY_DIR_IMAGE}/scripts/* ${DEPLOYDIR}/${PN}
     install -m 0644 ${DEPLOY_DIR_IMAGE}/arm-trusted-firmware/*.stm32 ${DEPLOYDIR}/${PN}
     install -m 0644 ${DEPLOY_DIR_IMAGE}/bootloader/*.stm32 ${DEPLOYDIR}/${PN}


### PR DESCRIPTION
When the stm32mp was added to lmp the deploy was not correct.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>