### PR TITLE
Stable kernel updates (linux-lmp family)

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
@@ -1,0 +1,4 @@
+KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
+KERNEL_META_REPO_PROTOCOL ?= "https"
+KERNEL_META_BRANCH ?= "linux-v5.15.y"
+KERNEL_META_COMMIT ?= "7b00db136c7eebc266831667eec63ea840104629"

--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp-lts_git.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp-lts_git.bb
@@ -1,8 +1,8 @@
 include kmeta-linux-lmp-5.10.y.inc
 
-LINUX_VERSION ?= "5.10.76"
+LINUX_VERSION ?= "5.10.93"
 KBRANCH = "linux-v5.10.y"
-SRCREV_machine = "4baefc8955156f1bf240cc083e7384eb6ebf2be9"
+SRCREV_machine = "e71db0c3c75d02ca3a55c18f614d8c63a4667f3b"
 SRCREV_meta = "${KERNEL_META_COMMIT}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"

--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp-rt_git.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp-rt_git.bb
@@ -1,8 +1,8 @@
-include kmeta-linux-lmp-5.10.y.inc
+include kmeta-linux-lmp-5.15.y.inc
 
-LINUX_VERSION ?= "5.10.73"
-KBRANCH = "linux-v5.10.y-rt"
-SRCREV_machine = "43e4c279564e2288cc16f1b0f49e2c09a2bfae24"
+LINUX_VERSION ?= "5.15.13"
+KBRANCH = "linux-v5.15.y-rt"
+SRCREV_machine = "c23f14adc6e89aa26b1dedf43e987ed5ae13d743"
 SRCREV_meta = "${KERNEL_META_COMMIT}"
 LINUX_KERNEL_TYPE = "preempt-rt"
 

--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp_git.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp_git.bb
@@ -1,8 +1,8 @@
-include kmeta-linux-lmp-5.14.y.inc
+include kmeta-linux-lmp-5.15.y.inc
 
-LINUX_VERSION ?= "5.14.15"
-KBRANCH = "linux-v5.14.y"
-SRCREV_machine = "43b58400fd07ca1c146108b4bf27c6444d729503"
+LINUX_VERSION ?= "5.15.16"
+KBRANCH = "linux-v5.15.y"
+SRCREV_machine = "06b5c06f04a9e74b7d3658749878ce1253242965"
 SRCREV_meta = "${KERNEL_META_COMMIT}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp/qemuarm64/zone_dma_revert.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp/qemuarm64/zone_dma_revert.patch
@@ -11,10 +11,10 @@ Upstream-Status: Inappropriate
 Signed-off-by: Jon Mason <jon.mason@arm.com>
 
 diff --git a/arch/arm64/include/asm/processor.h b/arch/arm64/include/asm/processor.h
-index fce8cbecd6bc..a884d7773989 100644
+index ee2bdc1b9f5bb..4f1ac36eb74a5 100644
 --- a/arch/arm64/include/asm/processor.h
 +++ b/arch/arm64/include/asm/processor.h
-@@ -96,7 +96,8 @@
+@@ -100,7 +100,8 @@
  #endif /* CONFIG_ARM64_FORCE_52BIT */
  
  extern phys_addr_t arm64_dma_phys_limit;
