### PR TITLE
base: u-boot-fio: bump to 66b40b69abe

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2020.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2020.04.bb
@@ -1,4 +1,4 @@
 require u-boot-fio-common.inc
 
-SRCREV = "ee4483499f52aa26a80979b5013940cd5f92eb45"
+SRCREV = "7992f6974d7ce5b2c5202d91d91a3ef2c2c31690"
 SRCBRANCH = "2020.04+fio"


### PR DESCRIPTION
Relevant changes:
- 66b40b69abe [FIO internal] spl: enable hw_watchdog for non-dm case
- f9ae151ff88 [FIO internal] add mx7 and mx7ulp support
- e1ce3e1e25f [FIO internal] imx: add low level code for secondary boot in 7ulp
- f1c76782b30 [FIO extras] fiovb: return error on init if board not closed
- 8aaa110b909 [FIO internal] imx: drop imx_warm_reset workaround

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>