### PR TITLE
base: fioconfig: reuse OE ldflags and enable shared

### DIFF
--- a/meta-lmp-base/recipes-support/fioconfig/fioconfig_git.bb
+++ b/meta-lmp-base/recipes-support/fioconfig/fioconfig_git.bb
@@ -17,8 +17,8 @@ UPSTREAM_CHECK_COMMITS = "1"
 
 inherit go-mod systemd
 
-GOBUILDFLAGS += '-tags vpn -ldflags="-X ${GO_IMPORT}/internal.Commit=${SRCREV}"'
-GO_LINKSHARED = ""
+# Extend from go.bbclass to include internal.Commit and tags
+GO_LDFLAGS = '-tags vpn -ldflags="-X ${GO_IMPORT}/internal.Commit=${SRCREV} ${GO_RPATH} ${GO_LINKMODE} -extldflags '${GO_EXTLDFLAGS}'"'
 
 SYSTEMD_PACKAGES += "${PN}"
 SYSTEMD_SERVICE_${PN} = "fioconfig.service fioconfig-extract.service fioconfig.path"


### PR DESCRIPTION
Let OE handle the default ldflags used by the build and also allow
shared support as an effort to reduce the binary size.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>