### PR TITLE
base: wayland: weston-init: Add $OPTARGS

### DIFF
--- a/meta-lmp-base/recipes-graphics/wayland/weston-init.bbappend
+++ b/meta-lmp-base/recipes-graphics/wayland/weston-init.bbappend
@@ -3,6 +3,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_append_lmp-wayland = " \
     file://utilities-terminal.png \
     file://background.jpg \
+    file://weston.env \
+    file://weston.service.patch \
 "
 
 FILES_${PN}_append_lmp-wayland = " \

--- a/meta-lmp-base/recipes-graphics/wayland/weston-init/lmp-wayland/weston.env
+++ b/meta-lmp-base/recipes-graphics/wayland/weston-init/lmp-wayland/weston.env
@@ -1,0 +1,1 @@
+OPTARGS=--continue-without-input

--- a/meta-lmp-base/recipes-graphics/wayland/weston-init/lmp-wayland/weston.service.patch
+++ b/meta-lmp-base/recipes-graphics/wayland/weston-init/lmp-wayland/weston.service.patch
@@ -1,0 +1,11 @@
+--- weston-init/weston.service	2021-07-14 19:28:08.215047280 -0300
++++ weston-init/weston.service_new	2021-07-14 19:37:25.339173787 -0300
+@@ -34,7 +34,7 @@
+ # Requires systemd-notify.so Weston plugin.
+ Type=notify
+ EnvironmentFile=/etc/default/weston
+-ExecStart=/usr/bin/weston --modules=systemd-notify.so
++ExecStart=/usr/bin/weston --modules=systemd-notify.so $OPTARGS
+ 
+ # Optional watchdog setup
+ TimeoutStartSec=60


### PR DESCRIPTION
- Some devices do not launch weston without the input device connected.
  Looks like the configuration on weston.ini [core] require-input=bool
  is not the same as --continue-without-input.
  According to this issue, it will be fixed in the next version:
  https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/524

Signed-off-by: Raul Muñoz <raul@foundries.io>