### PR TITLE
base: u-boot-ostree-scr-fit: ubootenv: initialize bootfirmware_version

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common.cmd.in
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common.cmd.in
@@ -38,6 +38,7 @@ else
 	if test -z "${rollback}"; then setenv rollback 0; setenv envsave 1; fi
 	if test -z "${upgrade_available}"; then setenv upgrade_available 0; setenv envsave 1; fi
 	if test -z "${bootupgrade_available}"; then setenv bootupgrade_available 0; setenv envsave 1; fi
+	if test -z "${bootfirmware_version}"; then run bootcmd_bootenv; setenv envsave 1; fi
 	# Call saveenv if not yet set (e.g. first boot after clean flash)
 	if test "${envsave}" = "1"; then setenv envsave; run saveenv_mmc; fi
 


### PR DESCRIPTION
Initialize bootfirmware_version to the version available at the rootfs
when performing initial boot after a clean flash (no valid
environment).

This helps aktualizr-lite to avoid doing unnecessary boot firmware
updates if nothing really changed from initial flash.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>