### PR TITLE
base: init-install-efi: fix compose-apps preloading

### DIFF
--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-module-install-efi/init-install-efi.sh
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-module-install-efi/init-install-efi.sh
@@ -223,6 +223,8 @@ if [ -d /run/media/$1/ostree/deploy/lmp/var/lib/docker ]; then
     cp -a /run/media/$1/ostree/deploy/lmp/var/sota/import/installed_versions /tgt_root/ostree/deploy/lmp/var/sota/import/
 fi
 if [ -d /run/media/$1/ostree/deploy/lmp/var/sota/compose-apps ]; then
+    # Delete preloaded containers previously available as part of rootfs.img (platform build)
+    rm -rf /tgt_root/ostree/deploy/lmp/var/sota/compose-apps
     cp -a /run/media/$1/ostree/deploy/lmp/var/sota/compose-apps /tgt_root/ostree/deploy/lmp/var/sota/compose-apps
 fi
 


### PR DESCRIPTION
Fix compose-apps preloading logic by making sure the older preloaded
content gets removed before copying over the ones available as part of
the EFI installer.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>