### PR TITLE
base: fiotools: add a recipe for fiotools

### DIFF
--- a/meta-lmp-base/recipes-sota/fiotools/fiotools_git.bb
+++ b/meta-lmp-base/recipes-sota/fiotools/fiotools_git.bb
@@ -1,0 +1,26 @@
+DESCRIPTION = "Tools used to push an ostree repo to and check if it is synced with OSTreeHub"
+HOMEPAGE = "https://github.com/foundriesio/ostreehub"
+SECTION = "devel"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=2a944942e1496af1886903d274dedb13"
+
+GO_IMPORT = "github.com/foundriesio/ostreehub"
+SRC_URI = "git://${GO_IMPORT}"
+SRCREV = "cb807b1f745e380f0bc1c8b47d9ada1dd5bd2e8b"
+
+UPSTREAM_CHECK_COMMITS = "1"
+
+BBCLASSEXTEND = "native"
+
+inherit go-mod
+
+go_do_compile() {
+	cd ${B}/src/github.com/foundriesio/ostreehub
+	make fiopush fiocheck
+}
+
+do_install() {
+	install -d ${D}${bindir}
+	install -m 0755 ${B}/src/github.com/foundriesio/ostreehub/bin/fiopush ${D}${bindir}
+	install -m 0755 ${B}/src/github.com/foundriesio/ostreehub/bin/fiocheck ${D}${bindir}
+}


### PR DESCRIPTION
- A recipe to build and install fiotools.
  It includes fiopush and fiocheck aimed to push an ostree repo to and check if it's synced with OSTreeHub.

Signed-off-by: Mike Sul <mike.sul@foundries.io>