### PR TITLE
bsp: linux-lmp-fslc-imx: bump to b536e818d3a1

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_git.bb
@@ -3,10 +3,10 @@ include recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
 # Use Freescale kernel by default
 KERNEL_REPO ?= "git://github.com/Freescale/linux-fslc.git"
 KERNEL_REPO_PROTOCOL ?= "https"
-LINUX_VERSION ?= "5.10.90"
+LINUX_VERSION ?= "5.10.92"
 KERNEL_BRANCH ?= "5.10-2.1.x-imx"
 
-SRCREV_machine = "e730e691a1edb8c38004d81b070529224e8df714"
+SRCREV_machine = "b536e818d3a1af4cba578ad3ff81f2aa03dbc05b"
 SRCREV_meta = "${KERNEL_META_COMMIT}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"


### PR DESCRIPTION
Relevant changes:
- b536e818d3a1 Merge pull request #526 from zandrey/5.10-2.1.x-imx
- 30dac067167b Merge tag 'v5.10.92' into 5.10-2.1.x-imx
- c982c1a83932 Linux 5.10.92
- c0091233f3d8 staging: greybus: fix stack size warning with UBSAN
- 66d21c005d9b drm/i915: Avoid bitwise vs logical OR warning in snb_wm_latency_quirk()
- 2d4fda471dc3 staging: wlan-ng: Avoid bitwise vs logical OR warning in hfa384x_usb_throttlefn()
- 3609fed7ac8b media: Revert "media: uvcvideo: Set unique vdev name based in type"
- 9b3c761e78d5 random: fix crash on multiple early calls to add_bootloader_randomness()
- 61cca7d191c7 random: fix data race on crng init time
- 3de9478230c3 random: fix data race on crng_node_pool
- 43c494294f30 can: gs_usb: gs_can_start_xmit(): zero-initialize hf->{flags,reserved}
- 45221a57b609 can: isotp: convert struct tpcon::{idx,len} to unsigned int
- bd61ae808b15 can: gs_usb: fix use of uninitialized variable, detach device on reception of invalid USB data
- f68e60001735 mfd: intel-lpss: Fix too early PM enablement in the ACPI ->probe()
- 5f76445a31b7 veth: Do not record rx queue hint in veth_xmit
- ddfa53825f3d mmc: sdhci-pci: Add PCI ID for Intel ADL
- 2e691f9894cc ath11k: Fix buffer overflow when scanning with extraie
- a87cecf94375 USB: Fix "slab-out-of-bounds Write" bug in usb_hcd_poll_rh_status
- 15982330b61d USB: core: Fix bug in resuming hub's handling of wakeup requests
- 413108ce3b56 ARM: dts: exynos: Fix BCM4330 Bluetooth reset polarity in I9100
- b6dd07023699 Bluetooth: bfusb: fix division by zero in send path
- 869e1677a058 Bluetooth: btusb: Add support for Foxconn QCA 0xe0d0
- c20021ce945f Bluetooth: btusb: Add support for Foxconn MT7922A
- 83493918380f Bluetooth: btusb: Add two more Bluetooth parts for WCN6855
- 294c0dd80d8a Bluetooth: btusb: fix memory leak in btusb_mtk_submit_wmt_recv_urb()
- 35ab8c9085b0 bpf: Fix out of bounds access from invalid *_or_null type verification
- c84fbba8a945 workqueue: Fix unbind_workers() VS wq_worker_running() race
- c39d68ab3836 md: revert io stats accounting
- 3aeaa9e07d59 Merge pull request #521 from zandrey/5.10-2.1.x-imx
- e1200a7e2645 Merge tag 'v5.10.91' into 5.10-2.1.x-imx
- df395c763ba0 Linux 5.10.91
- 674071c9eb26 Input: zinitix - make sure the IRQ is allocated before it gets enabled
- ef81f7d406c2 ARM: dts: gpio-ranges property is now required
- f63fa1a0d4df ipv6: raw: check passed optlen before reading
- cf07884e6bec drm/amd/display: Added power down for DCN10
- 10b9ccd0674d mISDN: change function names to avoid conflicts
- dd8a09cfbb99 atlantic: Fix buff_ring OOB in aq_ring_rx_clean
- c2f4bb251eb4 net: udp: fix alignment problem in udp4_seq_show()
- f82b48d1d86b ip6_vti: initialize __ip6_tnl_parm struct in vti6_siocdevprivate
- 8c87a83ef891 scsi: libiscsi: Fix UAF in iscsi_conn_get_param()/iscsi_conn_teardown()
- b798b677f94d usb: mtu3: fix interval value for intr and isoc
- 498d77fc5e38 ipv6: Do cleanup if attribute validation fails in multipath route
- 72b0d14a0a88 ipv6: Continue processing multipath route even if gateway attribute is invalid
- 5a7d650bb181 power: bq25890: Enable continuous conversion for ADC at charging
- 4f260ea5537d phonet: refcount leak in pep_sock_accep
- 61952934608c rndis_host: support Hytera digital radios
- 62cbde77d9c1 power: reset: ltc2952: Fix use of floating point literals
- 998d157e3b2a power: supply: core: Break capacity loop
- 16d8568378f9 xfs: map unwritten blocks in XFS_IOC_{ALLOC,FREE}SP just like fallocate
- aa606b82cdfb net: ena: Fix error handling when calculating max IO queues number
- e7f5480978fd net: ena: Fix undefined state when tx request id is out of bounds
- 2de3d961f8e7 sch_qfq: prevent shift-out-of-bounds in qfq_init_qdisc
- 4c34d5fd8c96 batman-adv: mcast: don't send link-local multicast to mcast routers
- f403b5f96e9a lwtunnel: Validate RTA_ENCAP_TYPE attribute length
- 48d5adb08d60 ipv6: Check attribute length for RTA_GATEWAY when deleting multipath route
- 173bfa2782fa ipv6: Check attribute length for RTA_GATEWAY in multipath route
- 914420a2a6c5 ipv4: Check attribute length for RTA_FLOW in multipath route
- a8fe915be6c2 ipv4: Check attribute length for RTA_GATEWAY in multipath route
- 786a335fef18 ftrace/samples: Add missing prototypes direct functions
- c859c4de0bd7 i40e: Fix incorrect netdev's real number of RX/TX queues
- d0ad64438fb5 i40e: Fix for displaying message regarding NVM version
- 32845aa60203 i40e: fix use-after-free in i40e_sync_filters_subtask()
- f7edb6b9438b sfc: The RX page_ring is optional
- 2b3f34da0d79 mac80211: initialize variable have_higher_than_11mbit
- 16e5cad6eca1 RDMA/uverbs: Check for null return of kmalloc_array
- a7c2cae997db netrom: fix copying in user data in nr_setsockopt
- beeb0fdedae8 RDMA/core: Don't infoleak GRH fields
- 3ca132e6b065 iavf: Fix limit of total number of queues to active queues of VF
- 396e3016905d i40e: Fix to not show opcode msg on unsuccessful VF MAC change
- 7f13d14e563c ieee802154: atusb: fix uninit value in atusb_set_extended_addr
- 7db1e245cb71 tracing: Tag trace_percpu_buffer as a percpu pointer
- 760c6a625506 tracing: Fix check for trace_percpu_buffer validity in get_trace_buf()
- c1e2da4b3f72 selftests: x86: fix [-Wstringop-overread] warn in test_process_vm_readv()
- 384111e12367 f2fs: quota: fix potential deadlock

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>