### PR TITLE
base: Remove prebuilt image logic

### DIFF
--- a/meta-lmp-base/classes/lmp.bbclass
+++ b/meta-lmp-base/classes/lmp.bbclass
@@ -23,26 +23,6 @@ IMAGE_CMD_ota_append () {
 		${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/sota/import/installed_versions \
 			${GARAGE_TARGET_NAME}-${target_version}
 	fi
-
-	if [ "${DOCKER_COMPOSE_APP_PRELOAD}" = "1" ]; then
-		if [ -n "${APP_IMAGES_PRELOADER}" ]; then
-			bbplain "Preloading Compose Apps of the given Target: ${GARAGE_TARGET_NAME}-${target_version}"
-
-			mkdir -p "${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/lib/docker"
-
-			${APP_IMAGES_PRELOADER} \
-				"${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/sota/import/installed_versions" \
-				"${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/lib/docker" \
-				--images-root-dir="${APP_IMAGES_ROOT_DIR}" \
-				--apps-tree-dir="${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/sota/compose-apps-tree" \
-				--apps-root-dir="${OTA_SYSROOT}/ostree/deploy/${OSTREE_OSNAME}/var/sota/compose-apps" \
-				--app-shortlist="${DOCKER_COMPOSE_APP_SHORTLIST}" \
-				--factory="${LMP_DEVICE_FACTORY}" \
-				--log-file="${APP_IMAGES_PRELOAD_LOG_FILE}"
-		else
-			bbwarn "Compose app preloading is turned on but an app preloader is not specified"
-		fi
-	fi
 }
 
 # LMP specific cleanups after the main ostree image from meta-updater


### PR DESCRIPTION
We are changing CI to trigger an "assemble-system-image" run that works
identical to our container builds. This gives us one code path that is
capable of dealing with our advanced tagging scenarios customers are
starting to hit.

Signed-off-by: Andy Doan <andy@foundries.io>