### PR TITLE
bsp: linux-lmp-toradex-imx: Add patch for HDMI interface on Apalis-iMX8

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-toradex-imx/apalis-imx8/0001-FIO-internal-Revert-ARM-dts-apalis-imx8-disable-HDMI.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-toradex-imx/apalis-imx8/0001-FIO-internal-Revert-ARM-dts-apalis-imx8-disable-HDMI.patch
@@ -1,0 +1,204 @@
+From aef8cea6c41a7d8e98d9d71603502bc1622419c3 Mon Sep 17 00:00:00 2001
+From: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
+Date: Wed, 25 Aug 2021 20:09:14 +0300
+Subject: [PATCH] [FIO internal] Revert "ARM: dts: apalis-imx8: disable HDMI
+ interface"
+
+This reverts commit e9261b8a65349cda45e4017d9e493fc7e7d3df8f.
+
+FIO BSP doesn't support overlays so far, while Toradex moved enabling
+all display/touch interfaces to overlays, disabling them in the main
+device trees.
+Revert disabling HDMI on Apalis-iMX8 to make HDMI working properly in
+FIO BSP.
+
+Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
+---
+
+ .../boot/dts/freescale/imx8-apalis-eval.dtsi  | 58 +++++++++++++++++++
+ .../dts/freescale/imx8-apalis-ixora-v1.1.dtsi | 58 +++++++++++++++++++
+ .../boot/dts/freescale/imx8-apalis-v1.1.dtsi  | 11 +++-
+ 3 files changed, 125 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/freescale/imx8-apalis-eval.dtsi b/arch/arm64/boot/dts/freescale/imx8-apalis-eval.dtsi
+index 0a4fe3898993..228872ea98fe 100644
+--- a/arch/arm64/boot/dts/freescale/imx8-apalis-eval.dtsi
++++ b/arch/arm64/boot/dts/freescale/imx8-apalis-eval.dtsi
+@@ -195,6 +195,60 @@
+ 	status = "okay";
+ };
+ 
++/* Apalis HDMI1 */
++&hdmi {
++	status = "okay";
++};
++
++&hdmi_lpcg_apb {
++	status = "okay";
++};
++
++&hdmi_lpcg_apb_mux_csr {
++	status = "okay";
++};
++
++&hdmi_lpcg_apb_mux_ctrl {
++	status = "okay";
++};
++
++&hdmi_lpcg_gpio_ipg {
++	status = "okay";
++};
++
++&hdmi_lpcg_i2c0 {
++	status = "okay";
++};
++
++&hdmi_lpcg_i2s {
++	status = "okay";
++};
++
++&hdmi_lpcg_lis_ipg {
++	status = "okay";
++};
++
++&hdmi_lpcg_msi_hclk {
++	status = "okay";
++};
++
++&hdmi_lpcg_phy {
++	status = "okay";
++};
++
++&hdmi_lpcg_pwm_ipg {
++	status = "okay";
++};
++
++&hdmi_lpcg_pxl {
++	status = "okay";
++};
++
++/* Apalis I2C2 (DDC) */
++&i2c0 {
++	status = "okay";
++};
++
+ /* Apalis I2C1 */
+ &i2c2 {
+ 	status = "okay";
+@@ -234,6 +288,10 @@
+ 	status = "okay";
+ };
+ 
++&irqsteer_hdmi {
++	status = "okay";
++};
++
+ /* Apalis SPI1 */
+ &lpspi0 {
+ 	status = "okay";
+diff --git a/arch/arm64/boot/dts/freescale/imx8-apalis-ixora-v1.1.dtsi b/arch/arm64/boot/dts/freescale/imx8-apalis-ixora-v1.1.dtsi
+index 53f56dc8f536..d8b361f662e6 100644
+--- a/arch/arm64/boot/dts/freescale/imx8-apalis-ixora-v1.1.dtsi
++++ b/arch/arm64/boot/dts/freescale/imx8-apalis-ixora-v1.1.dtsi
+@@ -213,6 +213,60 @@
+ 	status = "okay";
+ };
+ 
++/* Apalis HDMI1 */
++&hdmi {
++	status = "okay";
++};
++
++&hdmi_lpcg_apb {
++	status = "okay";
++};
++
++&hdmi_lpcg_apb_mux_csr {
++	status = "okay";
++};
++
++&hdmi_lpcg_apb_mux_ctrl {
++	status = "okay";
++};
++
++&hdmi_lpcg_gpio_ipg {
++	status = "okay";
++};
++
++&hdmi_lpcg_i2c0 {
++	status = "okay";
++};
++
++&hdmi_lpcg_i2s {
++	status = "okay";
++};
++
++&hdmi_lpcg_lis_ipg {
++	status = "okay";
++};
++
++&hdmi_lpcg_msi_hclk {
++	status = "okay";
++};
++
++&hdmi_lpcg_phy {
++	status = "okay";
++};
++
++&hdmi_lpcg_pwm_ipg {
++	status = "okay";
++};
++
++&hdmi_lpcg_pxl {
++	status = "okay";
++};
++
++/* Apalis I2C2 (DDC) */
++&i2c0 {
++	status = "okay";
++};
++
+ /* Apalis I2C1 */
+ &i2c2 {
+ 	status = "okay";
+@@ -279,6 +333,10 @@
+ 	status = "okay";
+ };
+ 
++&irqsteer_hdmi {
++	status = "okay";
++};
++
+ &lsio_gpio5 {
+ 	ngpios = <32>;
+ 	gpio-line-names = "gpio5-00", "gpio5-01", "gpio5-02", "gpio5-03",
+diff --git a/arch/arm64/boot/dts/freescale/imx8-apalis-v1.1.dtsi b/arch/arm64/boot/dts/freescale/imx8-apalis-v1.1.dtsi
+index 3a970692aae8..cf6e820409f9 100644
+--- a/arch/arm64/boot/dts/freescale/imx8-apalis-v1.1.dtsi
++++ b/arch/arm64/boot/dts/freescale/imx8-apalis-v1.1.dtsi
+@@ -253,13 +253,20 @@
+ 		};
+ 	};
+ 
+-	sound_hdmi: sound-hdmi {
++	sound-hdmi {
+ 		compatible = "fsl,imx-audio-cdnhdmi";
+ 		model = "imx-audio-hdmi-tx";
+ 		audio-cpu = <&sai5>;
+ 		protocol = <1>;
+ 		hdmi-out;
+-		status = "disabled";
++	};
++
++	sound-hdmi-arc {
++		compatible = "fsl,imx-audio-spdif";
++		model = "imx-hdmi-arc";
++		spdif-controller = <&spdif1>;
++		spdif-in;
++		spdif-out;
+ 	};
+ 
+ 	sound-spdif {
+-- 
+2.31.1
+

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-toradex-imx_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-toradex-imx_git.bb
@@ -11,6 +11,10 @@ SRC_URI = "git://git.toradex.com/linux-toradex.git;protocol=git;branch=${KBRANCH
     ${KERNEL_META_REPO};protocol=${KERNEL_META_REPO_PROTOCOL};type=kmeta;name=meta;branch=${KERNEL_META_BRANCH};destsuffix=${KMETA} \
 "
 
+SRC_URI_append_apalis-imx8 = " \
+    file://0001-FIO-internal-Revert-ARM-dts-apalis-imx8-disable-HDMI.patch \
+"
+
 KMETA = "kernel-meta"
 
 include recipes-kernel/linux/linux-lmp.inc


### PR DESCRIPTION
Toradex disabled all display interfaces by default. Add patch that
enables HDMI interface on Apalis-iMX8 on boot.

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>