### PR TITLE
Initial implementation for ostree factory reset

### DIFF
--- a/meta-lmp-base/classes/lmp.bbclass
+++ b/meta-lmp-base/classes/lmp.bbclass
@@ -32,6 +32,8 @@ IMAGE_CMD_ostree_append () {
 
 	# Prefer /usr/lib/tmpfiles.d instead of /etc
 	mv usr/etc/tmpfiles.d/00ostree-tmpfiles.conf usr/lib/tmpfiles.d
+	# Cover missing /var/rootdirs/home (pending in meta-updater)
+	echo "d /var/rootdirs/home 0755 root root -" >> usr/lib/tmpfiles.d/00ostree-tmpfiles.conf
 
 	# Update default home path (compatible with nss alt files)
 	sed -i -e 's,:/home,:/var/rootdirs/home,g' usr/etc/passwd

--- a/meta-lmp-base/recipes-core/images/initramfs-ostree-lmp-image.bb
+++ b/meta-lmp-base/recipes-core/images/initramfs-ostree-lmp-image.bb
@@ -4,6 +4,7 @@ PACKAGE_INSTALL = "initramfs-framework-base \
 	initramfs-module-udev \
 	initramfs-module-rootfs \
 	initramfs-module-ostree \
+	initramfs-module-ostree-factory-reset \
 	${VIRTUAL-RUNTIME_base-utils} \
 	${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'initramfs-framework-ima', '', d)} \
 	udev base-passwd e2fsprogs-e2fsck \

--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework/ostree_factory_reset
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework/ostree_factory_reset
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Copyright (C) 2021 Foundries.io Ltd
+#
+# SPDX-License-Identifier: MIT
+
+OSTREE_DISTRO="lmp"
+FACTORY_RESET_TAG=".factory_reset"
+FACTORY_RESET_KEEP_SOTA_TAG=".factory_reset_keep_sota"
+FACTORY_RESET_KEEP_SOTA_DOCKER_TAG=".factory_reset_keep_sota_docker"
+
+ostree_factory_reset_enabled() {
+	return 0
+}
+
+factory_reset() {
+	keep_sota=$1
+	keep_docker=$2
+
+	msg "Performing factory reset..."
+
+	# Replace /etc/ with /usr/etc (from deployment)
+	rm -rf ${ROOTFS_DIR}/etc
+	cp -a ${ROOTFS_DIR}/usr/etc ${ROOTFS_DIR}/
+	# TODO: Handle use case when var is provided via a separated partition
+	OSTREE_VAR="${ROOTFS_DIR}/sysroot/ostree/deploy/${OSTREE_DISTRO}/var"
+
+	# Filter of what not to remove (at /var root level)
+	FIND_EXCLUDE="! -name '.' ! -name '..' ! -name '${FACTORY_RESET_TAG}' \
+		! -name '${FACTORY_RESET_KEEP_SOTA_TAG}' ! -name '${FACTORY_RESET_KEEP_SOTA_DOCKER_TAG}'"
+	if [ "${keep_sota}" = "true" ]; then
+		msg "Keeping current ${OSTREE_DISTRO} SOTA content"
+		FIND_EXCLUDE="${FIND_EXCLUDE} ! -name 'sota'"
+	fi
+	if [ "${keep_docker}" = "true" ]; then
+		msg "Keeping current docker content"
+		FIND_EXCLUDE="${FIND_EXCLUDE} ! -name 'lib'"
+	fi
+
+	# Clear /var, stored under the shared ostree folder, not
+	# available after prepare-root (mounted later by systemd)
+	cd ${OSTREE_VAR}
+	eval find . -maxdepth 1 ${FIND_EXCLUDE} -exec rm -rf {} "';'"
+	if [ "${keep_docker}" = "true" ] && [ -d lib ]; then
+		find lib -maxdepth 1 ! -name "lib" ! -name "docker" -exec rm -rf {} ';'
+	else
+		rm -rf sota/compose-apps*
+	fi
+	cd - >/dev/null
+
+	# TODO: Erase HSM/Secure storage content?
+	# TODO: U-Boot/fiovb env?
+}
+
+ostree_factory_reset_run() {
+	FACTORY_RESET_TAG_PATH="${ROOTFS_DIR}/sysroot/ostree/deploy/${OSTREE_DISTRO}/var/${FACTORY_RESET_TAG}"
+	FACTORY_RESET_KEEP_SOTA_TAG_PATH="${ROOTFS_DIR}/sysroot/ostree/deploy/${OSTREE_DISTRO}/var/${FACTORY_RESET_KEEP_SOTA_TAG}"
+	FACTORY_RESET_KEEP_SOTA_DOCKER_TAG_PATH="${ROOTFS_DIR}/sysroot/ostree/deploy/${OSTREE_DISTRO}/var/${FACTORY_RESET_KEEP_SOTA_DOCKER_TAG}"
+
+	# Only run after ostree-prepare-root
+	if [ -n "${ROOTFS_DIR}" ] && [ -h "${ROOTFS_DIR}/ostree" ]; then
+		if [ -f "${FACTORY_RESET_TAG_PATH}" ]; then
+			factory_reset "false" "false"
+			rm -f ${FACTORY_RESET_TAG_PATH} ${FACTORY_RESET_KEEP_SOTA_TAG_PATH} ${FACTORY_RESET_KEEP_SOTA_DOCKER_TAG_PATH}
+		elif [ -f "${FACTORY_RESET_KEEP_SOTA_TAG_PATH}" ]; then
+			factory_reset "true" "false"
+			rm -f ${FACTORY_RESET_TAG_PATH} ${FACTORY_RESET_KEEP_SOTA_TAG_PATH} ${FACTORY_RESET_KEEP_SOTA_DOCKER_TAG_PATH}
+		elif [ -f "${FACTORY_RESET_KEEP_SOTA_DOCKER_TAG_PATH}" ]; then
+			factory_reset "true" "true"
+			rm -f ${FACTORY_RESET_TAG_PATH} ${FACTORY_RESET_KEEP_SOTA_TAG_PATH} ${FACTORY_RESET_KEEP_SOTA_DOCKER_TAG_PATH}
+		fi
+	else
+		msg "No ostree deployment found"
+	fi
+}

--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -2,15 +2,21 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += " \
 	file://ostree \
+	file://ostree_factory_reset \
 	file://run-tmpfs.patch \
 "
 
-PACKAGES_append = " initramfs-module-ostree"
+PACKAGES_append = " initramfs-module-ostree initramfs-module-ostree-factory-reset"
 
 SUMMARY_initramfs-module-ostree = "initramfs support for ostree based filesystems"
 RDEPENDS_initramfs-module-ostree = "${PN}-base ostree-switchroot"
 FILES_initramfs-module-ostree = "/init.d/98-ostree"
 
+SUMMARY_initramfs-module-ostree-factory-reset = "initramfs support for ostree based filesystems"
+RDEPENDS_initramfs-module-ostree-factory-reset = "${PN}-base ostree-switchroot"
+FILES_initramfs-module-ostree-factory-reset = "/init.d/98-ostree_factory_reset"
+
 do_install_append() {
 	install -m 0755 ${WORKDIR}/ostree ${D}/init.d/98-ostree
+	install -m 0755 ${WORKDIR}/ostree_factory_reset ${D}/init.d/98-ostree_factory_reset
 }

--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -28,6 +28,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     lmp-boot-firmware \
     networkmanager \
     nss-altfiles \
+    pam-plugin-mkhomedir \
     resize-helper \
     sudo \
 "
@@ -65,6 +66,9 @@ configure_rootfs_nss_altfiles () {
 fakeroot do_populate_rootfs_common_src () {
     # Allow sudo group users to use sudo
     install -m 0440 ${WORKDIR}/sudoers ${IMAGE_ROOTFS}${sysconfdir}/sudoers.d/50-lmp
+
+    # Enable pam_mkhomedir (requires pam-plugin-mkhomedir to be installed)
+    echo "session required pam_mkhomedir.so silent skel=/etc/skel/ umask=0022" >> ${IMAGE_ROOTFS}${sysconfdir}/pam.d/common-session
 }
 
 IMAGE_PREPROCESS_COMMAND += "do_populate_rootfs_common_src; "

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr/tmpfiles.conf
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr/tmpfiles.conf
@@ -1,0 +1,1 @@
+d /var/sota 0700 root root -

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -8,6 +8,7 @@ SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;branch=${BRANCH};na
     file://aktualizr-lite.service.in \
     file://aktualizr-secondary.service \
     file://aktualizr-serialcan.service \
+    file://tmpfiles.conf \
     file://10-resource-control.conf \
     ${@ d.expand("https://tuf-cli-releases.ota.here.com/cli-${GARAGE_SIGN_PV}.tgz;unpack=0;name=garagesign") if not oe.types.boolean(d.getVar('GARAGE_SIGN_AUTOVERSION')) else ''} \
 "
@@ -45,9 +46,11 @@ do_install_prepend_lmp() {
     [ -e ${B}/src ] || ln -s ${B}/aktualizr/src ${B}/src
 }
 
-do_install_append() {
+do_install_append_lmp() {
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/aktualizr-lite.service ${D}${systemd_system_unitdir}/
+    install -d ${D}${nonarch_libdir}/tmpfiles.d
+    install -m 0644 ${WORKDIR}/tmpfiles.conf ${D}${nonarch_libdir}/tmpfiles.d/aktualizr-lite.conf
 }
 
 PACKAGES += "${PN}-get ${PN}-lite"
@@ -56,3 +59,5 @@ FILES_${PN}-lite = "${bindir}/aktualizr-lite"
 
 # Force same RDEPENDS, packageconfig rdepends common to both
 RDEPENDS_${PN}-lite = "${RDEPENDS_aktualizr}"
+
+FILES_${PN}-lite += "${nonarch_libdir}/tmpfiles.d/aktualizr-lite.conf"


### PR DESCRIPTION
On ostree-based systems there are basically 2 locations for rw content, /etc and /var.

As the original /etc (when creating the rootfs) is also stored under /usr/etc on the same deployment (and used during the 3-way merge for updating /etc when applying an update), it is easy to handle as we can simply just erase /etc and restore from what is available at /usr/etc.

As the system is able to manage an empty /var (which is the case during first boot) and recreate all the require directories and files (via systemd tmpfiles.d), we don't need to do much here besides just removing it entirely. While /var can be completely removed, we also have use cases for requiring /var/sota to stay (e.g. not wiping the device registration), so we need to allow the user to decide what to wipe.

As a way to trigger the factory reset, 3 stamp files where created:
 - /var/.factory_reset: sync /etc and wipes /var
 - /var/.factory_reset_keep_sota: sync /etc and wipes everything on /var but /var/sota
 - /var/.factory_reset_keep_sota_docker: sync /etc and wipes everything on /var but /var/sota and /var/lib/docker

TODO/Unknowns:
 - Decide what to do about u-boot env/fiovb
 - What to do when the original image had preloaded containers?