### PR TITLE
Add initial support for IMA

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -30,6 +30,9 @@ DISTRO_FEATURES_DEFAULT = "acl argp bluetooth ext2 ipv4 ipv6 largefile usbgadget
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "pulseaudio ldconfig"
 DISTRO_FEATURES_append = " pam usrmerge virtualization ptest"
 
+# Default IMA policy (tcb)
+IMA_POLICY ?= "ima-policy-tcb"
+
 # Extended packageconfig options for LMP
 PACKAGECONFIG_append_pn-docker-ce = " seccomp"
 PACKAGECONFIG_append_pn-docker-moby = " seccomp"

--- a/meta-lmp-base/recipes-core/images/initramfs-ostree-lmp-image.bb
+++ b/meta-lmp-base/recipes-core/images/initramfs-ostree-lmp-image.bb
@@ -5,6 +5,7 @@ PACKAGE_INSTALL = "initramfs-framework-base \
 	initramfs-module-rootfs \
 	initramfs-module-ostree \
 	${VIRTUAL-RUNTIME_base-utils} \
+	${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'initramfs-framework-ima', '', d)} \
 	udev base-passwd e2fsprogs-e2fsck \
 	${ROOTFS_BOOTSTRAP_INSTALL}"
 

--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.10.y"
-KERNEL_META_COMMIT ?= "6cd85741fcdf565730f7ac27fe2d9272939362ad"
+KERNEL_META_COMMIT ?= "1b0024b53c0d939b02235a45551afb49c78c6f77"

--- a/meta-lmp-base/recipes-samples/images/lmp-base-console-image.bb
+++ b/meta-lmp-base/recipes-samples/images/lmp-base-console-image.bb
@@ -14,6 +14,7 @@ require lmp-feature-jobserv.inc
 
 require ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'lmp-feature-optee.inc', '', d)}
 require ${@bb.utils.contains('MACHINE_FEATURES', 'tpm2', 'lmp-feature-tpm2.inc', '', d)}
+require ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'lmp-feature-ima.inc', '', d)}
 
 IMAGE_FEATURES += "ssh-server-openssh"
 

--- a/meta-lmp-base/recipes-samples/images/lmp-feature-ima.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-ima.inc
@@ -1,0 +1,5 @@
+# IMA packages
+CORE_IMAGE_BASE_INSTALL += " \
+    ima-evm-utils \
+    ima-inspect \
+"

--- a/meta-lmp-base/recipes-samples/images/lmp-gateway-image.bb
+++ b/meta-lmp-base/recipes-samples/images/lmp-gateway-image.bb
@@ -17,6 +17,7 @@ require lmp-feature-sysctl-net-queue-pfifo-fast.inc
 
 require ${@bb.utils.contains('MACHINE_FEATURES', 'optee', 'lmp-feature-optee.inc', '', d)}
 require ${@bb.utils.contains('MACHINE_FEATURES', 'tpm2', 'lmp-feature-tpm2.inc', '', d)}
+require ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'lmp-feature-ima.inc', '', d)}
 
 BT_6LOWPAN_NETWORK = "fe80:0:0:0:d4e7::1/80"
 require lmp-feature-bt-6lowpan.inc

--- a/meta-lmp-base/recipes-security/ima_policy_appraise_all/ima-policy-appraise-all_1.0.bbappend
+++ b/meta-lmp-base/recipes-security/ima_policy_appraise_all/ima-policy-appraise-all_1.0.bbappend
@@ -1,0 +1,1 @@
+IMA_POLICY = "ima_policy_appraise_all"

--- a/meta-lmp-base/recipes-security/ima_policy_hashed/ima-policy-hashed_1.0.bbappend
+++ b/meta-lmp-base/recipes-security/ima_policy_hashed/ima-policy-hashed_1.0.bbappend
@@ -1,0 +1,1 @@
+IMA_POLICY = "ima_policy_hashed"

--- a/meta-lmp-base/recipes-security/ima_policy_simple/ima-policy-simple_1.0.bbappend
+++ b/meta-lmp-base/recipes-security/ima_policy_simple/ima-policy-simple_1.0.bbappend
@@ -1,0 +1,1 @@
+IMA_POLICY = "ima_policy_simple"

