### PR TITLE
master: base: use https protocol

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
@@ -8,7 +8,7 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
 DEPENDS += "flex-native bison-native bc-native dtc-native python3-setuptools-native"
 
-SRC_URI = "git://github.com/foundriesio/u-boot.git;branch=${SRCBRANCH} \
+SRC_URI = "git://github.com/foundriesio/u-boot.git;protocol=https;branch=${SRCBRANCH} \
     file://fw_env.config \
     ${@bb.utils.contains('MACHINE_FEATURES', 'ebbr', 'file://lmp-ebbr.cfg', 'file://lmp.cfg', d)} \
 "

--- a/meta-lmp-base/recipes-containers/containerd/containerd-opencontainers_git.bb
+++ b/meta-lmp-base/recipes-containers/containerd/containerd-opencontainers_git.bb
@@ -6,7 +6,7 @@ DESCRIPTION = "containerd is a daemon to control runC, built for performance and
 
 
 SRCREV = "69e5db821af6458b4078d654ad3dcb3f31faa522"
-SRC_URI = "git://github.com/containerd/containerd;branch=release/1.5 \
+SRC_URI = "git://github.com/containerd/containerd;protocol=https;branch=release/1.5 \
            file://0001-Add-build-option-GODEBUG-1.patch \
            file://0001-Makefile-allow-GO_BUILD_FLAGS-to-be-externally-speci.patch \
           "

--- a/meta-lmp-base/recipes-containers/docker/docker-moby.bb
+++ b/meta-lmp-base/recipes-containers/docker/docker-moby.bb
@@ -39,9 +39,9 @@ SRCREV_moby = "e2f740de442bac52b280bc485a3ca5b31567d938"
 SRCREV_libnetwork = "64b7a4574d1426139437d20e81c0b6d391130ec8"
 SRCREV_cli = "b485636f4b90ed5a91a1f403e65ffced469c641a"
 SRC_URI = "\
-	git://github.com/moby/moby.git;branch=20.10;name=moby \
-	git://github.com/moby/libnetwork.git;branch=master;name=libnetwork;destsuffix=git/libnetwork \
-	git://github.com/docker/cli;branch=20.10;name=cli;destsuffix=git/cli \
+	git://github.com/moby/moby.git;protocol=https;branch=20.10;name=moby \
+	git://github.com/moby/libnetwork.git;protocol=https;branch=master;name=libnetwork;destsuffix=git/libnetwork \
+	git://github.com/docker/cli;protocol=https;branch=20.10;name=cli;destsuffix=git/cli \
 	file://0001-libnetwork-use-GO-instead-of-go.patch \
 	file://0001-cli-use-external-GO111MODULE-and-cross-compiler.patch \
 	file://0001-dynbinary-use-go-cross-compiler.patch \

--- a/meta-lmp-base/recipes-containers/runc/runc-opencontainers_git.bb
+++ b/meta-lmp-base/recipes-containers/runc/runc-opencontainers_git.bb
@@ -2,7 +2,7 @@ include recipes-containers/runc/runc.inc
 
 SRCREV = "86d83333d765f4535e4898d6778388dab715eb7c"
 SRC_URI = " \
-    git://github.com/opencontainers/runc;branch=release-1.0 \
+    git://github.com/opencontainers/runc;protocol=https;branch=release-1.0 \
     file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
     "
 RUNC_VERSION = "1.0.2"

--- a/meta-lmp-base/recipes-devtools/mcumgr/mcumgr_git.bb
+++ b/meta-lmp-base/recipes-devtools/mcumgr/mcumgr_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 GO_IMPORT = "github.com/apache/mynewt-mcumgr-cli/mcumgr"
-SRC_URI = "git://github.com/apache/mynewt-mcumgr-cli"
+SRC_URI = "git://github.com/apache/mynewt-mcumgr-cli;protocol=https"
 SRCREV = "0ba791a8d336bc751598be36099998439184b033"
 
 UPSTREAM_CHECK_COMMITS = "1"

--- a/meta-lmp-base/recipes-kernel/jool/jool_git.bb
+++ b/meta-lmp-base/recipes-kernel/jool/jool_git.bb
@@ -5,7 +5,7 @@ SECTION = "kernel/network"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/NICMx/Jool.git"
+SRC_URI = "git://github.com/NICMx/Jool.git;protocol=https"
 
 PV = "4.0.4"
 SRCREV = "4c3e99d00242cf54832985fbe5374225512de3d5"

