### PR TITLE
bsp: support: mfgtool-files: improve readme for -sec machines

### DIFF
--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6-sec/readme.md
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6-sec/readme.md
@@ -1,21 +1,19 @@
 # How to enable secure boot for apalis-imx6
 
-Download and extract CST from nxp.com.
+Download and extract CST from nxp.com: https://www.nxp.com/webapp/sps/download/license.jsp?colCode=IMX_CST_TOOL_NEW&appType=file2&location=null&DOWNLOAD_ID=null
 
-Start exporting the needed variable
+Start exporting the needed variables
 
    export CST_PATH=/path_to_cst/cst-3.3.1/linux64/bin/cst
    export SPL_PATH=/path_to_spl/
    export KEY_PATH=/path_to_key/
 
-
 Download the `lmp-tools`
 
-   git clone lmp-tools
+   git clone https://github.com/foundriesio/lmp-tools.git
    cd lmp-tools/security/imx_hab4
 
-
-Sign the MfgTool SPL file
+Sign the MFGTool SPL file
 
    ./sign-file.sh --key-dir $KEY_PATH --cst $CST_PATH --spl $SPL_PATH/mfgtool-files-apalis-imx6-sec/SPL-mfgtool
 

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx8-sec/readme.md
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx8-sec/readme.md
@@ -1,6 +1,6 @@
 # How to enable secure boot for apalis-imx8
 
-Download and extract CST from nxp.com.
+Download and extract CST from nxp.com: https://www.nxp.com/webapp/sps/download/license.jsp?colCode=IMX_CST_TOOL_NEW&appType=file2&location=null&DOWNLOAD_ID=null
 
 Start exporting the needed variables
 
@@ -10,7 +10,7 @@ Start exporting the needed variables
 
 Download the `lmp-tools`
 
-   git clone lmp-tools
+   git clone https://github.com/foundriesio/lmp-tools.git
    cd lmp-tools/security/imx_ahab
 
 Sign the MFGTool SPL file

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx6ullevk-sec/readme.md
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx6ullevk-sec/readme.md
@@ -1,21 +1,19 @@
 # How to enable secure boot for imx6ullevk
 
-Download and extract CST from nxp.com.
+Download and extract CST from nxp.com: https://www.nxp.com/webapp/sps/download/license.jsp?colCode=IMX_CST_TOOL_NEW&appType=file2&location=null&DOWNLOAD_ID=null
 
-Start exporting the needed variable
+Start exporting the needed variables
 
    export CST_PATH=/path_to_cst/cst-3.3.1/linux64/bin/cst
    export SPL_PATH=/path_to_spl/
    export KEY_PATH=/path_to_key/
 
-
 Download the `lmp-tools`
 
-   git clone lmp-tools
+   git clone https://github.com/foundriesio/lmp-tools.git
    cd lmp-tools/security/imx_hab4
 
-
-Sign the MfgTool SPL file
+Sign the MFGTool SPL file
 
    ./sign-file.sh --engine SW --key-dir $KEY_PATH --cst $CST_PATH --spl $SPL_PATH/mfgtool-files-imx6ullevk-sec/SPL-mfgtool --fix-sdp-dcd
 

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mm-lpddr4-evk-sec/readme.md
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mm-lpddr4-evk-sec/readme.md
@@ -1,21 +1,19 @@
 # How to enable secure boot for imx8mm-lpddr4-evk
 
-Download and extract CST from nxp.com.
+Download and extract CST from nxp.com: https://www.nxp.com/webapp/sps/download/license.jsp?colCode=IMX_CST_TOOL_NEW&appType=file2&location=null&DOWNLOAD_ID=null
 
-Start exporting the needed variable
+Start exporting the needed variables
 
    export CST_PATH=/path_to_cst/cst-3.3.1/linux64/bin/cst
    export SPL_PATH=/path_to_spl/
    export KEY_PATH=/path_to_key/
 
-
 Download the `lmp-tools`
 
-   git clone lmp-tools
+   git clone https://github.com/foundriesio/lmp-tools.git
    cd lmp-tools/security/imx_hab4
 
-
-Sign the MfgTool SPL file
+Sign the MFGTool SPL file
 
    ./sign-file.sh --key-dir $KEY_PATH --cst $CST_PATH --spl $SPL_PATH/mfgtool-files-imx8mm-lpddr4-evk-sec/imx-boot-mfgtool
 


### PR DESCRIPTION
Include more information on the SPL signing process and
standardize the readme between the -sec supported machines.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>