### PR TITLE
base: u-boot-tools: fix a mkimage signature issue

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-tools/0001-tools-image-host-fix-wrong-return-value.patch
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-tools/0001-tools-image-host-fix-wrong-return-value.patch
@@ -1,0 +1,39 @@
+From 033a668779c4bd808c05a90702bb59d01114ee72 Mon Sep 17 00:00:00 2001
+From: Ming Liu <liu.ming50@gmail.com>
+Date: Mon, 31 May 2021 09:04:51 +0200
+Subject: [PATCH] tools: image-host: fix wrong return value
+
+The return value '-ENOSPC' of fit_set_timestamp function does not match
+the caller fit_image_write_sig's expection which is '-FDT_ERR_NOSPACE'.
+
+Fix it by not calling fit_set_timestamp, but call fdt_setprop instead.
+
+This fixes a following mkimage error:
+| Can't write signature for 'signature@1' signature node in
+| 'conf@imx6ull-colibri-wifi-eval-v3.dtb' conf node: <unknown error>
+| mkimage Can't add hashes to FIT blob: -1
+
+Signed-off-by: Ming Liu <liu.ming50@gmail.com>
+---
+ tools/image-host.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/tools/image-host.c b/tools/image-host.c
+index 270d36fe45..73095461a7 100644
+--- a/tools/image-host.c
++++ b/tools/image-host.c
+@@ -132,8 +132,10 @@ static int fit_image_write_sig(void *fit, int noffset, uint8_t *value,
+ 	if (!ret) {
+ 		time_t timestamp = imagetool_get_source_date(cmdname,
+ 							     time(NULL));
++		uint32_t t = cpu_to_uimage(timestamp);
+ 
+-		ret = fit_set_timestamp(fit, noffset, timestamp);
++		ret = fdt_setprop(fit, noffset, FIT_TIMESTAMP_PROP, &t,
++			sizeof(uint32_t));
+ 	}
+ 	if (region_prop && !ret) {
+ 		uint32_t strdata[2];
+-- 
+2.30.2
+

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-tools_%.bbappend
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-tools_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-tools-image-host-fix-wrong-return-value.patch"


### PR DESCRIPTION
```
Backport patch from [1], which fixes FIT signing issues. Details:
A following error was observed:
| Can't write signature for 'signature@1' signature node in
| 'conf@imx6ull-colibri-wifi-eval-v3.dtb' conf node: <unknown error>
| uboot-mkimage Can't add hashes to FIT blob: -1

This is caused by a wrong return value being used in uboot source.

The return value '-ENOSPC' of fit_set_timestamp function does not match
the caller fit_image_write_sig's expection which is '-FDT_ERR_NOSPACE'.

Fix it by not calling fit_set_timestamp, but call fdt_setprop instead.

[1] http://git.yoctoproject.org/cgit.cgi/poky/commit/?id=e9fa8f9001471bb240e997cb4537d2f617f22957
Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>
```