### PR TITLE
Use freescale 5.10-2.1.x-imx linux kernel instead of nxp lf-5.10.y

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp-dev-mfgtool.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp-dev-mfgtool.bb
@@ -2,11 +2,11 @@ SUMMARY = "Produces a Manufacturing Tool compatible Linux Kernel"
 DESCRIPTION = "Linux Kernel recipe that produces a Manufacturing Tool \
 compatible Linux Kernel to be used in updater environment"
 
-# Use NXP BSP by default
-KERNEL_REPO ?= "git://source.codeaurora.org/external/imx/linux-imx.git"
+# Use Freescale kernel by default
+KERNEL_REPO ?= "git://github.com/Freescale/linux-fslc.git"
 KERNEL_REPO_PROTOCOL ?= "https"
-LINUX_VERSION ?= "5.10.35"
-KERNEL_BRANCH ?= "lf-5.10.y"
+LINUX_VERSION ?= "5.10.80"
+KERNEL_BRANCH ?= "5.10-2.1.x-imx"
 
 # Drop features that are appended by other layers (not required here)
 KERNEL_FEATURES_remove = "cfg/fs/vfat.scc"

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_git.bb
@@ -1,13 +1,17 @@
 include recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
 
-LINUX_VERSION ?= "5.10.52"
-KBRANCH = "lf-5.10.y"
-SRCREV_machine = "a11753a89ec610768301d4070e10b8bd60fde8cd"
+# Use Freescale kernel by default
+KERNEL_REPO ?= "git://github.com/Freescale/linux-fslc.git"
+KERNEL_REPO_PROTOCOL ?= "https"
+LINUX_VERSION ?= "5.10.80"
+KERNEL_BRANCH ?= "5.10-2.1.x-imx"
+
+SRCREV_machine = "c0604ebbd45934a2c42df8382b674244d1963fa2"
 SRCREV_meta = "${KERNEL_META_COMMIT}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-SRC_URI = "git://source.codeaurora.org/external/imx/linux-imx.git;protocol=https;branch=${KBRANCH};name=machine; \
+SRC_URI = "${KERNEL_REPO};protocol=${KERNEL_REPO_PROTOCOL};branch=${KERNEL_BRANCH};name=machine; \
     ${KERNEL_META_REPO};protocol=${KERNEL_META_REPO_PROTOCOL};type=kmeta;name=meta;branch=${KERNEL_META_BRANCH};destsuffix=${KMETA} \
     file://0004-FIO-toup-hwrng-optee-support-generic-crypto.patch \
     file://0001-FIO-extras-arm64-dts-imx8mm-evk-use-imx8mm-evkb-for-.patch \


### PR DESCRIPTION
The 5.10-2.1.x-imx includes fixes from the mainline linux-stable and atm seems compatible with our patches and configs for lf-5.10.y.
