### PR TITLE
bsp: imx-atf: update to lf-5.10.72-2.2.0

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-atf/imx-atf_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-atf/imx-atf_%.bbappend
@@ -1,5 +1,9 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
+SRCBRANCH = "lf_v2.4"
+# lf-5.10.72-2.2.0
+SRCREV = "5782363f92a2fdf926784449270433cf3ddf44bd"
+
 PROVIDES += "virtual/trusted-firmware-a"
 RPROVIDES_${PN} += "virtual/trusted-firmware-a"
 


### PR DESCRIPTION
Forgot one commit.

Important: NXP can change a branch in the imx-atf recipe. To make
fetching a particular commit reliable, stick a branch in FIO recipe
part.

Refresh patches based on the lf-5.10.72-2.2.0 release.

Related changes:
  - 7db434609 ("LF-4794 plat: imx8ulp: move OPTEE OS base address to 0xa6000000")
  - 0767d16d7 ("caam: refine code to avoid hang issue for some of toolchain")
  - 0a0a737d5 ("LF-4872 plat: imx8ulp: enable -fno-strict-aliasing")
  - e5562d954 ("plat: ls1088a ls2088a: fix erratum A-009810")
  - d72f464c2 ("nxp: soc-lx2160: drop erratum A-009810")
  - 68a45ce8c ("plat/nxp/ls1043a: remove confused header file")
  - 228c9787f ("LF-4810 plat: imx8ulp: Fix the tpm5 register restore")
  - 2ca00f66a ("LF-4801 plat: imx8ulp: Enable AFBB by default for APD side active mode")
  - 824f660d6 ("LF-4723-03 plat: imx8ulp: Add system power off support")
  - 37f2cbb7c ("LF-4723-02 plat: imx8ulp: Add APD power down mode(PD) support in system suspend")
  - 01901e590 ("LF-4723-01 plat: imx: Enable 512KB cache after resume on imx8ulp")
  - 14a860c13 ("LF-4715-4 imx8ulp: add scmi_sensor support")
  - e364ecb82 ("LF-4715-3 imx8ulp: upower: add read temperature hal function")
  - a0e14034a ("LF-4715-2 imx8ulp: update upower api")
  - 504d8b91b ("LF-4715-1 drivers: scmi-msg: add sensor support")
  - 2e36dd9be ("plat: imx8ulp: upower: Fix build by initializing srvgrp and function")
  - ded2cd343 ("LF-4593 plat: imx8ulp: Set cpu reset vector base to rom entry")
  - a80529a5d ("LF-4615 plat: imx: Update the license for upower api")

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>