### PR TITLE
bsp: Fix boot command for apalis-imx8 for distro lmp-base

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-base-scr/apalis-imx8/uEnv.txt.in
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-base-scr/apalis-imx8/uEnv.txt.in
@@ -1,4 +1,4 @@
 bootcmd_dtb=fatload ${devtype} ${devnum}:1 ${fdt_addr_r} ${fdtfile}
 bootcmd_load_k=fatload ${devtype} ${devnum}:1 ${loadaddr} ${boot_file}
 bootcmd_run=booti ${loadaddr} - ${fdt_addr_r}
-bootcmd=run bootcmd_dtb; run setup; run bootcmd_load_k; run bootcmd_run
+bootcmd=run bootcmd_dtb; run finduuid; run setup; run bootcmd_load_k; run bootcmd_run


### PR DESCRIPTION
The boot script requires one more variable to be set (uuid) for the root
partition.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>