### PR TITLE
base: aktualizr-lite: bump to e7821f4

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "master"
-SRCREV_lmp = "5a0b9d5df7ed83ef6fe6c270efa5c0e1c71f6ee0"
+SRCREV_lmp = "e7821f494aef038a917c04845f88b78fc05738c1"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
Relevant changes:
- e7821f4 docker: assume TUF repo server is Hub creds provider
- ac594c1 callback: explicit Target name as callback context

Signed-off-by: Mike Sul <mike.sul@foundries.io>