### PR TITLE
base: u-boot-ostree-scr-fit: save fiovb.is_secondary_boot state

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common.cmd.in
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common.cmd.in
@@ -133,6 +133,12 @@ if test "${fiovb.is_secondary_boot}" = "0"; then
 		imx_secondary_boot 0
 		reset
 	fi
+else
+	# Save fiovb.is_secondary_boot state for allowing userspace
+	# to easily identify the boot mode via environment
+	if test -z "${fiovb_rpmb}"; then
+		run saveenv_mmc
+	fi
 fi
 
 setenv bootcmd_load_f 'ext4load ${devtype} ${devnum}:${rootpart} ${fit_addr} "/boot"${kernel_image}'


### PR DESCRIPTION
Save fiovb.is_secondary_boot state for allowing userspace to
easily identify the boot mode via environment.

Only done with ubootenv as we don't have a variable in fiovb for
is_secondary_boot.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>