### PR TITLE
Read EMAC from EEPROM on uz3eg-iocc

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/device-tree/device-tree/uz3eg-iocc/system-board.dtsi
+++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/device-tree/device-tree/uz3eg-iocc/system-board.dtsi
@@ -30,6 +30,9 @@
 			linux,default-trigger = "heartbeat";
 		};
 	};
+        chosen {
+                xlnx,eeprom = &eeprom; /* EMAC on EEPROM */
+        };
 };
 
 /* Ethernet0 with hard-coded MAC */
@@ -37,7 +40,7 @@
 	status = "okay";
 	phy-handle = <&phy0>;
 	phy-mode = "rgmii-id";
-	local-mac-address = [00 0a 35 00 02 90];
+	#local-mac-address = [00 0a 35 00 02 90]; /* EMAC on EEPROM */
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_gem3_default>;
 	phy0: ethernet-phy@9 {
@@ -69,7 +72,7 @@
 			#size-cells = <0>;
 			reg = <0>;
 			/* IIC_EEPROM */
-			eeprom@51 { /* U5 on UZ3EG IOCC and U7 on the UZ7EV EVCC*/
+			eeprom: eeprom@51 { /* U5 on UZ3EG IOCC and U7 on the UZ7EV EVCC*/
 				compatible = "atmel,24c08";
 				reg = <0x51>;
 				#address-cells = <0x01>;


### PR DESCRIPTION
Remove fixed EMAC address from device-tree and read it from EEPROM.

Tested on an AES-ZU3EG-1-SK-G evaluation board.

Without this change:
```
Warning: ethernet@ff0e0000 using MAC address from DT
ZynqMP> printenv ethaddr
ethaddr=00:0a:35:00:02:90
```
With this change and EEPROM UNinitialized:
```
Warning: ethernet@ff0e0000 (eth0) using random MAC address - c2:d0:ec:05:1d:af
```
Write MAC on EEPROM:
```
Hit any key to stop autoboot:  0
ZynqMP> i2c dev 2
Setting bus to 2
ZynqMP> mm.b 0
00000000: 60 ? 12
00000001: 09 ? 34
00000002: 00 ? 56
00000003: 20 ? 78
00000004: 00 ? 9a
00000005: 00 ? bc
00000006: 00 ? q
ZynqMP> i2c write 0 51 20 6
ZynqMP> reset
...
Warning: ethernet@ff0e0000 using MAC address from ROM
```