### PR TITLE
bsp: u-boot-xlnx: 2021.07: bump to 05532d557e

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx_2021.07.bb
+++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx_2021.07.bb
@@ -3,7 +3,7 @@ UBOOT_VERSION = "v2021.07"
 UBRANCH = "xilinx-v2021.07-bsp"
 UBOOTURI = "git://github.com/foundriesio/u-boot.git;protocol=https"
 
-SRCREV = "c1907f22d4ec60b7fdfbf8a166d079bb6304cb62"
+SRCREV = "05532d557e4a515612c0eaa810f4b6c1097f29b9"
 
 include recipes-bsp/u-boot/u-boot-xlnx.inc
 include recipes-bsp/u-boot/u-boot-spl-zynq-init.inc


### PR DESCRIPTION
Relevant changes:
- 05532d557e [FIO toup] zynqmp: add dynamic detection of fit image spi offset
- 775778ae34 [FIO fromlist] xilinx: zynqmp: Config non zero SYS_SPI_U_BOOT_OFFS

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>