### PR TITLE
base: add mfgtool-resize-helper

### DIFF
--- a/meta-lmp-base/recipes-support/mfgtool-resize-helper/mfgtool-resize-helper/mfgtool-resize-helper
+++ b/meta-lmp-base/recipes-support/mfgtool-resize-helper/mfgtool-resize-helper/mfgtool-resize-helper
@@ -1,0 +1,32 @@
+#!/bin/sh -x
+
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Copyright (c) Fathi Boudra <fathi.boudra@linaro.org>
+# Copyright (c) Michael Scott <mike@foundries.io>
+# All rights reserved.
+
+# exit on any error
+set -e
+
+# we must be root
+[ $(whoami) = "root" ] || { echo "E: You must be root" && exit 1; }
+
+# we must have few tools
+PARTED=$(which parted) || { echo "E: You must have parted" && exit 1; }
+PARTPROBE=$(which partprobe) || { echo "E: You must have partprobe" && exit 1; }
+RESIZE2FS=$(which resize2fs) || { echo "E: You must have resize2fs" && exit 1; }
+E2FSCK=$(which e2fsck) || { echo "E: You must have e2fsck" && exit 1; }
+
+ROOT_DEVICE=${1}
+PART_ENTRY_NUMBER=${2}
+
+# Make sure everything gets probed before any command gets executed
+${PARTPROBE} --summary
+
+echo "CMD: ${PARTED} ---pretend-input-tty ${ROOT_DEVICE} resizepart ${PART_ENTRY_NUMBER}"
+
+echo -e '100%' | ${PARTED} ---pretend-input-tty ${ROOT_DEVICE} resizepart ${PART_ENTRY_NUMBER}
+${PARTPROBE} --summary
+${E2FSCK} -f -p "${ROOT_DEVICE}p${PART_ENTRY_NUMBER}"
+${RESIZE2FS} "${ROOT_DEVICE}p${PART_ENTRY_NUMBER}"

--- a/meta-lmp-base/recipes-support/mfgtool-resize-helper/mfgtool-resize-helper_0.1.bb
+++ b/meta-lmp-base/recipes-support/mfgtool-resize-helper/mfgtool-resize-helper_0.1.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Rootfs disk resize-helper for mfgtools"
+SECTION = "devel"
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-2-Clause;md5=cb641bc04cda31daea161b1bc15da69f"
+
+inherit allarch
+
+RDEPENDS_${PN} += "udev e2fsprogs-resize2fs e2fsprogs-e2fsck gptfdisk parted"
+
+SRC_URI = "file://mfgtool-resize-helper \
+"
+
+S = "${WORKDIR}"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_install () {
+	install -d ${D}${sbindir}
+	install -m 0755 ${S}/mfgtool-resize-helper ${D}${sbindir}
+}


### PR DESCRIPTION
This will allow us to use the mfgtools to resize the filesystem
on the device without leaving GPLv3 code in the production image.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>