### PR TITLE
base: lmp-passwd/group: add pulse user and group

### DIFF
--- a/meta-lmp-base/files/lmp-group-table
+++ b/meta-lmp-base/files/lmp-group-table
@@ -49,6 +49,9 @@ wayland:x:64:
 shutdown:x:70:
 nobody:*:99:
 users:x:100:
+pulse:x:171:
+pulse-access:x:973:
+pulse-rt:x:974:
 nm-openvpn:x:975:
 mosquitto:x:976:
 dhcpcd:x:977:

--- a/meta-lmp-base/files/lmp-passwd-table
+++ b/meta-lmp-base/files/lmp-passwd-table
@@ -16,6 +16,7 @@ list:x:38:38:Mailing List Manager:/var/list:/bin/sh
 irc:x:39:39:ircd:/var/run/ircd:/bin/sh
 gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/bin/sh
 weston:x:63:63::/home/weston:/bin/false
+pulse:x:171:171:PulseAudio System Daemon:/var/run/pulse:/sbin/nologin
 nm-openvpn:x:975:975::/home/nm-openvpn:/bin/sh
 mosquitto:x:976:976::/home/mosquitto:/bin/false
 dhcpcd:x:977:977::/var/lib/dhcpcd:/bin/false


### PR DESCRIPTION
Required and used by the pulseaudio recipe.

Signed-off-by: Raul Muñoz <raul@foundries.io>