### PR TITLE
bsp: linux-lmp-ea-imx: bump to 4026a5c

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-ea-imx_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-ea-imx_git.bb
@@ -2,7 +2,7 @@ include recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
 
 LINUX_VERSION ?= "5.10.35"
 KBRANCH = "linux-ea-v5.10.y"
-SRCREV_machine = "a5db6c05ad18c141bfa493b9627af98781b86ab8"
+SRCREV_machine = "4026a5c637c4237dabffbaea1c1b38fddcf73fba"
 SRCREV_meta = "${KERNEL_META_COMMIT}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"


### PR DESCRIPTION
Relevant changes:
- 4026a5c639c Revert "[fio extras] imx7ulp poweroff state"

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>