### PR TITLE
base: ostree: patch to setup a curl request timeout

### DIFF
--- a/meta-lmp-base/recipes-extended/ostree/ostree/0001-ostree-pull-set-request-timeout.patch
+++ b/meta-lmp-base/recipes-extended/ostree/ostree/0001-ostree-pull-set-request-timeout.patch
@@ -1,0 +1,21 @@
+diff --git a/src/libostree/ostree-fetcher-curl.c b/src/libostree/ostree-fetcher-curl.c
+index 0ce3ff00..d50d62e7 100644
+--- a/src/libostree/ostree-fetcher-curl.c
++++ b/src/libostree/ostree-fetcher-curl.c
+@@ -817,6 +817,16 @@ initiate_next_curl_request (FetcherRequest *req,
+   curl_easy_setopt (req->easy, CURLOPT_WRITEDATA, task);
+   curl_easy_setopt (req->easy, CURLOPT_PROGRESSDATA, task);
+ 
++
++  /* set a request timeout, make sure it's not 0, otherwise an overall ostree pull session might hang */
++  long curl_timeout = 0L;
++  const char* curl_timeout_str = g_getenv ("OSTREE_CURL_TIMEOUT");
++  if (curl_timeout_str != NULL)
++    curl_timeout = atoi(curl_timeout_str);
++  if (curl_timeout == 0)
++    curl_timeout = 600L;
++  curl_easy_setopt (req->easy, CURLOPT_TIMEOUT, curl_timeout);
++
+   CURLMcode multi_rc = curl_multi_add_handle (self->multi, req->easy);
+   g_assert (multi_rc == CURLM_OK);
+ }

--- a/meta-lmp-base/recipes-extended/ostree/ostree_%.bbappend
+++ b/meta-lmp-base/recipes-extended/ostree/ostree_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append = " \
+    file://0001-ostree-pull-set-request-timeout.patch \
+"


### PR DESCRIPTION
Set a timeout for an overall request processing in order to avoid an
ostree pull/fetch API call or CLI command hang.
The timeout value can be specified via an env variable OSTREE_CURL_TIMEOUT,
if not defined, or equal to zero or it cannot be converted to a long type then
the default value is set.

Signed-off-by: Mike Sul <mike.sul@foundries.io>