### PR TITLE
base: kmeta-linux-lmp-5.10.y: bump to 1ebe16a

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.10.y"
-KERNEL_META_COMMIT ?= "35c5614acb303c83b66fa870a39cde107a74a294"
+KERNEL_META_COMMIT ?= "1ebe16a566b2433722ab80e2c98842b08929ec3b"


### PR DESCRIPTION
Relevant changes:
- 1ebe16a bsp: imx: iot-gate-imx8: remove DPAA options
- e010a48 bsp: imx: apalis-imx8: fix config conflicts
- c869933 bsp: imx: imx8qm-mek: fix config conflicts
- 80f7905 bsp: imx: imx8mmevk: fix config conflicts
- 2985f07 bsp: uz3eg-iocc: enable CONFIG_COMMON_CLK_VC5

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>