### PR TITLE
bsp: uz3eg-iocc: set default tune to cortexa53

### DIFF
--- a/meta-lmp-bsp/conf/machine/uz3eg-iocc.conf
+++ b/meta-lmp-bsp/conf/machine/uz3eg-iocc.conf
@@ -2,6 +2,8 @@
 #@NAME: uz3eg-iocc
 #@DESCRIPTION: Machine support for UltraZed-EG with IOCC customized for LmP
 
+DEFAULTTUNE = "cortexa53"
+
 require conf/machine/include/ultrazed-lmp.inc
 
 # DSA file taken from UZ3EG_IOCC_2019p1_PetaLinux_SDSoC_Platform.zip ->


### PR DESCRIPTION
soc-zynqmp.inc uses cortexa72-cortexa53 as default tune for zynqmp
devices, but uz3eg-iocc only has a53 cores, so define the correct tune
at board level.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>