### PR TITLE
bsp: u-boot-xlnx: deploy u-boot config used by the build

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
@@ -21,6 +21,7 @@ B = "${WORKDIR}/build"
 do_configure[cleandirs] = "${B}"
 
 require recipes-bsp/u-boot/u-boot.inc
+require recipes-bsp/u-boot/u-boot-lmp-common.inc
 
 # Support additional u-boot classes such as u-boot-fitimage
 UBOOT_CLASSES ?= ""
@@ -64,45 +65,6 @@ EOF
             chmod +x sit_gen
             ./sit_gen
             objcopy -I binary -O binary --pad-to 512 ${B}/sit.bin
-        fi
-    fi
-}
-
-# Also deploy u-boot config used during build
-do_deploy_append() {
-    if [ -n "${UBOOT_CONFIG}" ]; then
-        for config in ${UBOOT_MACHINE}; do
-            i=$(expr $i + 1);
-            for type in ${UBOOT_CONFIG}; do
-                j=$(expr $j + 1);
-                if [ $j -eq $i ]; then
-                    install -D -m 644 ${B}/${config}/.config ${DEPLOYDIR}/${PN}-config-${MACHINE}-${type}-${PV}-${PR}
-                    cd ${DEPLOYDIR}
-                    ln -sf ${PN}-config-${MACHINE}-${type}-${PV}-${PR} ${PN}-config-${MACHINE}-${type}
-                    ln -sf ${PN}-config-${MACHINE}-${type}-${PV}-${PR} ${PN}-config-${type}
-                    if [ -f ${B}/${config}/sit-${type}.bin ]; then
-                        install -D -m 644 ${B}/${config}/sit-${type}.bin ${DEPLOYDIR}/${PN}-sit.bin-${MACHINE}-${type}-${PV}-${PR}
-                        cd ${DEPLOYDIR}
-                        ln -sf ${PN}-sit.bin-${MACHINE}-${type}-${PV}-${PR} ${PN}-sit.bin-${MACHINE}-${type}
-                        ln -sf ${PN}-sit.bin-${MACHINE}-${type}-${PV}-${PR} sit-${MACHINE}-${type}.bin
-                        ln -sf ${PN}-sit.bin-${MACHINE}-${type}-${PV}-${PR} ${PN}-sit.bin-${type}
-                    fi
-                fi
-            done
-            unset j
-        done
-        unset i
-    else
-        install -D -m 644 ${B}/.config ${DEPLOYDIR}/${PN}-config-${MACHINE}-${PV}-${PR}
-        cd ${DEPLOYDIR}
-        ln -sf ${PN}-config-${MACHINE}-${PV}-${PR} ${PN}-config-${MACHINE}
-        ln -sf ${PN}-config-${MACHINE}-${PV}-${PR} ${PN}-config
-        if [ -f ${B}/sit.bin ]; then
-            install -D -m 644 ${B}/sit.bin ${DEPLOYDIR}/${PN}-sit.bin-${MACHINE}-${PV}-${PR}
-            cd ${DEPLOYDIR}
-            ln -sf ${PN}-sit.bin-${MACHINE}-${PV}-${PR} ${PN}-sit.bin-${MACHINE}
-            ln -sf ${PN}-sit.bin-${MACHINE}-${PV}-${PR} sit-${MACHINE}.bin
-            ln -sf ${PN}-sit.bin-${MACHINE}-${PV}-${PR} ${PN}-sit.bin
         fi
     fi
 }

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-lmp-common.inc
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-lmp-common.inc
@@ -1,0 +1,40 @@
+# Common include for all LMP u-boot recipes
+
+# Also deploy u-boot config used during build
+do_deploy_append() {
+    if [ -n "${UBOOT_CONFIG}" ]; then
+        for config in ${UBOOT_MACHINE}; do
+            i=$(expr $i + 1);
+            for type in ${UBOOT_CONFIG}; do
+                j=$(expr $j + 1);
+                if [ $j -eq $i ]; then
+                    install -D -m 644 ${B}/${config}/.config ${DEPLOYDIR}/${PN}-config-${MACHINE}-${type}-${PV}-${PR}
+                    cd ${DEPLOYDIR}
+                    ln -sf ${PN}-config-${MACHINE}-${type}-${PV}-${PR} ${PN}-config-${MACHINE}-${type}
+                    ln -sf ${PN}-config-${MACHINE}-${type}-${PV}-${PR} ${PN}-config-${type}
+                    if [ -f ${B}/${config}/sit-${type}.bin ]; then
+                        install -D -m 644 ${B}/${config}/sit-${type}.bin ${DEPLOYDIR}/${PN}-sit.bin-${MACHINE}-${type}-${PV}-${PR}
+                        cd ${DEPLOYDIR}
+                        ln -sf ${PN}-sit.bin-${MACHINE}-${type}-${PV}-${PR} ${PN}-sit.bin-${MACHINE}-${type}
+                        ln -sf ${PN}-sit.bin-${MACHINE}-${type}-${PV}-${PR} sit-${MACHINE}-${type}.bin
+                        ln -sf ${PN}-sit.bin-${MACHINE}-${type}-${PV}-${PR} ${PN}-sit.bin-${type}
+                    fi
+                fi
+            done
+            unset j
+        done
+        unset i
+    else
+        install -D -m 644 ${B}/.config ${DEPLOYDIR}/${PN}-config-${MACHINE}-${PV}-${PR}
+        cd ${DEPLOYDIR}
+        ln -sf ${PN}-config-${MACHINE}-${PV}-${PR} ${PN}-config-${MACHINE}
+        ln -sf ${PN}-config-${MACHINE}-${PV}-${PR} ${PN}-config
+        if [ -f ${B}/sit.bin ]; then
+            install -D -m 644 ${B}/sit.bin ${DEPLOYDIR}/${PN}-sit.bin-${MACHINE}-${PV}-${PR}
+            cd ${DEPLOYDIR}
+            ln -sf ${PN}-sit.bin-${MACHINE}-${PV}-${PR} ${PN}-sit.bin-${MACHINE}
+            ln -sf ${PN}-sit.bin-${MACHINE}-${PV}-${PR} sit-${MACHINE}.bin
+            ln -sf ${PN}-sit.bin-${MACHINE}-${PV}-${PR} ${PN}-sit.bin
+        fi
+    fi
+}

--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx_2021.07.bb
+++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx_2021.07.bb
@@ -7,6 +7,7 @@ SRCREV = "67197d5a1df47d98066a8f65999257d54d08eb4b"
 
 include recipes-bsp/u-boot/u-boot-xlnx.inc
 include recipes-bsp/u-boot/u-boot-spl-zynq-init.inc
+include recipes-bsp/u-boot/u-boot-lmp-common.inc
 
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://README;beginline=1;endline=4;md5=744e7e3bb0c94b4b9f6b3db3bf893897"


### PR DESCRIPTION
```
Deploy the u-boot configuration that was used during the build
process as it's done by default now for u-boot-fio,
as it might be useful as reference later.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>
```