### PR TITLE
base: lmp: add support for ETC_GROUP_MEMBERS

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -48,6 +48,8 @@ PACKAGECONFIG_append_pn-networkmanager = " nss"
 
 # Alternatives used by nss-altfiles
 NSS_ALT_TYPES ?= "hosts,pwd,grp,spwd,sgrp"
+# Unix groups that will be mirrored in /etc/group to allow manipulation
+ETC_GROUP_MEMBERS ?= "sudo audio video plugdev users docker"
 
 # Use staticids for deterministic uid/gid values
 USERADDEXTENSION = "useradd-staticids"

--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -54,6 +54,10 @@ configure_rootfs_nss_altfiles () {
             cat ${IMAGE_ROOTFS}${libdir}/${sysconf_file} >> ${IMAGE_ROOTFS}${sysconfdir}/${sysconf_file}
         elif [ "$type" = "pwd" ]; then
             grep "^${LMP_USER}:" ${IMAGE_ROOTFS}${libdir}/${sysconf_file} >> ${IMAGE_ROOTFS}${sysconfdir}/${sysconf_file}
+        elif [ "$type" = "grp" ]; then
+            for gmember in ${ETC_GROUP_MEMBERS}; do
+                grep "^${gmember}:" ${IMAGE_ROOTFS}${libdir}/${sysconf_file} >> ${IMAGE_ROOTFS}${sysconfdir}/${sysconf_file} || true
+            done
         fi
     done
 }


### PR DESCRIPTION
Currently a normal user is unable to change the group list for a user
based on normal tooling (e.g. useradd/usermod), as the main group file
is provided by nss-altfiles (ro - /usr/lib/group) and not by /etc/group.

Follow the same solution as done in rpm-ostree and define a list of
groups that should be mirrored from /usr/lib/group to /etc/group when
creating the image. This should be used for groups that are commonly
changed by the user at runtime (e.g. when adding a new user) such as
audio, sudo and video. Build time groups and users can stay at
nss-altfiles (getgrent will do a merge based on what is configured in
nsswitch.conf).

Reference change from rpm-ostree:
https://github.com/coreos/rpm-ostree/commit/9a2007389337c61c152ea6e89575436e4fe5b1c0

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>