### PR TITLE
base: u-boot-ostree-scr-fit: alternative: add missing fiovb header

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common-alternative.cmd.in
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common-alternative.cmd.in
@@ -122,7 +122,7 @@ if test "${fiovb.is_secondary_boot}" = "0"; then
 
 		else
 			# we haven't updated primary boot image yet
-			if test "${fiovb.bootupgrade_available}" = "1" && test "${bootupgrade_primary_updated}" = "0"; then
+			if test "${fiovb.bootupgrade_available}" = "1" && test "${fiovb.bootupgrade_primary_updated}" = "0"; then
 				run backup_boot0
 				echo "${fio_msg} updating primary boot images from ${ostree_root} ..."
 


### PR DESCRIPTION
Refer to fiovb.bootupgrade_primary_updated instead of bootupgrade_primary_updated
when in the closed platform path.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>