### PR TITLE
ebbr-nxp: add wi-fi firmware for imx8mm evkb #483

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-feature-wifi.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-wifi.inc
@@ -1,4 +1,6 @@
 # Wifi packages
+MACHINE_FIRMWARE_append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8987', 'linux-firmware-nxp89xx', '', d)}"
+
 CORE_IMAGE_BASE_INSTALL += " \
     hostapd \
     linux-firmware-ar3k \
@@ -8,4 +10,5 @@ CORE_IMAGE_BASE_INSTALL += " \
     linux-firmware-wl18xx \
     ${@bb.utils.contains('MACHINE_EXTRA_RRECOMMENDS', 'linux-firmware-rpidistro-bcm43430', 'linux-firmware-rpidistro-bcm43430', 'linux-firmware-bcm43430', d)} \
     ${@bb.utils.contains('MACHINE_EXTRA_RRECOMMENDS', 'linux-firmware-rpidistro-bcm43455', 'linux-firmware-rpidistro-bcm43455', 'linux-firmware-bcm43455', d)} \
+    ${@bb.utils.contains('MACHINE_EXTRA_RRECOMMENDS', 'linux-firmware-nxp89xx', 'linux-firmware-nxp89xx', '', d)} \
 "

--- a/meta-lmp-base/recipes-samples/images/lmp-feature-wifi.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-wifi.inc
@@ -11,4 +11,5 @@ CORE_IMAGE_BASE_INSTALL += " \
     ${@bb.utils.contains('MACHINE_EXTRA_RRECOMMENDS', 'linux-firmware-rpidistro-bcm43430', 'linux-firmware-rpidistro-bcm43430', 'linux-firmware-bcm43430', d)} \
     ${@bb.utils.contains('MACHINE_EXTRA_RRECOMMENDS', 'linux-firmware-rpidistro-bcm43455', 'linux-firmware-rpidistro-bcm43455', 'linux-firmware-bcm43455', d)} \
     ${@bb.utils.contains('MACHINE_EXTRA_RRECOMMENDS', 'linux-firmware-nxp89xx', 'linux-firmware-nxp89xx', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'mxm-mwifiex-load', 'mxm-mwifiex-setup', '', d)} \
 "

--- a/meta-lmp-base/recipes-support/mxm-mwifiex-setup/mxm-mwifiex-setup/modprobe-moal.conf
+++ b/meta-lmp-base/recipes-support/mxm-mwifiex-setup/mxm-mwifiex-setup/modprobe-moal.conf
@@ -1,0 +1,2 @@
+# Parameters for NXP MXM MWiFiEx dispatcher module
+options moal mod_para=nxp/wifi_mod_para.conf drvdbg=0x6

--- a/meta-lmp-base/recipes-support/mxm-mwifiex-setup/mxm-mwifiex-setup/modules-load-moal.conf
+++ b/meta-lmp-base/recipes-support/mxm-mwifiex-setup/mxm-mwifiex-setup/modules-load-moal.conf
@@ -1,0 +1,2 @@
+# NXP MXM MWiFiEx dispatcher module (serves all variants of 8987/8997)
+moal

--- a/meta-lmp-base/recipes-support/mxm-mwifiex-setup/mxm-mwifiex-setup_0.1.bb
+++ b/meta-lmp-base/recipes-support/mxm-mwifiex-setup/mxm-mwifiex-setup_0.1.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Setup NXP MXM MWiFiEx kernel module"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit allarch
+
+SRC_URI = " \
+	file://modules-load-moal.conf \
+	file://modprobe-moal.conf \
+"
+
+S = "${WORKDIR}"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_install() {
+	install -d ${D}${libdir}/modules-load.d
+	install -m 0644 ${WORKDIR}/modules-load-moal.conf ${D}${libdir}/modules-load.d/moal.conf
+
+	install -d ${D}${libdir}/modprobe.d
+	install -m 0644 ${WORKDIR}/modprobe-moal.conf ${D}${libdir}/modprobe.d/moal.conf
+}
+
+FILES_${PN} += "${libdir}/modules-load.d/moal.conf ${libdir}/modprobe.d/moal.conf"

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -379,6 +379,8 @@ EFI_PROVIDER_imx8mm-lpddr4-evk-ebbr ?= "grub-efi"
 OSTREE_BOOTLOADER_imx8mm-lpddr4-evk-ebbr ?= "grub"
 IMAGE_EFI_BOOT_FILES_sota_imx8mm-lpddr4-evk-ebbr ?= "${@make_efi_dtb_boot_files(d)}"
 WKS_FILE_sota_imx8mm-lpddr4-evk-ebbr ?= "efidisk-sota.wks"
