### PR TITLE
Backport docker/containerd/runc updates from meta-virtualization master

### DIFF
--- a/meta-lmp-base/recipes-containers/containerd/containerd-opencontainers_git.bb
+++ b/meta-lmp-base/recipes-containers/containerd/containerd-opencontainers_git.bb
@@ -5,7 +5,7 @@ DESCRIPTION = "containerd is a daemon to control runC, built for performance and
                support as well as checkpoint and restore for cloning and live migration of containers."
 
 
-SRCREV = "1c13c54cae4f53510a7a45ae3e4af49030a76193"
+SRCREV = "69e5db821af6458b4078d654ad3dcb3f31faa522"
 SRC_URI = "git://github.com/containerd/containerd;branch=release/1.5 \
            file://0001-Add-build-option-GODEBUG-1.patch \
            file://0001-Makefile-allow-GO_BUILD_FLAGS-to-be-externally-speci.patch \
@@ -15,7 +15,7 @@ SRC_URI = "git://github.com/containerd/containerd;branch=release/1.5 \
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://src/import/LICENSE;md5=1269f40c0d099c21a871163984590d89"
 
-CONTAINERD_VERSION = "v1.5.4"
+CONTAINERD_VERSION = "v1.5.5"
 
 EXTRA_OEMAKE += "GODEBUG=1"
 

--- a/meta-lmp-base/recipes-containers/docker/docker-moby.bb
+++ b/meta-lmp-base/recipes-containers/docker/docker-moby.bb
@@ -34,10 +34,10 @@ DESCRIPTION = "Linux container runtime \
 #   - The common components of this recipe and docker-ce do need to be moved
 #     to a docker.inc recipe
 
-# commits based on v20.10.7
-SRCREV_moby = "013d6655bb0f4c86bcd9d48372ef67afd0ded65e"
+# commits based on v20.10.8
+SRCREV_moby = "d24c6dc5cf5e68dfb30027b2db454099566a9b9e"
 SRCREV_libnetwork = "64b7a4574d1426139437d20e81c0b6d391130ec8"
-SRCREV_cli = "e9b8231d6a57b6a5a5efd96504ace70a78dc6e5d"
+SRCREV_cli = "62eae52c2a76f4c1dcf79dfc7b5ea3bf5eebab8b"
 SRC_URI = "\
 	git://github.com/moby/moby.git;branch=20.10;name=moby \
 	git://github.com/moby/libnetwork.git;branch=master;name=libnetwork;destsuffix=git/libnetwork \
@@ -63,7 +63,7 @@ GO_IMPORT = "import"
 
 S = "${WORKDIR}/git"
 
-DOCKER_VERSION = "20.10.7"
+DOCKER_VERSION = "20.10.8"
 PV = "${DOCKER_VERSION}"
 
 PACKAGES =+ "${PN}-contrib"

--- a/meta-lmp-base/recipes-containers/runc/files/0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch
+++ b/meta-lmp-base/recipes-containers/runc/files/0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch
@@ -1,19 +1,21 @@
-From d2c47a973f354ffd505bb4e809c59e57b543726d Mon Sep 17 00:00:00 2001
-From: Chen Qi <Qi.Chen@windriver.com>
-Date: Tue, 6 Aug 2019 19:01:45 +0800
+From 0fe50d2ca4517f5e3070585040f35ace413acd44 Mon Sep 17 00:00:00 2001
+From: Bruce Ashfield <bruce.ashfield@gmail.com>
+Date: Tue, 24 Aug 2021 11:38:23 -0400
 Subject: [PATCH] Makefile: respect GOBUILDFLAGS for runc and remove recvtty
  from static
 
 Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[bva: refreshed for release 1.0.2]
+Signed-off-by: Bruce Ashfield <bruce.ashfield@gmail.com>
 ---
  Makefile | 3 +--
  1 file changed, 1 insertion(+), 2 deletions(-)
 
-Index: git/src/import/Makefile
-===================================================================
---- git.orig/src/import/Makefile
-+++ git/src/import/Makefile
-@@ -25,7 +25,7 @@
+diff --git a/src/import/Makefile b/src/import/Makefile
+index efbddf0d..4b174c80 100644
+--- a/src/import/Makefile
++++ b/src/import/Makefile
+@@ -24,7 +24,7 @@ ifeq ($(shell $(GO) env GOOS),linux)
  		endif
  	endif
  endif
@@ -21,8 +23,8 @@ Index: git/src/import/Makefile
 +GO_BUILD := $(GO) build $(GOBUILDFLAGS) -trimpath $(MOD_VENDOR) $(GO_BUILDMODE) $(EXTRA_FLAGS) -tags "$(BUILDTAGS)" \
  	-ldflags "-X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
  GO_BUILD_STATIC := CGO_ENABLED=1 $(GO) build -trimpath $(MOD_VENDOR) $(EXTRA_FLAGS) -tags "$(BUILDTAGS) netgo osusergo" \
- 	-ldflags "-w -extldflags -static -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
-@@ -42,7 +42,6 @@
+ 	-ldflags "-extldflags -static -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) $(EXTRA_LDFLAGS)"
+@@ -41,7 +41,6 @@ recvtty:
  
  static:
  	$(GO_BUILD_STATIC) -o runc .
@@ -30,3 +32,6 @@ Index: git/src/import/Makefile
  
  release:
  	script/release.sh -r release/$(VERSION) -v $(VERSION)
+-- 
+2.19.1
+

--- a/meta-lmp-base/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/meta-lmp-base/recipes-containers/runc/runc-opencontainers_git.bb
@@ -1,10 +1,10 @@
 include recipes-containers/runc/runc.inc
 
-SRCREV = "bfcbc947d5d11327f2680047e2e6e94f4ee93d2a"
+SRCREV = "86d83333d765f4535e4898d6778388dab715eb7c"
 SRC_URI = " \
-    git://github.com/opencontainers/runc;branch=master \
+    git://github.com/opencontainers/runc;branch=release-1.0 \
     file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
     "
-RUNC_VERSION = "1.0.0-rc95"
+RUNC_VERSION = "1.0.2"
 
 CVE_PRODUCT = "runc"


### PR DESCRIPTION
* containerd updated to 1.5.5
* docker updated to 20.10.8
* runc updated to v1.0.2