### PR TITLE
base: docker-moby: patch dockerd to increase timeouts

### DIFF
--- a/meta-lmp-base/recipes-containers/docker/docker-moby.bb
+++ b/meta-lmp-base/recipes-containers/docker/docker-moby.bb
@@ -49,6 +49,7 @@ SRC_URI = "\
 	file://cli-config-support-default-system-config.patch \
 	file://increase_containerd_timeouts.patch \
 	file://dockerd-daemon-reload-image-store-on-a-hup-signal.patch \
+	file://0001-registry-increase-TLS-and-connection-timeouts.patch \
 	"
 
 require recipes-containers/docker/docker.inc

--- a/meta-lmp-base/recipes-containers/docker/docker-moby/0001-registry-increase-TLS-and-connection-timeouts.patch
+++ b/meta-lmp-base/recipes-containers/docker/docker-moby/0001-registry-increase-TLS-and-connection-timeouts.patch
@@ -1,0 +1,81 @@
+From dad27a99a51fa58c26bef209f2370d85992a2895 Mon Sep 17 00:00:00 2001
+From: Mike Sul <mike.sul@foundries.io>
+Date: Wed, 30 Jun 2021 15:06:05 +0300
+Subject: [PATCH] registry: increase TLS and connection timeouts
+
+Signed-off-by: Mike Sul <mike.sul@foundries.io>
+---
+ distribution/registry.go | 4 ++--
+ registry/auth.go         | 4 ++--
+ registry/registry.go     | 4 ++--
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/import/distribution/registry.go b/src/import/distribution/registry.go
+index 2e031847c0..bae5df68a2 100644
+--- a/src/import/distribution/registry.go
++++ b/src/import/distribution/registry.go
+@@ -66,7 +66,7 @@ func NewV2Repository(
+ 	}
+ 
+ 	direct := &net.Dialer{
+-		Timeout:   30 * time.Second,
++		Timeout:   60 * time.Second,
+ 		KeepAlive: 30 * time.Second,
+ 		DualStack: true,
+ 	}
+@@ -75,7 +75,7 @@ func NewV2Repository(
+ 	base := &http.Transport{
+ 		Proxy:               http.ProxyFromEnvironment,
+ 		DialContext:         direct.DialContext,
+-		TLSHandshakeTimeout: 10 * time.Second,
++		TLSHandshakeTimeout: 60 * time.Second,
+ 		TLSClientConfig:     endpoint.TLSConfig,
+ 		// TODO(dmcgowan): Call close idle connections when complete and use keep alive
+ 		DisableKeepAlives: true,
+diff --git a/src/import/registry/auth.go b/src/import/registry/auth.go
+index 2d0ecde2d4..3541cb0de2 100644
+--- a/src/import/registry/auth.go
++++ b/src/import/registry/auth.go
+@@ -146,7 +146,7 @@ func v2AuthHTTPClient(endpoint *url.URL, authTransport http.RoundTripper, modifi
+ 
+ 	return &http.Client{
+ 		Transport: tr,
+-		Timeout:   15 * time.Second,
++		Timeout:   60 * time.Second,
+ 	}, foundV2, nil
+ 
+ }
+@@ -211,7 +211,7 @@ func PingV2Registry(endpoint *url.URL, transport http.RoundTripper) (challenge.M
+ 
+ 	pingClient := &http.Client{
+ 		Transport: transport,
+-		Timeout:   15 * time.Second,
++		Timeout:   60 * time.Second,
+ 	}
+ 	endpointStr := strings.TrimRight(endpoint.String(), "/") + "/v2/"
+ 	req, err := http.NewRequest(http.MethodGet, endpointStr, nil)
+diff --git a/src/import/registry/registry.go b/src/import/registry/registry.go
+index 7a70bf28b5..60c8cae303 100644
+--- a/src/import/registry/registry.go
++++ b/src/import/registry/registry.go
+@@ -181,7 +181,7 @@ func NewTransport(tlsConfig *tls.Config) *http.Transport {
+ 	}
+ 
+ 	direct := &net.Dialer{
+-		Timeout:   30 * time.Second,
++		Timeout:   60 * time.Second,
+ 		KeepAlive: 30 * time.Second,
+ 		DualStack: true,
+ 	}
+@@ -189,7 +189,7 @@ func NewTransport(tlsConfig *tls.Config) *http.Transport {
+ 	base := &http.Transport{
+ 		Proxy:               http.ProxyFromEnvironment,
+ 		DialContext:         direct.DialContext,
+-		TLSHandshakeTimeout: 10 * time.Second,
++		TLSHandshakeTimeout: 60 * time.Second,
+ 		TLSClientConfig:     tlsConfig,
+ 		// TODO(dmcgowan): Call close idle connections when complete and use keep alive
+ 		DisableKeepAlives: true,
+-- 
+2.17.1
+


### PR DESCRIPTION
- increase TLS connection timeout (10s is too low for poor network condition);
- increase ping & host resolution timeout
- increase an overall connection timeout.

Signed-off-by: Mike Sul <mike.sul@foundries.io>