### PR TITLE
base: wayland: weston-init: require lmp-wayland for files append

### DIFF
--- a/meta-lmp-base/recipes-graphics/wayland/weston-init.bbappend
+++ b/meta-lmp-base/recipes-graphics/wayland/weston-init.bbappend
@@ -1,15 +1,15 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI_append = " \
+SRC_URI_append_lmp-wayland = " \
     file://utilities-terminal.png \
     file://background.jpg \
 "
 
-FILES_${PN}_append = " \
+FILES_${PN}_append_lmp-wayland = " \
     ${datadir}/weston \
 "
 
-do_install_append() {
+do_install_append_lmp-wayland() {
     install -d ${D}${datadir}/weston/backgrounds
     install -d ${D}${datadir}/weston/icon
 


### PR DESCRIPTION
When building DISTRO=lmp-[x]wayland several files are setup for
the weston-init recipe.  The files themselves are under an
lmp-wayland directory.

However, the bbappend attempts to use them without qualification.

This results in the following messages whenever any DISTRO besides
lmp-[x]wayland builds weston-init (eventually resulting in a build break):
WARNING: build-xxx/conf/../../layers/openembedded-core/meta/recipes-graphics/wayland/weston-init.bb: Unable to get checksum for weston-init SRC_URI entry utilities-terminal.png: file could not be found
WARNING: build-xxx/conf/../../layers/openembedded-core/meta/recipes-graphics/wayland/weston-init.bb: Unable to get checksum for weston-init SRC_URI entry background.jpg: file could not be found
...
ERROR: weston-init-1.0-r0 do_fetch: Fetcher failure: Unable to find file file://utilities-terminal.png anywhere. The paths that were searched were:

Signed-off-by: Michael Scott <mike@foundries.io>