### PR TITLE
base: aktualizr-lite: bump to 5a0b9d5

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "master"
-SRCREV_lmp = "fe447e0c56d05d9d003722a2bbdc9a00205f6a55"
+SRCREV_lmp = "5a0b9d5df7ed83ef6fe6c270efa5c0e1c71f6ee0"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
Relevant changes:
- a2b16db callback: extend the post check callback context
- bc6c76f hsm: make p11 engine singleton and run multiple HSM tests
- 9b43d68 composeappmanager: replace docker ps with REST api
- 0067252 apps: send currently running apps on any update type

Signed-off-by: Mike Sul <mike.sul@foundries.io>