### PR TITLE
base: class: lmp-disable-gplv3: Enable the LMP_DISABLE_GPLV3

### DIFF
--- a/meta-lmp-base/classes/lmp-disable-gplv3.bbclass
+++ b/meta-lmp-base/classes/lmp-disable-gplv3.bbclass
@@ -5,6 +5,7 @@ PACKAGECONFIG_remove_pn-python3 = "readline"
 PACKAGECONFIG_remove_pn-curl = "libidn"
 PACKAGECONFIG_remove_pn-bluez5 = "readline mesh"
 PACKAGECONFIG_remove_pn-iproute2 = "elf"
+LMP_DISABLE_GPLV3 = "1"
 
 # TODO: switch to a solution that doesn't depend on parted
 CORE_IMAGE_BASE_INSTALL_remove = "resize-helper"


### PR DESCRIPTION
Turn LMP_DISABLE_GPLV3 on when this class is used.

This way, we can better control along the meta-layer which package or packagegroup is being installed