--- a/meta-lmp-base/recipes-security/ima_policy_tcb/files/ima_policy_tcb
+++ b/meta-lmp-base/recipes-security/ima_policy_tcb/files/ima_policy_tcb
@@ -1,0 +1,34 @@
+# PROC_SUPER_MAGIC = 0x9fa0
+dont_measure fsmagic=0x9fa0
+# SYSFS_MAGIC = 0x62656572
+dont_measure fsmagic=0x62656572
+# DEBUGFS_MAGIC = 0x64626720
+dont_measure fsmagic=0x64626720
+# TMPFS_MAGIC = 0x1021994
+dont_measure fsmagic=0x1021994
+# DEVPTS_SUPER_MAGIC=0x1cd1
+dont_measure fsmagic=0x1cd1
+# BINFMTFS_MAGIC=0x42494e4d
+dont_measure fsmagic=0x42494e4d
+# SECURITYFS_MAGIC=0x73636673
+dont_measure fsmagic=0x73636673
+# SELINUX_MAGIC=0xf97cff8c
+dont_measure fsmagic=0xf97cff8c
+# SMACK_MAGIC=0x43415d53
+dont_measure fsmagic=0x43415d53
+# CGROUP_SUPER_MAGIC=0x27e0eb
+dont_measure fsmagic=0x27e0eb
+# CGROUP2_SUPER_MAGIC=0x63677270
+dont_measure fsmagic=0x63677270
+# NSFS_MAGIC=0x6e736673
+dont_measure fsmagic=0x6e736673
+# EFIVARFS_MAGIC=0xde5e81e4
+dont_measure fsmagic=0xde5e81e4
+
+measure func=MMAP_CHECK mask=MAY_EXEC
+measure func=BPRM_CHECK mask=MAY_EXEC
+measure func=FILE_CHECK mask=^MAY_READ euid=0
+measure func=FILE_CHECK mask=^MAY_READ uid=0
+measure func=MODULE_CHECK
+measure func=FIRMWARE_CHECK
+measure func=POLICY_CHECK

--- a/meta-lmp-base/recipes-security/ima_policy_tcb/ima-policy-tcb_1.0.bb
+++ b/meta-lmp-base/recipes-security/ima_policy_tcb/ima-policy-tcb_1.0.bb
@@ -1,0 +1,23 @@
+SUMMARY = "IMA sample tcb policy"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+# This policy file will get installed as /etc/ima/ima-policy.
+# It is located via the normal file search path, so a .bbappend
+# to this recipe can just point towards one of its own files.
+IMA_POLICY = "ima_policy_tcb"
+
+SRC_URI = " \
+    file://${IMA_POLICY} \
+"
+
+inherit features_check
+REQUIRED_DISTRO_FEATURES = "ima"
+
+do_install () {
+    install -d ${D}/${sysconfdir}/ima
+    install ${WORKDIR}/${IMA_POLICY}  ${D}/${sysconfdir}/ima/ima-policy
+}
+
+FILES_${PN} = "${sysconfdir}/ima"
+RDEPENDS_${PN} = "ima-evm-utils"

--- a/meta-lmp-base/recipes-support/ima-inspect/ima-inspect_0.14.bb
+++ b/meta-lmp-base/recipes-support/ima-inspect/ima-inspect_0.14.bb
@@ -1,0 +1,12 @@
+SUMMARY = "Output IMA/EVM extended attributes in a human readable format"
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=a23a74b3f4caf9616230789d94217acb"
+
+DEPENDS += "attr ima-evm-utils tclap"
+
+SRC_URI = "git://github.com/mgerstner/ima-inspect.git"
+SRCREV = "05db29b37965366cba22abe5e4de545e439cb4f2"
+
+S = "${WORKDIR}/git"
+
+inherit autotools pkgconfig


### PR DESCRIPTION
Add patches to allow initial support for IMA, when enabled via DISTRO_FEATURES (to be done at factory level).

This will cause the build to include a default IMA policy file that gets loaded by initrd.

Recommend reading both https://wiki.gentoo.org/wiki/Integrity_Measurement_Architecture and https://en.opensuse.org/SDB:Ima_evm for having a better understanding about IMA in general.