### PR TITLE
apalis-imx6 pl310 fix

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.10.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.10.0.bb
@@ -1,5 +1,5 @@
 require optee-os-fio.inc
 
 PV = "3.10.0+git"
-SRCREV = "01ed34ee14b241ab33146ddd7e9a528153d2ad3e"
+SRCREV = "9e4e3adebc20ed9bd5c96564ba2e5f123e52d6ea"
 SRCBRANCH = "3.10+fio"

--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.12.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.12.0.bb
@@ -1,7 +1,7 @@
 require optee-os-fio.inc
 
 PV = "3.12.0+git"
-SRCREV = "dfcce199d6b9e5acf61d409bb1828d2034b4bae7"
+SRCREV = "a410cdf6c38dd2debdde2e3b72841f3a79b6a878"
 SRCBRANCH = "3.12+fio"
 
 DEFAULT_PREFERENCE = "-1"

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-dev-mfgtool.bbappend
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-dev-mfgtool.bbappend
@@ -3,3 +3,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI += " \
     file://defconfig \
 "
+
+# fix OP-TEE performance regression for Cortex-A9 i.MX6QDL
+SRC_URI_append_apalis-imx6 = " \
+    file://0001-MLK-16912-PL310-unlock-ways-during-initialization.patch \
+"

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-dev-mfgtool/apalis-imx6/0001-MLK-16912-PL310-unlock-ways-during-initialization.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-dev-mfgtool/apalis-imx6/0001-MLK-16912-PL310-unlock-ways-during-initialization.patch
@@ -1,0 +1,38 @@
+From 7726883a228d997a58108688025100142ca9ab74 Mon Sep 17 00:00:00 2001
+From: Cedric Neveux <cedric.neveux@nxp.com>
+Date: Tue, 14 Nov 2017 16:42:42 +0000
+Subject: MLK-16912 PL310: unlock ways during initialization
+
+This change affects all i.MX 6 with PL310 L2 Cache controller.
+When Linux runs in Non-secure World the PL310 has already
+been initialized by the ARM secure World running OP-TEE os.
+However, in order to have a proper Linux Initialization all the
+L2 cache ways have been locked by the secure world.
+
+This patch unlock all the ways during pl310 initialization.
+
+Signed-off-by: Cedric Neveux <cedric.neveux@nxp.com>
+Signed-off-by: Arulpandiyan Vadivel <arulpandiyan_vadivel@mentor.com>
+(cherry picked from commit 5133fbe9aaafd24add7d92b1aa2d3474b7a13723)
+---
+ arch/arm/mm/cache-l2x0.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm/mm/cache-l2x0.c b/arch/arm/mm/cache-l2x0.c
+index 12c26eb..bc632a3 100644
+--- a/arch/arm/mm/cache-l2x0.c
++++ b/arch/arm/mm/cache-l2x0.c
+@@ -867,6 +867,11 @@ static int __init __l2c_init(const struct l2c_init_data *data,
+ 		l2x0_saved_regs.aux_ctrl = aux;
+ 
+ 		data->enable(l2x0_base, data->num_lock);
++	} else {
++		pr_info("%s cache controller enabled try to unlock\n",
++			data->type);
++
++		data->unlock(l2x0_base, data->num_lock);
+ 	}
+ 
+ 	outer_cache = fns;
+-- 
+cgit v1.1

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp/apalis-imx6/0001-MLK-16912-PL310-unlock-ways-during-initialization.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp/apalis-imx6/0001-MLK-16912-PL310-unlock-ways-during-initialization.patch
@@ -1,0 +1,38 @@
+From 7726883a228d997a58108688025100142ca9ab74 Mon Sep 17 00:00:00 2001
+From: Cedric Neveux <cedric.neveux@nxp.com>
+Date: Tue, 14 Nov 2017 16:42:42 +0000
+Subject: MLK-16912 PL310: unlock ways during initialization
+
+This change affects all i.MX 6 with PL310 L2 Cache controller.
+When Linux runs in Non-secure World the PL310 has already
+been initialized by the ARM secure World running OP-TEE os.
+However, in order to have a proper Linux Initialization all the
+L2 cache ways have been locked by the secure world.
+
+This patch unlock all the ways during pl310 initialization.
+
+Signed-off-by: Cedric Neveux <cedric.neveux@nxp.com>
+Signed-off-by: Arulpandiyan Vadivel <arulpandiyan_vadivel@mentor.com>
+(cherry picked from commit 5133fbe9aaafd24add7d92b1aa2d3474b7a13723)
+---
+ arch/arm/mm/cache-l2x0.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm/mm/cache-l2x0.c b/arch/arm/mm/cache-l2x0.c
+index 12c26eb..bc632a3 100644
+--- a/arch/arm/mm/cache-l2x0.c
++++ b/arch/arm/mm/cache-l2x0.c
+@@ -867,6 +867,11 @@ static int __init __l2c_init(const struct l2c_init_data *data,
+ 		l2x0_saved_regs.aux_ctrl = aux;
+ 
+ 		data->enable(l2x0_base, data->num_lock);
++	} else {
++		pr_info("%s cache controller enabled try to unlock\n",
++			data->type);
++
++		data->unlock(l2x0_base, data->num_lock);
+ 	}
+ 
+ 	outer_cache = fns;
+-- 
+cgit v1.1

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp_git.bbappend
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp_git.bbappend
@@ -4,6 +4,11 @@ SRC_URI_append_corstone700 = " \
     file://defconfig \
 "
 
+# fix OP-TEE performance regression for Cortex-A9 i.MX6QDL
+SRC_URI_append_apalis-imx6 = " \
+    file://0001-MLK-16912-PL310-unlock-ways-during-initialization.patch \
+"
+
 # Modules are not supported on corstone700, so allow empty
 # package to satisfy rdependencies.
 PACKAGES_append_corstone700 = " kernel-module-wireguard"


### PR DESCRIPTION
- Linux patches to fix Linux init of PL310 caches.
- Bump optee-os SHAs to include PL310 tuning changes

These changes fix performance issues for imx6qdl HW when running OP-TEE.