### PR TITLE
bsp: mfgtool-files: update fit separator

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot.cmd
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot.cmd
@@ -7,4 +7,4 @@ env import -t ${loadaddr} ${filesize}
 
 load ${devtype} ${devnum}:2 ${loadaddr} "/boot"${kernel_image}
 
-bootm ${loadaddr}#conf@${fdtfile}
+bootm ${loadaddr}#conf-${fdtfile}

--- a/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files/bootloader.uuu.in
+++ b/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files/bootloader.uuu.in
@@ -9,7 +9,7 @@ uuu_version 1.0.1
 #FB: ucmd setenv fastboot_buffer ${initrd_addr}
 #FB: download -f fitImage-@@MACHINE@@-mfgtool
 #FB: acmd run mfgtool_args
-#FB: acmd bootm ${initrd_addr}#conf@${fdt_file}
+#FB: acmd bootm ${initrd_addr}#conf-${fdt_file}
 
 # Wait for eMMC
 #FBK: ucmd while [ ! -e /dev/mmcblk*boot0 ]; do sleep 1; echo "wait for /dev/mmcblk*boot* appear"; done;

--- a/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files/full_image.uuu.in
+++ b/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files/full_image.uuu.in
@@ -9,7 +9,7 @@ uuu_version 1.0.1
 #FB: ucmd setenv fastboot_buffer ${initrd_addr}
 #FB: download -f fitImage-@@MACHINE@@-mfgtool
 #FB: acmd run mfgtool_args
-#FB: acmd bootm ${initrd_addr}#conf@${fdt_file}
+#FB: acmd bootm ${initrd_addr}#conf-${fdt_file}
 
 # Wait for eMMC
 #FBK: ucmd while [ ! -e /dev/mmcblk*boot0 ]; do sleep 1; echo "wait for /dev/mmcblk*boot* appear"; done;

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx7ulpea-ucom/bootloader.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx7ulpea-ucom/bootloader.uuu.in
@@ -18,12 +18,12 @@ FB: ucmd setenv fastboot_buffer ${initrd_addr}
 FB: download -f fitImage-imx7ulpea-ucom-mfgtool
 # Apply OP-TEE overlay (provided by the OP-TEE OS)
 FB: ucmd setenv optee_ovl 0x65000000
-FB: ucmd imxtract ${initrd_addr}#conf@imx7ulpea-ucom-kit_v2.dtb fdt@imx7ulpea-ucom-kit_v2.dtb ${fdt_addr}
+FB: ucmd imxtract ${initrd_addr}#conf-imx7ulpea-ucom-kit_v2.dtb fdt-imx7ulpea-ucom-kit_v2.dtb ${fdt_addr}
 FB: ucmd fdt addr ${fdt_addr}
 FB: ucmd fdt resize 0x1000
 FB: ucmd fdt apply ${optee_ovl}
 FB: acmd run mfgtool_args
-FB: acmd bootm ${initrd_addr}#conf@imx7ulpea-ucom-kit_v2.dtb ${initrd_addr}:ramdisk@1 ${fdt_addr}
+FB: acmd bootm ${initrd_addr}#conf-imx7ulpea-ucom-kit_v2.dtb ${initrd_addr}:ramdisk-1 ${fdt_addr}
 
 # Wait for emmc
 FBK: ucmd while [ ! -e /dev/mmcblk*boot0 ]; do sleep 1; echo "wait for /dev/mmcblk*boot* appear"; done;


### PR DESCRIPTION
Prefer using the new default fit separator '-' instead of '@', so it is
able to load standard mfgtools fit images.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>