### PR TITLE
uz3eg-iocc: enable UMS on u-boot

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/device-tree/device-tree/uz3eg-iocc/system-board.dtsi
+++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/device-tree/device-tree/uz3eg-iocc/system-board.dtsi
@@ -155,7 +155,7 @@
 
 &dwc3_0 {
 	status = "okay";
-	dr_mode = "host";
+	dr_mode = "otg";
 	snps,usb3_lpm_capable;
 	phy-names = "usb3-phy";
 	/* 4==PHY_TYPE_USB3 */


### PR DESCRIPTION
Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>