@@ -25,27 +25,19 @@ index fce8cbecd6bc..a884d7773989 100644
  struct debug_info {
  #ifdef CONFIG_HAVE_HW_BREAKPOINT
 diff --git a/arch/arm64/mm/init.c b/arch/arm64/mm/init.c
-index a985d292e820..7fbb9c85af8a 100644
+index 37a81754d9b61..196f8cccb7b3c 100644
 --- a/arch/arm64/mm/init.c
 +++ b/arch/arm64/mm/init.c
-@@ -29,7 +29,6 @@
- #include <linux/kexec.h>
- #include <linux/crash_dump.h>
- #include <linux/hugetlb.h>
--#include <linux/acpi_iort.h>
- 
- #include <asm/boot.h>
- #include <asm/fixmap.h>
-@@ -43,6 +42,8 @@
- #include <asm/tlb.h>
+@@ -46,6 +46,8 @@
  #include <asm/alternative.h>
+ #include <asm/xen/swiotlb-xen.h>
  
 +#define ARM64_ZONE_DMA_BITS	30
 +
  /*
   * We need to be able to catch inadvertent references to memstart_addr
   * that occur (potentially in generic code) before arm64_memblock_init()
-@@ -53,13 +54,13 @@ s64 memstart_addr __ro_after_init = -1;
+@@ -56,13 +58,13 @@ s64 memstart_addr __ro_after_init = -1;
  EXPORT_SYMBOL(memstart_addr);
  
  /*
@@ -64,16 +56,16 @@ index a985d292e820..7fbb9c85af8a 100644
  
  #ifdef CONFIG_KEXEC_CORE
  /*
-@@ -84,7 +85,7 @@ static void __init reserve_crashkernel(void)
+@@ -75,7 +77,7 @@ phys_addr_t arm64_dma_phys_limit __ro_after_init;
+ static void __init reserve_crashkernel(void)
+ {
+ 	unsigned long long crash_base, crash_size;
+-	unsigned long long crash_max = arm64_dma_phys_limit;
++	unsigned long long crash_max = arm64_dma32_phys_limit;
+ 	int ret;
  
- 	if (crash_base == 0) {
- 		/* Current arm64 boot protocol requires 2MB alignment */
--		crash_base = memblock_find_in_range(0, arm64_dma_phys_limit,
-+		crash_base = memblock_find_in_range(0, arm64_dma32_phys_limit,
- 				crash_size, SZ_2M);
- 		if (crash_base == 0) {
- 			pr_warn("cannot allocate crashkernel (size:0x%llx)\n",
-@@ -187,24 +188,15 @@ static phys_addr_t __init max_zone_phys(unsigned int zone_bits)
+ 	ret = parse_crashkernel(boot_command_line, memblock_phys_mem_size(),
+@@ -137,24 +139,15 @@ static phys_addr_t __init max_zone_phys(unsigned int zone_bits)
  static void __init zone_sizes_init(unsigned long min, unsigned long max)
  {
  	unsigned long max_zone_pfns[MAX_NR_ZONES]  = {0};
@@ -100,7 +92,7 @@ index a985d292e820..7fbb9c85af8a 100644
  	max_zone_pfns[ZONE_NORMAL] = max;
  
  	free_area_init(max_zone_pfns);
-@@ -398,9 +390,16 @@ void __init arm64_memblock_init(void)
+@@ -352,7 +345,14 @@ void __init arm64_memblock_init(void)
  
  	early_init_fdt_scan_reserved_mem();
  
@@ -109,15 +101,13 @@ index a985d292e820..7fbb9c85af8a 100644
 +	else
 +		arm64_dma32_phys_limit = PHYS_MASK + 1;
 +
- 	reserve_elfcorehdr();
- 
  	high_memory = __va(memblock_end_of_DRAM() - 1) + 1;
 +
 +	dma_contiguous_reserve(arm64_dma32_phys_limit);
  }
  
  void __init bootmem_init(void)
-@@ -435,11 +434,6 @@ void __init bootmem_init(void)
+@@ -389,11 +389,6 @@ void __init bootmem_init(void)
  	sparse_init();
  	zone_sizes_init(min, max);
  
@@ -129,20 +119,20 @@ index a985d292e820..7fbb9c85af8a 100644
  	/*
  	 * request_standard_resources() depends on crashkernel's memory being
  	 * reserved, so do it here.
-@@ -522,7 +516,7 @@ static void __init free_unused_memmap(void)
+@@ -411,7 +406,7 @@ void __init bootmem_init(void)
  void __init mem_init(void)
  {
  	if (swiotlb_force == SWIOTLB_FORCE ||
 -	    max_pfn > PFN_DOWN(arm64_dma_phys_limit))
 +	    max_pfn > PFN_DOWN(arm64_dma_phys_limit ? : arm64_dma32_phys_limit))
  		swiotlb_init(1);
- 	else
+ 	else if (!xen_swiotlb_detect())
  		swiotlb_force = SWIOTLB_NO_FORCE;
 diff --git a/drivers/acpi/arm64/iort.c b/drivers/acpi/arm64/iort.c
-index 2494138a6905..94f34109695c 100644
+index 3b23fb775ac45..c5415d162e7d4 100644
 --- a/drivers/acpi/arm64/iort.c
 +++ b/drivers/acpi/arm64/iort.c
-@@ -1730,58 +1730,3 @@ void __init acpi_iort_init(void)
+@@ -1637,58 +1637,3 @@ void __init acpi_iort_init(void)
  
  	iort_init_platform_devices();
  }
@@ -202,18 +192,18 @@ index 2494138a6905..94f34109695c 100644
 -}
 -#endif
 diff --git a/include/linux/acpi_iort.h b/include/linux/acpi_iort.h
-index 1a12baa58e40..20a32120bb88 100644
+index f1f0842a2cb2b..0ce9756781a65 100644
 --- a/include/linux/acpi_iort.h
 +++ b/include/linux/acpi_iort.h
-@@ -38,7 +38,6 @@ void iort_dma_setup(struct device *dev, u64 *dma_addr, u64 *size);
- const struct iommu_ops *iort_iommu_configure_id(struct device *dev,
- 						const u32 *id_in);
+@@ -37,7 +37,6 @@ int iort_pmsi_get_dev_id(struct device *dev, u32 *dev_id);
+ int iort_dma_get_ranges(struct device *dev, u64 *size);
+ int iort_iommu_configure_id(struct device *dev, const u32 *id_in);
  int iort_iommu_msi_get_resv_regions(struct device *dev, struct list_head *head);
 -phys_addr_t acpi_iort_dma_get_max_cpu_address(void);
  #else
  static inline void acpi_iort_init(void) { }
  static inline u32 iort_msi_map_id(struct device *dev, u32 id)
-@@ -56,9 +55,6 @@ static inline const struct iommu_ops *iort_iommu_configure_id(
+@@ -54,9 +53,6 @@ static inline int iort_iommu_configure_id(struct device *dev, const u32 *id_in)
  static inline
  int iort_iommu_msi_get_resv_regions(struct device *dev, struct list_head *head)
  { return 0; }


### PR DESCRIPTION
Updating main linux-lmp kernel from 5.14 to 5.15 as 5.15 is the latest LTS.