### PR TITLE
base: optee-os: Bump to 53fad5f6

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.10.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.10.0.bb
@@ -1,5 +1,5 @@
 require optee-os-fio.inc
 
 PV = "3.10.0+git"
-SRCREV = "12c1070921b882bd7a1e4de3f2eed796370d1420"
+SRCREV = "53fad5f6fe1804e7179e132483bc022f677ef1cb"
 SRCBRANCH = "3.10+fio"


### PR DESCRIPTION
Relevant changes:
- 53fad5f6 Add object name to error output
- e5f5fa8b core: imx: build snvs driver for imx8mm
- daaa6cb8 core: imx: add snvs base address for imx8m
- 8d35b6cf imx: pm: add support for reset2 function
- 1cc8748d core: sm: add PSCI 1.1 SYSTEM_RESET2 support

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>