### PR TITLE
base: lmp-image-common: add mtd-utils

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -30,6 +30,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     nss-altfiles \
     pam-plugin-mkhomedir \
     resize-helper \
+    mtd-utils \
     sudo \
     zram \
 "


### PR DESCRIPTION
Add mtd-utils package for providing general MTD utilities (e.g. help
manipulating QSPI devices).

Licensed under GPLv2+ and provided by oe-core.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>