### PR TITLE
base: wayland: weston: Installing weston-screenshooter

### DIFF
--- a/meta-lmp-base/recipes-graphics/wayland/weston_%.bbappend
+++ b/meta-lmp-base/recipes-graphics/wayland/weston_%.bbappend
@@ -1,0 +1,1 @@
+FILES_${PN} += " ${bindir}/weston-screenshooter "


### PR DESCRIPTION
To add the possibility of capture a screenshot with (super + s),
    weston-screenshooter needed to be installed.