### PR TITLE
base: systemd-journald-config: add recipe

### DIFF
--- a/meta-lmp-base/recipes-support/systemd-journald-config/systemd-journald-config.bb
+++ b/meta-lmp-base/recipes-support/systemd-journald-config/systemd-journald-config.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Systemd Journald Configuration Fragment"
+SECTION = "devel"
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-2-Clause;md5=cb641bc04cda31daea161b1bc15da69f"
+
+inherit allarch
+
+SRC_URI = "file://forward-console.conf"
+
+S = "${WORKDIR}"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_install() {
+    install -d ${D}${systemd_unitdir}/journald.conf.d
+    install -m 0644 ${S}/forward-console.conf ${D}${systemd_unitdir}/journald.conf.d/10-forward-console.conf
+}
+
+FILES_${PN} = "${systemd_unitdir}/journald.conf.d"

--- a/meta-lmp-base/recipes-support/systemd-journald-config/systemd-journald-config/forward-console.conf
+++ b/meta-lmp-base/recipes-support/systemd-journald-config/systemd-journald-config/forward-console.conf
@@ -1,0 +1,2 @@
+[Journal]
+ForwardToConsole=yes


### PR DESCRIPTION
Add recipe used to provide configuration fragments for systemd journald,
including one config to forward journal to console by default.

This can be useful on systems with getty disabled.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>