### PR TITLE
Bump lmp-dev-reg version

### DIFF
--- a/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl glib-2.0"
 
-SRCREV = "bc56368f6921dd4050064c3547c53b853bbc34e8"
+SRCREV = "032d4f690cb4bad6da22734c939a0b3fa2bf8bac"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https"
 


### PR DESCRIPTION
base: lmp-device-register: bump to bc56368f
   
    Relevant changes:
    - 032d4f6 Add parameter to turn on an ostree proxy usage