--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp-dev-mfgtool.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp-dev-mfgtool.bb
@@ -7,6 +7,7 @@ LIC_FILES_CHKSUM ?= "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 # Use NXP BSP by default
 KERNEL_REPO ?= "git://source.codeaurora.org/external/imx/linux-imx.git"
+KERNEL_REPO_PROTOCOL ?= "https"
 LINUX_VERSION ?= "5.4.y"
 KERNEL_BRANCH ?= "imx_5.4.70_2.3.0"
 
@@ -18,5 +19,5 @@ require recipes-kernel/linux/linux-lmp-dev.bb
 # lzop is commonly used by mfgtool-based kernel
 DEPENDS += "lzop-native"
 
-SRC_URI = "${KERNEL_REPO};branch=${KERNEL_BRANCH};name=machine;"
+SRC_URI = "${KERNEL_REPO};protocol=${KERNEL_REPO_PROTOCOL};branch=${KERNEL_BRANCH};name=machine;"
 KMETA = ""

--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp-dev.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp-dev.bb
@@ -17,6 +17,7 @@ LINUX_VERSION_EXTENSION ?= "-lmpdev-${LINUX_KERNEL_TYPE}"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
 KERNEL_REPO ?= "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
+KERNEL_REPO_PROTOCOL ?= "https"
 KERNEL_BRANCH ?= "master"
 KERNEL_COMMIT ?= "${AUTOREV}"
 KERNEL_META_REPO ?= "git://${FIO_LMP_GIT_URL}/${FIO_LMP_GIT_NAMESPACE}lmp-kernel-cache.git"
@@ -30,7 +31,7 @@ SRCREV_meta = "${KERNEL_META_COMMIT}"
 
 LIC_FILES_CHKSUM ?= "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-SRC_URI = "${KERNEL_REPO};branch=${KERNEL_BRANCH};name=machine; \
+SRC_URI = "${KERNEL_REPO};protocol=${KERNEL_REPO_PROTOCOL};branch=${KERNEL_BRANCH};name=machine; \
            ${KERNEL_META_REPO};protocol=${KERNEL_META_REPO_PROTOCOL};type=kmeta;name=meta;branch=${KERNEL_META_BRANCH};destsuffix=${KMETA}"
 
 KMETA = "kernel-meta"

--- a/meta-lmp-base/recipes-kernel/wireguard/wireguard-module_1.0.20210606.bb
+++ b/meta-lmp-base/recipes-kernel/wireguard/wireguard-module_1.0.20210606.bb
@@ -2,7 +2,7 @@ require recipes-kernel/wireguard/wireguard.inc
 
 SRCREV = "edb7f9587794326b3023fdf2c2e5cc69faf31a33"
 
-SRC_URI = "git://git.zx2c4.com/wireguard-linux-compat"
+SRC_URI = "git://git.zx2c4.com/wireguard-linux-compat;protocol=https"
 
 inherit module kernel-module-split
 

--- a/meta-lmp-base/recipes-kernel/wpanusb/wpanusb_git.bb
+++ b/meta-lmp-base/recipes-kernel/wpanusb/wpanusb_git.bb
@@ -6,7 +6,7 @@ SECTION = "kernel/network"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
-SRC_URI = "git://github.com/foundriesio/wpanusb.git"
+SRC_URI = "git://github.com/foundriesio/wpanusb.git;protocol=https"
 
 SRCREV = "a2b0a385d71861923524d35badaed172d3109fdd"
 

--- a/meta-lmp-base/recipes-security/optee/optee-client.inc
+++ b/meta-lmp-base/recipes-security/optee/optee-client.inc
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=69663ab153298557a59c67a60a743e5b"
 inherit systemd
 
 SRC_URI = " \
-    git://github.com/OP-TEE/optee_client.git \
+    git://github.com/OP-TEE/optee_client.git;protocol=https \
     file://tee-supplicant.service \
 "
 

