### PR TITLE
lmp-device-register: bump rev to 3fb49bb

### DIFF
--- a/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl glib-2.0"
 
-SRCREV = "9c333771e5c299a7a26b21800c6c714f1925a3ca"
+SRCREV = "3fb49bb5659377c63469fc9a49d6ab7d65bab702"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https;branch=master"
 


### PR DESCRIPTION
Relevant changes:
- 3fb49bb Ping the registration server prior to registration
- f3bbc70 Obtain an oauth token before HSM init

Signed-off-by: Mike Sul <mike.sul@foundries.io>