### PR TITLE
initramfs-framework: create /var/lock later

### DIFF
--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework/run-tmpfs.patch
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework/run-tmpfs.patch
@@ -24,11 +24,11 @@ index c71ce0c..79cf5c1 100755
  
  # initialize /proc, /sys, /run/lock and /var/lock
 -mkdir -p /proc /sys /run/lock /var/lock
-+mkdir -p /proc /sys /run /var/lock
++mkdir -p /proc /sys /run
  mount -t proc proc /proc
  mount -t sysfs sysfs /sys
 +mount -t tmpfs tmpfs /run
-+mkdir -p /run/lock
++mkdir -p /run/lock /var/lock
  
  if [ -d $EFI_DIR ];then
  	mount -t efivarfs none /sys/firmware/efi/efivars


### PR DESCRIPTION
In run-tmpfs.patch, we had changed /run to be a tmpfs mountpoint, and
/var/lock is a symbolic link to ../run/lock, so we shall move the
'mkdir' after /run created, or else we get a error as follows:
| mkdir: can't create directory '/var/lock': No such file or directory

Signed-off-by: Ming Liu <liu.ming50@gmail.com>