### PR TITLE
base: u-boot-fio: 2020.04: bump to e7934985ad

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2020.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2020.04.bb
@@ -1,4 +1,4 @@
 require u-boot-fio-common.inc
 
-SRCREV = "bfbf318ff17d239b43b73881cc72f00f14099670"
+SRCREV = "e7934985ad556aaae5ba29f0ba17abd49e69c571"
 SRCBRANCH = "2020.04+imx_5.4.70_2.3.0-fio"


### PR DESCRIPTION
Relevant changes:
- e7934985ad [FIO extras-squash] imx_env: fix set mfg to run fastboot by default

Signed-off-by: Michael Scott <mike@foundries.io>