### PR TITLE
base: aktualizr-lite: bump to 4999fa0

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "master"
-SRCREV_lmp = "df0760abc5149f1ceba544df47aa0442e234e1ca"
+SRCREV_lmp = "4999fa003da1a3ee95e426c7e46b471966be5d6d"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
Relevant changes:
    - 4999fa0 apps: use DEBUG level msg if no app state file
    - 273ee00: fixup! add dummy 'update-lockfile' param for
      backward compatibility with older LmP versions

Signed-off-by: Mike Sul <mike.sul@foundries.io>