### PR TITLE
wpausb: point to correct gpl-2.0 license.

### DIFF
--- a/meta-lmp-base/recipes-kernel/wpanusb/wpanusb_git.bb
+++ b/meta-lmp-base/recipes-kernel/wpanusb/wpanusb_git.bb
@@ -4,7 +4,7 @@ SUMMARY = "SoftMAC 802.15.4 kernel driver"
 HOMEPAGE = "https://github.com/foundriesio/wpanusb"
 SECTION = "kernel/network"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
 SRC_URI = "git://github.com/foundriesio/wpanusb.git"
 


### PR DESCRIPTION
WARNING: wpanusb-git-r0 do_populate_lic: Could not copy license file /build/layers/poky/meta/files/common-licenses/GPL-2.0 to /build/project/tmp/work/qemuarm64-lmp-linux/wpanusb/git-r0/license-destdir/wpanusb/GPL-2.0: [Errno 2] No such file or directory: '/build/layers/poky/meta/files/common-licenses/GPL-2.0'
ERROR: wpanusb-git-r0 do_populate_lic: QA Issue: wpanusb: LIC_FILES_CHKSUM points to an invalid file: /build/layers/poky/meta/files/common-licenses/GPL-2.0 [license-checksum]
ERROR: wpanusb-git-r0 do_populate_lic: Fatal QA errors found, failing task.

Signed-off-by: Jeremy Puhlman <jpuhlman@mvista.com>