### PR TITLE
base: u-boot common add setting bootfirmware_version

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common.cmd.in
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common.cmd.in
@@ -62,6 +62,8 @@ if test "${fiovb.is_secondary_boot}" = "0"; then
 		if test ! $? -eq 0; then fiovb write_pvalue upgrade_available 0; fi
 		fiovb read_pvalue bootupgrade_available 4
 		if test ! $? -eq 0; then fiovb write_pvalue bootupgrade_available 0; fi
+		fiovb read_pvalue bootfirmware_version 128
+		if test ! $? -eq 0; then run bootcmd_bootenv; fiovb write_pvalue bootfirmware_version ${bootfirmware_version}; fi
 	fi
 
 	# Only update bootcount when upgrade_available is set and boot mode is


### PR DESCRIPTION
This will set the bootfirmware_version on a closed board if the
variable is not set, to the current version in rootfs.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>