### PR TITLE
base: u-boot-fio: 2020.04: bump to 89f95b569c

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2020.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2020.04.bb
@@ -1,4 +1,4 @@
 require u-boot-fio-common.inc
 
-SRCREV = "a36d90e2ecb5b50c5ab91e683878b46f176c66d5"
+SRCREV = "89f95b569c1474f73ae56e2f04a661170d232281"
 SRCBRANCH = "2020.04+fio"


### PR DESCRIPTION
```
Relevant changes:
- 89f95b569c [FIO internal] imx8mq: add definition for SRC_SBMR2_SEC_CONFIG

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>
```