### PR TITLE
Add apps-early-start recipe

### DIFF
--- a/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start.bb
+++ b/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start.bb
@@ -1,0 +1,19 @@
+SUMMARY = "A systemd oneshot helper to start compose apps as early as possible"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+	file://compose-apps-early-start.service \
+	file://compose-apps-early-start \
+"
+
+inherit systemd
+
+SYSTEMD_SERVICE_${PN} = "compose-apps-early-start.service"
+
+do_install() {
+	install -d ${D}${systemd_system_unitdir}
+	install -m 0644 ${WORKDIR}/compose-apps-early-start.service ${D}${systemd_system_unitdir}/
+	install -d ${D}${bindir}
+	install -m 0755 ${WORKDIR}/compose-apps-early-start ${D}${bindir}/
+}

--- a/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start
+++ b/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start
@@ -1,0 +1,24 @@
+#!/bin/sh -e
+
+if [ -f /var/lmp/default-apps ] ; then
+	if [ -d /var/sota/compose-apps ] ; then
+		for x in $(ls /var/sota/compose-apps) ; do
+			if ! grep -q $x /var/lmp/default-apps 2>/dev/null ; then
+				echo "Disabling preloaded app: $x"
+				rm -rf /var/sota/compose-apps/$x
+			fi
+		done
+	fi
+fi
+
+if [ -d /var/sota/compose-apps ] ; then
+	cd /var/sota/compose-apps
+	for x in `ls` ; do
+		cd $x
+		echo "Starting $x"
+		docker-compose up -d
+		cd ../
+	done
+else
+	echo "No apps defined"
+fi

--- a/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start.service
+++ b/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Ensure apps are configured and running as early as possible
+Wants=docker.service
+After=docker.service
+Before=lmp-device-auto-register.service
+ConditionPathExists=!/var/sota/sql.db
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/bin/compose-apps-early-start
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Its often desirable to start compose-apps (containers) before a device
is registered and aklite is running. This recipe creates a one shot
service that will start apps if aklite is not yet setup.

Signed-off-by: Andy Doan <andy@foundries.io>