### PR TITLE
bsp: Enable WiFi on am64xx-evm SK version

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-ti-staging/am64xx-evm/0001-arm64-dts-ti-k3-am642-sk-Enable-WLAN-connected-to-SD.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-ti-staging/am64xx-evm/0001-arm64-dts-ti-k3-am642-sk-Enable-WLAN-connected-to-SD.patch
@@ -1,0 +1,104 @@
+From 164239a47d14928972bdf6ff3f3f6dfc0f7f520f Mon Sep 17 00:00:00 2001
+From: Kishon Vijay Abraham I <kishon@ti.com>
+Date: Thu, 11 Feb 2021 20:21:23 +0530
+Subject: [PATCH] arm64: dts: ti: k3-am642-sk: Enable WLAN connected to SDHCI0
+
+WL1837 module is connected to SDHCI0 in AM642 SK. Enable it here.
+
+Signed-off-by: Kishon Vijay Abraham I <kishon@ti.com>
+Signed-off-by: Vignesh Raghavendra <vigneshr@ti.com>
+---
+ arch/arm64/boot/dts/ti/k3-am642-sk.dts | 63 ++++++++++++++++++++++++++
+ 1 file changed, 63 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/ti/k3-am642-sk.dts b/arch/arm64/boot/dts/ti/k3-am642-sk.dts
+index 727f06475670..34b21d155299 100644
+--- a/arch/arm64/boot/dts/ti/k3-am642-sk.dts
++++ b/arch/arm64/boot/dts/ti/k3-am642-sk.dts
+@@ -125,6 +125,31 @@
+ 		vin-supply = <&vcc_3v3_sys>;
+ 		gpio = <&exp1 3 GPIO_ACTIVE_HIGH>;
+ 	};
++
++	com8_ls_en: fixed-regulator-com8 {
++		compatible = "regulator-fixed";
++		regulator-name = "com8_ls_en";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-always-on;
++		regulator-boot-on;
++		pinctrl-0 = <&main_com8_ls_en_pins_default>;
++		pinctrl-names = "default";
++		gpio = <&main_gpio0 62 GPIO_ACTIVE_LOW>;
++	};
++
++	wlan_en: fixed-regulator-wlan {
++		/* output of SN74AVC4T245RSVR */
++		compatible = "regulator-fixed";
++		regulator-name = "wlan_en";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		enable-active-high;
++		pinctrl-0 = <&main_wlan_en_pins_default>;
++		pinctrl-names = "default";
++		vin-supply = <&com8_ls_en>;
++		gpio = <&main_gpio0 48 GPIO_ACTIVE_HIGH>;
++	};
+ };
+ 
+ &main_pmx0 {
+@@ -216,6 +241,24 @@
+ 			AM64X_IOPAD(0x0270, PIN_INPUT, 0) /* (D18) ECAP0_IN_APWM_OUT */
+ 		>;
+ 	};
++
++	main_wlan_en_pins_default: main-wlan-en-pins-default {
++		pinctrl-single,pins = <
++			AM64X_IOPAD(0x00c4, PIN_OUTPUT_PULLUP, 7) /* (V8) GPIO0_48 */
++		>;
++	};
++
++	main_com8_ls_en_pins_default: main-com8-ls-en-pins-default {
++		pinctrl-single,pins = <
++			AM64X_IOPAD(0x00fc, PIN_OUTPUT, 7) /* (U7) PRG1_PRU0_GPO17.GPIO0_62 */
++		>;
++	};
++
++	main_wlan_pins_default: main-wlan-pins-default {
++		pinctrl-single,pins = <
++			AM64X_IOPAD(0x00bc, PIN_INPUT, 7) /* (U8) GPIO0_46 */
++		>;
++	};
+ };
+ 
+ &mcu_uart0 {
+@@ -293,6 +336,26 @@
+ 	status = "reserved";
+ };
+ 
++&sdhci0 {
++	vmmc-supply = <&wlan_en>;
++	bus-width = <4>;
++	non-removable;
++	cap-power-off-card;
++	keep-power-in-suspend;
++	ti,driver-strength-ohm = <50>;
++
++	#address-cells = <1>;
++	#size-cells = <0>;
++	wlcore: wlcore@2 {
++		compatible = "ti,wl1837";
++		reg = <2>;
++		pinctrl-0 = <&main_wlan_pins_default>;
++		pinctrl-names = "default";
++		interrupt-parent = <&main_gpio0>;
++		interrupts = <46 IRQ_TYPE_EDGE_FALLING>;
++	};
++};
++
+ &sdhci1 {
+ 	/* SD/MMC */
+ 	vmmc-supply = <&vdd_mmc1>;
+-- 
+2.17.1
+

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-ti-staging_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-ti-staging_git.bb
@@ -17,6 +17,10 @@ SRC_URI = "git://git.ti.com/ti-linux-kernel/ti-linux-kernel.git;protocol=git;bra
     ${KERNEL_META_REPO};protocol=${KERNEL_META_REPO_PROTOCOL};type=kmeta;name=meta;branch=${KERNEL_META_BRANCH};destsuffix=${KMETA} \
 "
 
+SRC_URI_append_am64xx-evm = " \
+    file://0001-arm64-dts-ti-k3-am642-sk-Enable-WLAN-connected-to-SD.patch \
+"
+
 KMETA = "kernel-meta"
 
 do_kernel_metadata_prepend() {


### PR DESCRIPTION
In the 5.10 kernel the WiFi config was not set as it was in the
5.4 kernel. This will add that missing dtb data.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>