### PR TITLE
bsp: u-boot-ostree-scr-fit: add support for loading custom firmware

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common.cmd.in
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common.cmd.in
@@ -151,6 +151,9 @@ setenv bootcmd_rollback 'if test -n "${kernel_image2}" && test "${fiovb.is_secon
 run bootcmd_rollback
 run bootcmd_load_f
 run bootcmd_tee_ovy
+if test -n "${bootcmd_load_fw}"; then
+	run bootcmd_load_fw
+fi
 
 # If we are validating secondary boot path, Linux should force reboot back to
 # primary path after running reboot cmd (this is needed for boards without


### PR DESCRIPTION
Add support for loading custom firmware in boot-common.cmd.in include.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>