### PR TITLE
base: aktualizr-lite: bump to a40a69b

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "master"
-SRCREV_lmp = "a5d7363cd24e82659c9315f1e91a8b2563e9e118"
+SRCREV_lmp = "a40a69b8dae0b4fcf7360c6d132ed6d294016864"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
Relevant changes

- a40a69b pull ostree from GCS bucket(s) with fallback to ostreeproxy/DG
- a42d1d6 aklite: add ability to manage non-booted rootfs
- c698af0 apps: check if the state files exist before use
- 0d3bc06 apps: check downloaded App contains a compose file

Signed-off-by: Mike Sul <mike.sul@foundries.io>