### PR TITLE
base: aktualizr-lite: move tmpdir to /run

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
@@ -9,6 +9,8 @@ ConditionPathExists=!/usr/bin/mbedCloudClient
 [Service]
 RestartSec=180
 Restart=always
+ExecStartPre=/usr/bin/mkdir -p /run/aktualizr
+Environment="TMPDIR=/run/aktualizr"
 Environment="COMPOSE_HTTP_TIMEOUT=@@COMPOSE_HTTP_TIMEOUT@@"
 ExecStart=/usr/bin/aktualizr-lite --update-lockfile /run/lock/aktualizr-lite-update daemon
 


### PR DESCRIPTION
Move default tmpdir used by aktualizr (boost) to /run/aktualizr instead
of /tmp by default, to avoid having systemd cleaning up files that are
important for aktualizr's runtime.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>