### PR TITLE
Bump aklite version 3ceb809

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
@@ -12,7 +12,7 @@ Restart=always
 ExecStartPre=/usr/bin/mkdir -p /run/aktualizr
 Environment="TMPDIR=/run/aktualizr"
 Environment="COMPOSE_HTTP_TIMEOUT=@@COMPOSE_HTTP_TIMEOUT@@"
-ExecStart=/usr/bin/aktualizr-lite --update-lockfile /run/lock/aktualizr-lite-update daemon
+ExecStart=/usr/bin/aktualizr-lite daemon
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "master"
-SRCREV_lmp = "d2b77cd3e379d44b30211280aa2eb00f72fb4759"
+SRCREV_lmp = "ab345cceef098aac557bfc3a341eece7be023e7d"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
base: aktualizr-lite: bump to ab345cc
Relevant changes:
  - b94670a aklite: extend installation report with App state
  - d85c1ce apps: store and make use of App update state
  - 9bc4fc1 app: let dockerd manage App's container life
  - 14c21f2 aklite: add a system-wide lock for aklite
  - 3ceb809 aklite: remove the download and update locks

