### PR TITLE
base: lmp-base: drop modsign from DISTRO_FEATURES_DEFAULT

### DIFF
--- a/meta-lmp-base/conf/distro/lmp-base.conf
+++ b/meta-lmp-base/conf/distro/lmp-base.conf
@@ -10,3 +10,6 @@ INITRAMFS_FSTYPES = "cpio.gz"
 
 # By default we don't have any extra machine dependencies
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = ""
+
+# Facilitate kernel development by removing modsign by default
+DISTRO_FEATURES_DEFAULT_remove = "modsign"


### PR DESCRIPTION
modsign is useful on lmp but complicates local kernel module development
with lmp-base, so disable it by default (as we don't expect lmp-base to
follow the same security standards as lmp).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>