+# iMX8MM EVKB revision
+MACHINE_FEATURES_append_imx8mm-lpddr4-evk = " nxp8987 mxm-mwifiex-load"
 
 # iMX8MP
 UBOOT_SIGN_ENABLE_sota_mx8mp = "1"

--- a/meta-lmp-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-lmp-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,10 +1,23 @@
-# Support additional firmware for WiLink8 modules
+# Support additional firmware for WiLink8 and NXP Wireless modules
+#
 # TIInit_11.8.32.bts is required for bluetooth support but this particular
 # version is not available in the linux-firmware repository.
+#
+# sdiouart8987_combo_v0.bin is required for WiFi/BT support but this firmware
+# is not available in the linux-firmware repository.
+#
+# A code from meta-imx layer is used as a reference:
+# https://source.codeaurora.org/external/imx/meta-imx/tree/meta-bsp/recipes-kernel/linux-firmware/linux-firmware_%25.bbappend?h=hardknott-5.10.52-2.1.0
 #
 SRC_URI_append = "\
     https://git.ti.com/ti-bt/service-packs/blobs/raw/31a43dc1248a6c19bb886006f8c167e2fd21cb78/initscripts/TIInit_11.8.32.bts;name=TIInit_11.8.32 \
 "
+IMX_FIRMWARE_BRANCH ?= "lf-5.10.52_2.1.0"
+SRC_URI_append_imx = "\
+    git://github.com/NXP/imx-firmware.git;protocol=https;branch=${IMX_FIRMWARE_BRANCH};destsuffix=imx-firmware;name=imx-firmware \
+"
+SRCREV_imx-firmware ?= "6d7f77b83164b08334806c4aa2034bc1f7da7b7d"
+
 SRC_URI_append_beaglebone-yocto = "\
     https://github.com/beagleboard/beaglebone-black-wireless/raw/d9135000a223228158d92fd2e3f00e495f642fee/firmware/wl18xx-conf.bin;name=wl18xx-conf \
 "
@@ -22,3 +35,23 @@ do_install_append() {
 do_install_append_beaglebone-yocto() {
     cp ${WORKDIR}/wl18xx-conf.bin ${D}${nonarch_base_libdir}/firmware/ti-connectivity/
 }
+
+do_install_append_imx () {
+    # Install NXP Connectivity
+    install -d ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 ${WORKDIR}/imx-firmware/nxp/wifi_mod_para.conf    ${D}${nonarch_base_libdir}/firmware/nxp
+
+    # Install NXP Connectivity 8987 firmware
+    install -m 0644 ${WORKDIR}/imx-firmware/nxp/FwImage_8987/ed_mac_ctrl_V3_8987.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 ${WORKDIR}/imx-firmware/nxp/FwImage_8987/sdiouart8987_combo_v0.bin ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 ${WORKDIR}/imx-firmware/nxp/FwImage_8987/txpwrlimit_cfg_8987.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+}
+
+PACKAGES =+ "${PN}-nxp89xx"
+
+FILES_${PN}-nxp89xx = " \
+       ${nonarch_base_libdir}/firmware/nxp/ed_mac_ctrl_V3_8987.conf \
+       ${nonarch_base_libdir}/firmware/nxp/sdiouart8987_combo_v0.bin \
+       ${nonarch_base_libdir}/firmware/nxp/txpwrlimit_cfg_8987.conf \
+       ${nonarch_base_libdir}/firmware/nxp/wifi_mod_para.conf \
+"


### PR DESCRIPTION
Can be merged separately. Wi-Fi starts working after merging https://github.com/foundriesio/lmp-kernel-cache/pull/24
