### PR TITLE
base: go: limit RISC-V cgo/pie support patches to riscv64

### DIFF
--- a/meta-lmp-base/recipes-devtools/go/go-riscv-1.15.inc
+++ b/meta-lmp-base/recipes-devtools/go/go-riscv-1.15.inc
@@ -3,7 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 export CGO_ENABLED_riscv64 = "1"
 
 # From https://github.com/4a6f656c/go/commits/riscv64-cgo-1.15
-SRC_URI += " \
+SRC_URI_append_riscv64 = " \
 	file://0001-cmd-link-add-support-for-external-linking-on-linux-r.patch \
 	file://0002-cmd-link-cmd-internal-obj-riscv-add-TLS-support-for-.patch \
 	file://0003-cmd-compile-cmd-internal-obj-riscv-move-g-register-o.patch \


### PR DESCRIPTION
These patches seem to be causing a regression when applied for all
arches.  Let's limit them to only riscv64.

Signed-off-by: Michael Scott <mike@foundries.io>