### PR TITLE
base: recipes-samples: lmp-image-common: dont crush sysconf_file

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -45,7 +45,7 @@ configure_rootfs_nss_altfiles () {
             *) continue ;;
         esac
         cp -a ${IMAGE_ROOTFS}${sysconfdir}/${sysconf_file} ${IMAGE_ROOTFS}${libdir}
-        echo "# Default file provided via NSS altfiles at ${libdir}/${sysconf_file}" > ${IMAGE_ROOTFS}${sysconfdir}/${sysconf_file}
+        echo "# Default file provided via NSS altfiles at ${libdir}/${sysconf_file}" >> ${IMAGE_ROOTFS}${sysconfdir}/${sysconf_file}
         # NSS altfiles should be right after files
         sed -i -e "/^${sysconf_file}/s/files/files altfiles/" ${IMAGE_ROOTFS}${sysconfdir}/nsswitch.conf
 


### PR DESCRIPTION
Let's not crush the original ${sysconf_file} and instead append.

Noted on new container builds which use network_mode="host" that
some errored out with localhost connection errors: bad host.

Reproduced with and tested on intel-corei7-64 MACHINE.

Turns:

fio@intel-corei7-64:~$ cat /usr/etc/hosts
127.0.1.1 intel-corei7-64

Into:

fio@intel-corei7-64:~$ cat /etc/hosts
127.0.0.1       localhost.localdomain           localhost

::1     localhost ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
127.0.1.1 intel-corei7-64
127.0.1.1 intel-corei7-64

Signed-off-by: Michael Scott <mike@foundries.io>