### PR TITLE
base: lmp-device-register: bump to b54dfa3

### DIFF
--- a/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl glib-2.0"
 
-SRCREV = "3fb49bb5659377c63469fc9a49d6ab7d65bab702"
+SRCREV = "b54dfa3469e98334c0bcf0781d7374790ccb77b1"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https;branch=master"
 


### PR DESCRIPTION
Relative changes:
- b54dfa3 Enable Restorable Apps by default

Signed-off-by: Mike Sul <mike.sul@foundries.io>