### PR TITLE
base: fiopush: use fio tools instead of garage-tools

### DIFF
--- a/meta-lmp-base/classes/lmp.bbclass
+++ b/meta-lmp-base/classes/lmp.bbclass
@@ -45,6 +45,29 @@ IMAGE_CMD_ota_append () {
 	fi
 }
 
+run_fiotool_cmd () {
+	if [ -n "${SOTA_PACKED_CREDENTIALS}" ]; then
+                if [ -e "${SOTA_PACKED_CREDENTIALS}" ]; then
+                        "${1}" -repo "${OSTREE_REPO}" -creds "${SOTA_PACKED_CREDENTIALS}"
+                else
+                        bbwarn "SOTA_PACKED_CREDENTIALS file does not exist."
+                fi
+        else
+                bbwarn "SOTA_PACKED_CREDENTIALS not set. Please add SOTA_PACKED_CREDENTIALS."
+        fi
+
+}
+
+do_image_ostreepush[depends] += "fiotools-native:do_populate_sysroot ca-certificates-native:do_populate_sysroot"
+IMAGE_CMD_ostreepush_lmp () {
+	run_fiotool_cmd "fiopush"
+}
+
+do_image_garagecheck[depends] += "fiotools-native:do_populate_sysroot ca-certificates-native:do_populate_sysroot"
+IMAGE_CMD_garagecheck_lmp () {
+	run_fiotool_cmd "fiocheck"
+}
+
 # LMP specific cleanups after the main ostree image from meta-updater
 IMAGE_CMD_ostree_append () {
 	# No need for var/local as the entire var is bind-mounted

--- a/meta-lmp-base/recipes-sota/fiotools/fiotools_git.bb
+++ b/meta-lmp-base/recipes-sota/fiotools/fiotools_git.bb
@@ -1,0 +1,25 @@
+DESCRIPTION = "Tool used to push ostree repositories to ostreehub"
+HOMEPAGE = "https://github.com/foundriesio/ostreehub"
+SECTION = "devel"
+LICENSE = "CLOSED"
+
+GO_IMPORT = "github.com/foundriesio/ostreehub"
+SRC_URI = "git://${GO_IMPORT}"
+SRCREV = "7439a7975f79ee924eeab680ca3fec1ce74956ef"
+
+UPSTREAM_CHECK_COMMITS = "1"
+
+BBCLASSEXTEND = "native"
+
+inherit go-mod
+
+go_do_compile() {
+	cd ${B}/src/github.com/foundriesio/ostreehub
+	make fiopush fiocheck
+}
+
+do_install() {
+	install -d ${D}${bindir}
+	install ${B}/src/github.com/foundriesio/ostreehub/bin/fiopush ${D}${bindir}
+	install ${B}/src/github.com/foundriesio/ostreehub/bin/fiocheck ${D}${bindir}
+}


### PR DESCRIPTION
- recipe to build fiotools
- use fiopush instead of garage-push to upload an ostree repo
- use fiocheck instead of garage-check to check if an ostree repo is fully present on the backend

Signed-off-by: Mike Sul <mike.sul@foundries.io>