### PR TITLE
base: dropbear: prefer ecdsa instead of rsa

### DIFF
--- a/meta-lmp-base/recipes-core/dropbear/dropbear/dropbear@.service
+++ b/meta-lmp-base/recipes-core/dropbear/dropbear/dropbear@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=SSH Per-Connection Server
+Wants=dropbearkey.service
+After=syslog.target dropbearkey.service
+
+[Service]
+Environment="DROPBEAR_KEY_DIR=/etc/dropbear"
+EnvironmentFile=-/etc/default/dropbear
+ExecStart=-@SBINDIR@/dropbear -i -r ${DROPBEAR_KEY_DIR}/dropbear_ecdsa_host_key $DROPBEAR_EXTRA_ARGS
+ExecReload=@BASE_BINDIR@/kill -HUP $MAINPID
+StandardInput=socket
+KillMode=process

--- a/meta-lmp-base/recipes-core/dropbear/dropbear/dropbearkey.service
+++ b/meta-lmp-base/recipes-core/dropbear/dropbear/dropbearkey.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=SSH Key Generation
+RequiresMountsFor=/var /var/lib
+ConditionPathExists=!/etc/dropbear/dropbear_ecdsa_host_key
+ConditionPathExists=!/var/lib/dropbear/dropbear_ecdsa_host_key
+
+[Service]
+Environment="DROPBEAR_KEY_DIR=/etc/dropbear"
+EnvironmentFile=-/etc/default/dropbear
+Type=oneshot
+ExecStart=@BASE_BINDIR@/mkdir -p ${DROPBEAR_KEY_DIR}
+ExecStart=@SBINDIR@/dropbearkey -t ecdsa -f ${DROPBEAR_KEY_DIR}/dropbear_ecdsa_host_key
+RemainAfterExit=yes
+Nice=10

--- a/meta-lmp-base/recipes-core/dropbear/dropbear_%.bbappend
+++ b/meta-lmp-base/recipes-core/dropbear/dropbear_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
ECDSA is a lot faster to generate during first use, so prefer it instead
of RSA 2048 (default from OE).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>