### PR TITLE
base: lmp: nss-altfiles: keep standard hosts

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -51,7 +51,7 @@ configure_rootfs_nss_altfiles () {
 
         # Defaults which can later be replaced by the user
         if [ "$type" = "hosts" ]; then
-            grep "^127.0.1.1" ${IMAGE_ROOTFS}${libdir}/${sysconf_file} >> ${IMAGE_ROOTFS}${sysconfdir}/${sysconf_file}
+            cat ${IMAGE_ROOTFS}${libdir}/${sysconf_file} >> ${IMAGE_ROOTFS}${sysconfdir}/${sysconf_file}
         elif [ "$type" = "pwd" ]; then
             grep "^${LMP_USER}:" ${IMAGE_ROOTFS}${libdir}/${sysconf_file} >> ${IMAGE_ROOTFS}${sysconfdir}/${sysconf_file}
         fi


### PR DESCRIPTION
Allow hosts to be managed via nss-altfiles, but keep the original
content in place as it is common for containers to bind/reuse /etc/hosts
directly, which is a problem when that gets provided by nss-altfiles.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>