### PR TITLE
base: systemd: define default packageconfig via bbappend

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -41,8 +41,6 @@ PACKAGECONFIG_append_pn-docker-ce = " seccomp"
 PACKAGECONFIG_append_pn-docker-moby = " seccomp"
 # Required because of https://github.com/opencontainers/runc/issues/2008
 PACKAGECONFIG_remove_pn-runc-opencontainers = "static"
-PACKAGECONFIG_append_pn-systemd = " journal-upload resolved seccomp serial-getty-generator"
-PACKAGECONFIG_remove_pn-systemd = "networkd"
 PACKAGECONFIG_append_pn-qemu-native = " libusb"
 PACKAGECONFIG_append_pn-networkmanager = " nss"
 

--- a/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
@@ -1,5 +1,43 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
+# Based on the original recipe but changed for LmP (done to avoid changing via removal)
+## NOTE: This list will have to be reviewed / updated on every systemd recipe update from OE-Core
+PACKAGECONFIG ?= " \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'acl audit efi ldconfig pam selinux smack usrmerge polkit', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'rfkill', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'xkbcommon', '', d)} \
+    backlight \
+    binfmt \
+    gshadow \
+    hibernate \
+    hostnamed \
+    idn \
+    ima \
+    journal-upload \
+    kmod \
+    localed \
+    logind \
+    machined \
+    myhostname \
+    nss \
+    nss-mymachines \
+    nss-resolve \
+    quotacheck \
+    randomseed \
+    resolved \
+    seccomp \
+    serial-getty-generator \
+    set-time-epoch \
+    sysusers \
+    sysvinit \
+    timedated \
+    timesyncd \
+    userdb \
+    utmp \
+    vconsole \
+    xz \
+"
+
 ALTERNATIVE_PRIORITY[resolv-conf] = "300"
 
 DEF_FALLBACK_NTP_SERVERS ?= "time1.google.com time2.google.com time3.google.com time4.google.com time.cloudflare.com"


### PR DESCRIPTION
To allow the user to enable support for networkd, we can't really use
the _removal syntax because that always gets parsed last, so instead
define a default set of packageconfig entries used and required by the
default LmP configuration via bbappends.

This is heavily based on the oe-core systemd recipe, and will have to be
maintained and updated as the main recipe adds/removes new options.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>