### PR TITLE
lmp_base: force NM to ignore docker interfaces

### DIFF
--- a/meta-lmp-base/recipes-connectivity/networkmanager/networkmanager/20-docker0.conf
+++ b/meta-lmp-base/recipes-connectivity/networkmanager/networkmanager/20-docker0.conf
@@ -1,0 +1,2 @@
+[keyfile]
+unmanaged-devices+=interface-name:docker*,interface-name:br-*

--- a/meta-lmp-base/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/meta-lmp-base/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS_prepend_lmp := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://20-docker0.conf"
+
+do_install_append() {
+    install -m 0600 ${WORKDIR}/20-docker0.conf ${D}${sysconfdir}/NetworkManager/conf.d/20-docker0.conf
+}
+
+FILES_${PN} += "${sysconfdir}/NetworkManager/conf.d/20-docker0.conf"


### PR DESCRIPTION
Running NetworkManager CLI and attempting to turn networking off affects
docker bridge interfaces. NM turns them off and is not able to turn them
back on. This patch tells NM to ignore all docker* and br-* interfaces.
It might affect other bridges and should be used with caution.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>