### PR TITLE
recipes-sota: Set RDEPENDS for aktualizr-lite-lib

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -59,6 +59,7 @@ FILES_${PN}-lite = "${bindir}/aktualizr-lite"
 
 # Force same RDEPENDS, packageconfig rdepends common to both
 RDEPENDS_${PN}-lite = "${RDEPENDS_aktualizr}"
+RDEPENDS_${PN}-lite-lib = "${RDEPENDS_aktualizr}"
 
 FILES_${PN}-lite += "${nonarch_libdir}/tmpfiles.d/aktualizr-lite.conf"
 


### PR DESCRIPTION
Custom clients built against aktualizr-lite-lib have a couple of runtime
dependencies including libfyaml and lshw. This change ensure the
resulting images will include those dependencies.

Signed-off-by: Andy Doan <andy@foundries.io>