### PR TITLE
base: lmp-passwd/group: add weston/wayland user and group

### DIFF
--- a/meta-lmp-base/files/lmp-group-table
+++ b/meta-lmp-base/files/lmp-group-table
@@ -44,6 +44,8 @@ pwm:x:54:
 games:x:60:
 render:x:61:
 weston-launch:x:62:
+weston:x:63:
+wayland:x:64:
 shutdown:x:70:
 nobody:*:99:
 users:x:100:

--- a/meta-lmp-base/files/lmp-passwd-table
+++ b/meta-lmp-base/files/lmp-passwd-table
@@ -15,6 +15,7 @@ backup:x:34:34:backup:/var/backups:/bin/sh
 list:x:38:38:Mailing List Manager:/var/list:/bin/sh
 irc:x:39:39:ircd:/var/run/ircd:/bin/sh
 gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/bin/sh
+weston:x:63:63::/home/weston:/bin/false
 nm-openvpn:x:975:975::/home/nm-openvpn:/bin/sh
 mosquitto:x:976:976::/home/mosquitto:/bin/false
 dhcpcd:x:977:977::/var/lib/dhcpcd:/bin/false


### PR DESCRIPTION
Required and used by the weston and weston-init recipe.