### PR TITLE
base: docker: add pigz to rdepends

### DIFF
--- a/meta-lmp-base/recipes-containers/docker/docker-lmp.inc
+++ b/meta-lmp-base/recipes-containers/docker/docker-lmp.inc
@@ -27,4 +27,7 @@ do_install_append() {
     fi
 }
 
+# pigz takes advantage of both multiple CPUs and multiple CPU cores for higher
+# compression and decompression speed, and also set at the official packages
+RDEPENDS_${PN} += "pigz"
 FILES_${PN} += "${libdir}/docker"


### PR DESCRIPTION
pigz takes advantage of both multiple CPUs and multiple
CPU cores for higher compression and decompression speed,
and also set at the official packages.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>