### PR TITLE
Switch to new aktualizr

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "master"
-SRCREV_lmp = "d2232e2c0373ccd53917615452b22d549277ad35"
+SRCREV_lmp = "201341a3c1d8c1d09cea07bb1f74916fabea0db5"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;protocol=https;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -17,6 +17,7 @@ SRC_URI_append_libc-musl = " \
     file://utils.c-disable-tilde-as-it-is-not-supported-by-musl.patch \
 "
 
+PACKAGECONFIG[sota-tools] = "-DBUILD_SOTA_TOOLS=ON ${GARAGE_SIGN_OPS},-DBUILD_SOTA_TOOLS=OFF,glib-2.0 ostree,"
 PACKAGECONFIG += "${@bb.utils.filter('SOTA_EXTRA_CLIENT_FEATURES', 'fiovb', d)} libfyaml"
 PACKAGECONFIG[fiovb] = ",,,optee-fiovb aktualizr-fiovb-env-rollback"
 PACKAGECONFIG[ubootenv] = ",,u-boot-fw-utils,u-boot-fw-utils u-boot-default-env aktualizr-uboot-env-rollback"
@@ -64,6 +65,10 @@ FILES_${PN}-lite = " \
                     "
 FILES_${PN}-lite-lib = "${nonarch_libdir}/lib${PN}_lite.so"
 FILES_${PN}-lite-dev = "${includedir}/${PN}-lite"
+FILES_${PN}-dev = " \
+                   ${libdir}/pkgconfig/aktualizr.pc \
+                   ${includedir}/libaktualizr \
+                  "
 
 # Force same RDEPENDS, packageconfig rdepends common to both
 RDEPENDS_${PN}-lite = "${RDEPENDS_aktualizr} skopeo"


### PR DESCRIPTION
Adjust the aktualizr and sota-tools build configuration to the changes in the latest aktualizr build system.

1. Make sota-tools dependent on libostree.
2. Include package config metadata (aktualizr.pc) into the installation.
3. Switch to the latest aklite based on the latest aktualizr (uptane/aktualizr).