### PR TITLE
base: recipes-tpm: swtpm: drop home-dir param to fix parse error

### DIFF
--- a/meta-lmp-base/recipes-tpm/swtpm/swtpm_%.bbappend
+++ b/meta-lmp-base/recipes-tpm/swtpm/swtpm_%.bbappend
@@ -1,0 +1,12 @@
+# BUG STATEMENT:
+# Upstream recipe is breaking due to a parsing error when static IDs are enabled:
+# ERROR: build/conf/../../layers/meta-security/meta-tpm/recipes-tpm/swtpm/swtpm_0.2.0.bb: argument -d/--home-dir: expected one argument
+# ERROR: build/conf/../../layers/meta-security/meta-tpm/recipes-tpm/swtpm/swtpm_0.2.0.bb: swtpm: Unable to parse arguments for USERADD_PARAM_swtpm '--system -g tss --home-dir      --no-create-home  --shell /bin/false swtpm':
+# ERROR: Failed to parse recipe: build/conf/../../layers/meta-security/meta-tpm/recipes-tpm/swtpm/swtpm_0.2.0.bb
+#
+# FIX:
+# Drop --home-dir
+#
+# TODO: Submit upstream
+USERADD_PARAM_${PN} = "--system -g ${TSS_GROUP} \
+    --no-create-home --shell /bin/false ${BPN}"


### PR DESCRIPTION
When static user IDs are enabled, the build breaks on swtpm recipe:

ERROR: build/conf/../../layers/meta-security/meta-tpm/recipes-tpm/swtpm/swtpm_0.2.0.bb: argument -d/--home-dir: expected one argument
ERROR: build/conf/../../layers/meta-security/meta-tpm/recipes-tpm/swtpm/swtpm_0.2.0.bb: swtpm: Unable to parse arguments for USERADD_PARAM_swtpm '--system -g tss --home-dir      --no-create-home  --shell /bin/false swtpm':
ERROR: Failed to parse recipe: build/conf/../../layers/meta-security/meta-tpm/recipes-tpm/swtpm/swtpm_0.2.0.bb

The --home-dir parameter requires an argument according to the parser.

This fix should be discussed upstream.

Upstream-Status: Pending

Signed-off-by: Michael Scott <mike@foundries.io>