### PR TITLE
base: mfgtool-files: update UUU 1.4.43 -> 1.4.139

### DIFF
--- a/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb
+++ b/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb
@@ -1,6 +1,7 @@
 SUMMARY = "MFGTOOL Support Files and Binaries"
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+LICENSE = "BSD-3-Clause & LGPLv2.1+"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9 \
+                    file://${COMMON_LICENSE_DIR}/LGPL-2.1-or-later;md5=2a4f4fd2128ea2f65047ee63fbca9f68"
 
 inherit deploy nopackages
 
@@ -8,20 +9,20 @@ inherit deploy nopackages
 INITRAMFS_IMAGE = "fsl-image-mfgtool-initramfs"
 DEPENDS = "${INITRAMFS_IMAGE}"
 
-UUU_RELEASE = "1.4.43"
+UUU_RELEASE = "1.4.139"
 MFGTOOL_FLASH_IMAGE ?= "lmp-base-console-image"
 
 SRC_URI = " \
     https://github.com/NXPmicro/mfgtools/releases/download/uuu_${UUU_RELEASE}/uuu;downloadfilename=uuu-${UUU_RELEASE};name=Linux \
+    https://github.com/NXPmicro/mfgtools/releases/download/uuu_${UUU_RELEASE}/uuu_mac;downloadfilename=uuu-${UUU_RELEASE}_mac;name=Mac \
     https://github.com/NXPmicro/mfgtools/releases/download/uuu_${UUU_RELEASE}/uuu.exe;downloadfilename=uuu-${UUU_RELEASE}.exe;name=Windows \
     file://bootloader.uuu.in \
     file://full_image.uuu.in \
 "
 
-SRC_URI[Linux.md5sum] = "9d1fc1d931aea19d1215c410361116ab"
-SRC_URI[Linux.sha256sum] = "fbbe69d94843c4784c637f05162302b84fd9ffe667281d9cc0c5e577aa7bc123"
-SRC_URI[Windows.md5sum] = "3b6f807439b29bcc140ee2199243cb6d"
-SRC_URI[Windows.sha256sum] = "b6f7756b7a4559dd4d3316a458e435e0043a69e4ca0d73c9369f74e79303ede4"
+SRC_URI[Linux.sha256sum] = "75385372ec89adae666c42305d5b7a428f0fe7e3b4762276db8ecba70e48ef6a"
+SRC_URI[Mac.sha256sum] = "5206397f281bcb7ee707c1550b82fb667ce03dba4361cd36125bfd6beb7da1fd"
+SRC_URI[Windows.sha256sum] = "15331892a4fdf2b372fe55c9e8f8b504f7bbafcff2d7cf8a10cd6ccead4b7aa3"
 
 S = "${WORKDIR}"
 
@@ -38,6 +39,7 @@ do_compile() {
 do_deploy() {
     install -d ${DEPLOYDIR}/${PN}
     install -m 0755 ${WORKDIR}/uuu-${UUU_RELEASE} ${DEPLOYDIR}/${PN}/uuu
+    install -m 0755 ${WORKDIR}/uuu-${UUU_RELEASE}_mac ${DEPLOYDIR}/${PN}/uuu_mac
     install -m 0644 ${WORKDIR}/uuu-${UUU_RELEASE}.exe ${DEPLOYDIR}/${PN}/uuu.exe
     install -m 0644 ${WORKDIR}/bootloader.uuu ${DEPLOYDIR}/${PN}
     install -m 0644 ${WORKDIR}/full_image.uuu ${DEPLOYDIR}/${PN}


### PR DESCRIPTION
Update UUU release to 1.4.139, fix incorrect recipe license (based on
UUU upstream) and also install/deploy the mac binary which is now
released by upstream.

UUU Release Notes:

New features:

* Add help option -IgSerNum to set windows registry to ignore serial
* Number above too much entry in register when burn many boards.
* Add snap support
* Add 8ulp support
* Deploy mac image

Bug fixes

* Fixed missed last chunk when meet specific android sparse file
* Return out of memory when allocate failure
* -bshow don't show uuu version information and recover cursor ESC

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>