### PR TITLE
base: aktualizr-lite: bump to cfa32fc

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH_lmp = "master"
-SRCREV_lmp = "d132ef7456a06697b782e0c5ab6260e0a89e512e"
+SRCREV_lmp = "653a32d6eab22168b52d386c195216f11561b20b"
 
 SRC_URI_lmp = "gitsm://github.com/foundriesio/aktualizr-lite;protocol=https;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
Relevant changes:
- cfa32fc aklite: rollback if Apps creation failer before reboot
- 9ddfb0b aklite: rollback if Apps fail to start on boot
- 373d9ed aklite: fix comparision with `current` while
   checking for rollback. (Fix for just App update rollback)
- 8d77725 apps: check both skopeo and docker store before update
                (check available storage before update)
- a519a76 ostree: add the configured ostree remote before pull
                (switch to aktualizr 2022.1+fio)

Signed-off-by: Mike Sul <mike.sul@foundries.io>