### PR TITLE
base: aktualizr-lite: bump to df0760a

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "master"
-SRCREV_lmp = "ab345cceef098aac557bfc3a341eece7be023e7d"
+SRCREV_lmp = "df0760abc5149f1ceba544df47aa0442e234e1ca"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
Relevant changes:
- df0760a bootloader: update fw if bootfirmware_version is not set (#104)

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>