### PR TITLE
base: lmp-wayland: triggering system default target

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-feature-wayland.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-wayland.inc
@@ -6,3 +6,4 @@ CORE_IMAGE_BASE_INSTALL += " \
     wayland \
     ${@bb.utils.contains("DISTRO_FEATURES", "x11 wayland", "weston-xwayland", "", d)} \
 "
+IMAGE_FEATURES += '${@bb.utils.contains('DISTRO_FEATURES', 'wayland', ' weston', '', d)}'


### PR DESCRIPTION
rootfs-postcommands.bbclass changes the	system default target to
graphical.target if IMAGE_FEATURES contains x11-base or weston.
This patch checks for wayland on DISTRO_FEATURE and if finds it adds
weston to IMAGE_FEATURES.