### PR TITLE
base: ostree: increase default curl request timeout

### DIFF
--- a/meta-lmp-base/recipes-extended/ostree/ostree/0001-ostree-pull-set-request-timeout.patch
+++ b/meta-lmp-base/recipes-extended/ostree/ostree/0001-ostree-pull-set-request-timeout.patch
@@ -24,7 +24,7 @@ index d6534b46..1253da29 100644
 +  if (curl_timeout_str != NULL)
 +    curl_timeout = atoi(curl_timeout_str);
 +  if (curl_timeout == 0)
-+    curl_timeout = 600L;
++    curl_timeout = 780L;
 +  curl_easy_setopt (req->easy, CURLOPT_TIMEOUT, curl_timeout);
 +
    CURLMcode multi_rc = curl_multi_add_handle (self->multi, req->easy);


### PR DESCRIPTION
Increase the default curl request timeout up to 13 minutes. We cannot set higher than ~ 15m because of this issue https://github.com/ostreedev/ostree/issues/2383.
It can be critical in the case of big files pulling through the network with limited bandwidth. libostree doesn't do a resumable download of a single file, so if a timeout occurs then the subsequent file download retry starts from the beginning, which might lead to endless retries...
This change slightly improves chances to succeed. In addition to this, I am going to limit the maximum allowed file size in the rootfs that LmP build generates (currently it's set to 4GB).

Signed-off-by: Mike Sul <mike.sul@foundries.io>