--- a/meta-lmp-base/recipes-security/optee/optee-examples.inc
+++ b/meta-lmp-base/recipes-security/optee/optee-examples.inc
@@ -11,7 +11,7 @@ inherit python3native
 
 require optee.inc
 
-SRC_URI = "git://github.com/linaro-swg/optee_examples.git"
+SRC_URI = "git://github.com/linaro-swg/optee_examples.git;protocol=https"
 
 EXTRA_OEMAKE += "TA_DEV_KIT_DIR=${TA_DEV_KIT_DIR} \
                  HOST_CROSS_COMPILE=${HOST_PREFIX} \

--- a/meta-lmp-base/recipes-security/optee/optee-fiovb_git.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-fiovb_git.bb
@@ -7,7 +7,7 @@ DEPENDS = "optee-client"
 
 require optee.inc
 
-SRC_URI = "git://github.com/foundriesio/optee-fiovb.git"
+SRC_URI = "git://github.com/foundriesio/optee-fiovb.git;protocol=https"
 SRCREV = "77f2e70751b3a0585b7306dbf322077260ec6dd9"
 
 S = "${WORKDIR}/git"

--- a/meta-lmp-base/recipes-security/optee/optee-os-fio.inc
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio.inc
@@ -17,7 +17,7 @@ DEPENDS = "python3-pycryptodome-native python3-pycryptodomex-native python3-pyel
 DEPENDS_append_toolchain-clang = " compiler-rt"
 
 SRCBRANCH ?= "master"
-SRC_URI = "git://github.com/foundriesio/optee_os.git;branch=${SRCBRANCH}"
+SRC_URI = "git://github.com/foundriesio/optee_os.git;protocol=https;branch=${SRCBRANCH}"
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"

--- a/meta-lmp-base/recipes-security/optee/optee-sks_git.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-sks_git.bb
@@ -9,7 +9,7 @@ require optee.inc
 
 DEPENDS = "python3-pycryptodomex-native python3-pycrypto-native virtual/optee-os optee-client"
 
-SRC_URI = "git://github.com/foundriesio/optee-sks.git"
+SRC_URI = "git://github.com/foundriesio/optee-sks.git;protocol=https"
 SRCREV = "c5e0ae747c84b496585c4de7e4bded025e24959b"
 
 S = "${WORKDIR}/git"

--- a/meta-lmp-base/recipes-security/optee/optee-test.inc
+++ b/meta-lmp-base/recipes-security/optee/optee-test.inc
@@ -10,7 +10,7 @@ require optee.inc
 
 DEPENDS = "optee-client virtual/optee-os python3-pycryptodomex-native python3-pycrypto-native openssl"
 
-SRC_URI = "git://github.com/OP-TEE/optee_test.git"
+SRC_URI = "git://github.com/OP-TEE/optee_test.git;protocol=https"
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"

--- a/meta-lmp-base/recipes-security/optee/pkcs11-se050-import_git.bb
+++ b/meta-lmp-base/recipes-security/optee/pkcs11-se050-import_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause;md5=550794465ba0ec
 
 DEPENDS = "virtual/optee-os optee-client"
 
-SRC_URI = "git://github.com/foundriesio/optee-se050-pkcs11-import.git;branch=main"
+SRC_URI = "git://github.com/foundriesio/optee-se050-pkcs11-import.git;protocol=https;branch=main"
 SRCREV = "575c71c4c5cb7b7273232e55b776f6ce984b4e67"
 
 S = "${WORKDIR}/git"

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -3,7 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 BRANCH_lmp = "master"
 SRCREV_lmp = "5e2f6da2c1ad02ea87fa32564d9b37d9771a4ec3"
 
-SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;branch=${BRANCH};name=aktualizr \
+SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;protocol=https;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \
     file://aktualizr-lite.service.in \
     file://aktualizr-secondary.service \

--- a/meta-lmp-base/recipes-sota/custom-sota-client/custom-sota-client_git.bb
+++ b/meta-lmp-base/recipes-sota/custom-sota-client/custom-sota-client_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE;md5=815ca599c9df247a0c7f619bab
 inherit pkgconfig cmake systemd
 
 SRC_URI = "\
-    git://github.com/foundriesio/aktualizr-lite;branch=${BRANCH} \
+    git://github.com/foundriesio/aktualizr-lite;protocol=https;branch=${BRANCH} \
     file://systemd.service \
 "
 

