### PR TITLE
base: kernel-lmp-fitimage: fix loadable and dtb counters

### DIFF
--- a/meta-lmp-base/classes/kernel-lmp-fitimage.bbclass
+++ b/meta-lmp-base/classes/kernel-lmp-fitimage.bbclass
@@ -302,14 +302,14 @@ fitimage_emit_section_config() {
 	fi
 
 	if [ -n "${loadable_id}" ]; then
-		i=0
+		loadable_counter=0
 		for LOADABLE in ${loadable_id}; do
 			if [ -e ${DEPLOY_DIR_IMAGE}/${LOADABLE} ]; then
-				i=`expr ${i} + 1`
+				loadable_counter=`expr ${loadable_counter} + 1`
 				if [ -z "${loadable_line}" ]; then
 					conf_desc="${conf_desc}${sep}loadables"
 				fi
-				loadable_line="${loadable_line}loadable_${i} = \"loadable${FIT_NODE_SEPARATOR}${LOADABLE}\"; "
+				loadable_line="${loadable_line}loadable_${loadable_counter} = \"loadable${FIT_NODE_SEPARATOR}${LOADABLE}\"; "
 			fi
 		done
 	fi
@@ -373,11 +373,11 @@ EOF
 		fi
 
 		if [ -n "${loadable_id}" ]; then
-			i=0
+			loadable_counter=0
 			for LOADABLE in ${loadable_id}; do
 				if [ -e ${DEPLOY_DIR_IMAGE}/${LOADABLE} ]; then
-					i=`expr ${i} + 1`
-					sign_line="${sign_line}${sep}\"loadable_${i}\""
+					loadable_counter=`expr ${loadable_counter} + 1`
+					sign_line="${sign_line}${sep}\"loadable_${loadable_counter}\""
 				fi
 			done
 		fi


### PR DESCRIPTION
In fitimage_assemble, we use a shell variable "i" to keep track
of the number of DTBs we've added.  This variable is compared
to "dtbcount" in order to see if we're on the first or "default"
dtb.

However, we also use the "i" variable in fitimage_emit_section_config
to keep a running count of loadables so that we can name them
"loadable_${i}" for uniqueness.

This means anytime "FIT_LOADABLES" is set, we are messing with the DTB
counter and it causes more than 1 "default" node to possibly be set.

Fix this by not using the "i" variable in fitimage_emit_section_config.

Signed-off-by: Michael Scott <mike@foundries.io>