### PR TITLE
u-boot-ostree-scr-fit: boot-common: import only bootfirmware_version

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common.cmd.in
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common.cmd.in
@@ -4,7 +4,7 @@ setenv fio_msg "FIO:"
 # uEnv handling
 setenv bootcmd_resetvars 'setenv kernel_image; setenv bootargs; setenv kernel_image2; setenv bootargs2'
 setenv bootcmd_otenv 'run bootcmd_resetvars; ext4load ${devtype} ${devnum}:${rootpart} ${loadaddr} /boot/loader/uEnv.txt; env import -t ${loadaddr} ${filesize}'
-setenv bootcmd_bootenv 'setenv bootfirmware_version; ext4load ${devtype} ${devnum}:2 ${loadaddr} ${ostree_root}/usr/lib/firmware/version.txt; env import -t ${loadaddr} ${filesize}'
+setenv bootcmd_bootenv 'setenv bootfirmware_version; ext4load ${devtype} ${devnum}:2 ${loadaddr} ${ostree_root}/usr/lib/firmware/version.txt; env import -t ${loadaddr} ${filesize} bootfirmware_version'
 setenv bootcmd_getroot 'setexpr ostree_root gsub "^.*ostree=([^ ]*).*$" "\\\\1" "${bootargs}"'
 
 # Env saving


### PR DESCRIPTION
```
Provide explicitly bootfirmware_version as the only
variable that should be imported from version.txt.

For env import help:
env import [-d] [-t [-r] | -b | -c] addr [size] [var ...]
...

var... List of the names of the only variables that get
       imported from the environment at address 'addr'.
       Without arguments, the whole environment gets imported.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>
```