--- a/meta-lmp-base/recipes-sota/ostreeuploader/ostreeuploader_git.bb
+++ b/meta-lmp-base/recipes-sota/ostreeuploader/ostreeuploader_git.bb
@@ -5,7 +5,8 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=2a944942e1496af1886903d274dedb13"
 
 GO_IMPORT = "github.com/foundriesio/ostreeuploader"
-SRC_URI = "git://${GO_IMPORT}"
+GO_IMPORT_PROTO ?= "https"
+SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO}"
 SRCREV = "54daa6777667ab9263c65a379453b65d9a2eb19a"
 
 UPSTREAM_CHECK_COMMITS = "1"

--- a/meta-lmp-base/recipes-support/crucible/crucible_git.bb
+++ b/meta-lmp-base/recipes-support/crucible/crucible_git.bb
@@ -5,7 +5,8 @@ LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=f10c6a44a73c48e5edb8daddd89517ba"
 
 GO_IMPORT = "github.com/f-secure-foundry/crucible"
-SRC_URI = "git://${GO_IMPORT}"
+GO_IMPORT_PROTO ?= "https"
+SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO}"
 SRCREV = "b84eb54532b969fed3025fb291fd83eafa0417e3"
 
 PV = "v2021.05.03+git${SRCPV}"

--- a/meta-lmp-base/recipes-support/fio-docker-fsck/fio-docker-fsck_git.bb
+++ b/meta-lmp-base/recipes-support/fio-docker-fsck/fio-docker-fsck_git.bb
@@ -5,8 +5,9 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 GO_IMPORT = "github.com/foundriesio/fio-docker-fsck"
+GO_IMPORT_PROTO ?= "https"
 SRC_URI = " \
-	git://${GO_IMPORT};branch=${SRCBRANCH} \
+	git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO};branch=${SRCBRANCH} \
 	file://fio-docker-fsck.service \
 "
 SRCREV = "337b94e6f828adb55eab18499b472661d7607dfa"

--- a/meta-lmp-base/recipes-support/fioconfig/fioconfig_git.bb
+++ b/meta-lmp-base/recipes-support/fioconfig/fioconfig_git.bb
@@ -5,7 +5,8 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=2a944942e1496af1886903d274dedb13"
 
 GO_IMPORT = "github.com/foundriesio/fioconfig"
-SRC_URI = "git://${GO_IMPORT} \
+GO_IMPORT_PROTO ?= "https"
+SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO} \
 	file://fioconfig.service \
 	file://fioconfig.path \
 	file://fioconfig-extract.service \

--- a/meta-lmp-base/recipes-support/ima-inspect/ima-inspect_0.14.bb
+++ b/meta-lmp-base/recipes-support/ima-inspect/ima-inspect_0.14.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=a23a74b3f4caf9616230789d94217acb"
 
 DEPENDS += "attr ima-evm-utils tclap"
 
-SRC_URI = "git://github.com/mgerstner/ima-inspect.git"
+SRC_URI = "git://github.com/mgerstner/ima-inspect.git;protocol=https"
 SRCREV = "05db29b37965366cba22abe5e4de545e439cb4f2"
 
 S = "${WORKDIR}/git"

--- a/meta-lmp-base/recipes-support/lshw/lshw_git.bb
+++ b/meta-lmp-base/recipes-support/lshw/lshw_git.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 DEPENDS = "gettext-native pciutils usbutils"
 COMPATIBLE_HOST = "(i.86|x86_64|arm|aarch64|riscv64).*-linux"
 
-SRC_URI = "git://github.com/lyonel/lshw.git \
+SRC_URI = "git://github.com/lyonel/lshw.git;protocol=https \
     file://docbook2man.patch \
 "
 


### PR DESCRIPTION
Tested locally:

- lmp-mfgtool+mfgtool-files, machine=imx6ullevk: **OK**
- lmp-base+lmp-mini-image, machine=imx6ullevk: **OK**

Tested on Factory:

- lmp-mfgtool+mfgtool-files, machine=imx6ullevk: **OK**
- lmp-base+lmp-factory-image, machine=imx6ullevk: **OK**

Due to https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git
it is required to use https protocol for github repo accessing.

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>