### PR TITLE
base: u-boot-fio: 2021.04: bump to 08349585ff

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2021.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2021.04.bb
@@ -1,5 +1,5 @@
 require u-boot-fio-common.inc
 
-SRCREV = "89bfb61e9d085308675fad0e09196b604bd256a2"
+SRCREV = "08349585ff66ce79a9a3a75cd6ac6c444151123f"
 SRCBRANCH = "2021.04+imx_5.10.35-2.0.0-fio"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"


### PR DESCRIPTION
Relevant changes:
- 08349585ff [FIO internal] cmd: fiovb: increase fiovb_name buffer

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>