### PR TITLE
base: aktualizr-lite: bump to d132ef7

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "master"
-SRCREV_lmp = "201341a3c1d8c1d09cea07bb1f74916fabea0db5"
+SRCREV_lmp = "d132ef7456a06697b782e0c5ab6260e0a89e512e"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;protocol=https;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
Relevant changes:
 - d132ef7 apps: tests for the app fetch check
 - dd36f2c apps: do App fetching check thoroughly
 - 7c4bb06 aklite: invoke the post check callback in any case
 - baa56f3 apps: test container recreation parameterization
 - dc53ca6 apps: parameterized App recreation before reboot
 - a6400aa apps: check expected size of a layer manifest
 - a4d55f8 restorable-apps: check App update size if possible
 - cb3fd94 restorable-apps: check App metadata size before pull

Signed-off-by: Mike Sul <mike.sul@foundries.io>