### PR TITLE
linux-yocto: fixup virtualization include path

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/meta-lmp-base/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -7,4 +7,4 @@ LINUX_MINOR = "${@(d.getVar('LINUX_VERSION') or "x.y").split('.')[1]}"
 
 KERNEL_META_TYPE = "${@'yocto' if d.getVar('SRC_URI').find('type=kmeta') > 0 else 'none'}"
 
-include ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', 'linux-${KERNEL_META_TYPE}_${LINUX_MAJOR}.${LINUX_MINOR}_virtualization.inc', '', d)}
+include ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', 'recipes-kernel/linux/linux-${KERNEL_META_TYPE}_${LINUX_MAJOR}.${LINUX_MINOR}_virtualization.inc', '', d)}


### PR DESCRIPTION
This append is copied from meta-virtualization but now it is out of
the path is incomplete and the linux-yocto kernel virtualization are
silently dropped.

Correct the path and get the virtualization working again

Signed-off-by: Jerome Brunet <jbrunet@baylibre.com>