### PR TITLE
base: linux-lmp-dev-mfgtool: fix kernel revision used

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp-dev-mfgtool.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp-dev-mfgtool.bb
@@ -5,8 +5,9 @@ compatible Linux Kernel to be used in updater environment"
 # Use Freescale kernel by default
 KERNEL_REPO ?= "git://github.com/Freescale/linux-fslc.git"
 KERNEL_REPO_PROTOCOL ?= "https"
-LINUX_VERSION ?= "5.10.80"
+LINUX_VERSION ?= "5.10.93"
 KERNEL_BRANCH ?= "5.10-2.1.x-imx"
+KERNEL_COMMIT ?= "f28a9b90c506241e614212f2ce314d8f5460819d"
 
 # Drop features that are appended by other layers (not required here)
 KERNEL_FEATURES_remove = "cfg/fs/vfat.scc"


### PR DESCRIPTION
Fix the kernel revision used by the recipe to avoid unexpected changes
coming from upstream.

Revision and version aligned with linux-lmp-fslc-imx.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>