### PR TITLE
base: optee-os-fio: 3.10: bump to 12c10709

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.10.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.10.0.bb
@@ -1,5 +1,5 @@
 require optee-os-fio.inc
 
 PV = "3.10.0+git"
-SRCREV = "dafb267d3dcd7c25082d2ec5d9dce4d72fb15bd1"
+SRCREV = "12c1070921b882bd7a1e4de3f2eed796370d1420"
 SRCBRANCH = "3.10+fio"


### PR DESCRIPTION
```
Relevant changes:
- 12c10709 [FIO fromtree] ldelf: arm64: support R_AARCH64_NONE relocations
- da24e396 [FIO fromtree] ldelf: arm32: support R_ARM_NONE relocations

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>
```