### PR TITLE
base: recipes-support resize helper needs to be more forceful

### DIFF
--- a/meta-lmp-base/recipes-support/mfgtool-resize-helper/mfgtool-resize-helper/mfgtool-resize-helper
+++ b/meta-lmp-base/recipes-support/mfgtool-resize-helper/mfgtool-resize-helper/mfgtool-resize-helper
@@ -28,5 +28,5 @@ echo "CMD: ${PARTED} ---pretend-input-tty ${ROOT_DEVICE} resizepart ${PART_ENTRY
 
 echo -e '100%' | ${PARTED} ---pretend-input-tty ${ROOT_DEVICE} resizepart ${PART_ENTRY_NUMBER}
 ${PARTPROBE} --summary
-${E2FSCK} -f -p "${ROOT_DEVICE}p${PART_ENTRY_NUMBER}"
-${RESIZE2FS} "${ROOT_DEVICE}p${PART_ENTRY_NUMBER}"
+${E2FSCK} -f -y "${ROOT_DEVICE}p${PART_ENTRY_NUMBER}"
+${RESIZE2FS} -f "${ROOT_DEVICE}p${PART_ENTRY_NUMBER}"


### PR DESCRIPTION
The -p option on e2fsck is not enough to make sure the partition is clean for resizing
so change it to a -y so it will fix.

Then resize may still want e2fsck but since we just did it, we can force resize2fs to
do the resize anyway.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>