### PR TITLE
base: wayland: weston-init: Uncomment Assignments

### DIFF
--- a/meta-lmp-base/recipes-graphics/wayland/weston-init.bbappend
+++ b/meta-lmp-base/recipes-graphics/wayland/weston-init.bbappend
@@ -9,10 +9,25 @@ FILES_${PN}_append_lmp-wayland = " \
     ${datadir}/weston \
 "
 
+INI_UNCOMMENT_ASSIGNMENTS = " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11 wayland', 'xwayland=true', '', d)} \
+"
+
+uncomment() {
+    if ! grep -q "^#$1" $2 && ! grep -q "^$1" $2; then
+        bbwarn "Commented setting '#$1' not found in file $2"
+    fi
+    sed -i -e 's,^#'"$1"','"$1"',g' $2
+}
+
 do_install_append_lmp-wayland() {
     install -d ${D}${datadir}/weston/backgrounds
     install -d ${D}${datadir}/weston/icon
 
     install -m 0644 ${WORKDIR}/utilities-terminal.png ${D}${datadir}/weston/icon/utilities-terminal.png
     install -m 0644 ${WORKDIR}/background.jpg ${D}${datadir}/weston/backgrounds/background.jpg
+
+    for assignment in ${INI_UNCOMMENT_ASSIGNMENTS}; do
+        uncomment "$assignment" ${D}${sysconfdir}/xdg/weston/weston.ini
+    done
 }


### PR DESCRIPTION
meta-freescale implements a function to uncomment assignments like

This function is just available if meta-freescale is included.
The commit will duplicate the function and add the set
INI_UNCOMMENT_ASSIGNMENTS for x11 wayland distro regardless of
the board.

Tested with and without meta-freescale.

Signed-off-by: Raul Muñoz <raul@foundries.io>