### PR TITLE
base: lmp-passwd/group: add systemd journal-gateway and remote user/group

### DIFF
--- a/meta-lmp-base/files/lmp-group-table
+++ b/meta-lmp-base/files/lmp-group-table
@@ -73,5 +73,7 @@ systemd-timesync:x:992:
 systemd-resolve:x:993:
 systemd-journal:x:994:
 systemd-network:x:995:
+systemd-journal-gateway:x:996:
+systemd-journal-remote:x:997:
 fio:x:1000:
 nogroup:x:65534:

--- a/meta-lmp-base/files/lmp-passwd-table
+++ b/meta-lmp-base/files/lmp-passwd-table
@@ -35,5 +35,7 @@ systemd-bus-proxy:x:991:991::/:/sbin/nologin
 systemd-timesync:x:992:992::/:/sbin/nologin
 systemd-resolve:x:993:993::/:/sbin/nologin
 systemd-network:x:995:995::/:/sbin/nologin
+systemd-journal-gateway:x:996:996::/:/sbin/nologin
+systemd-journal-remote:x:997:997::/:/sbin/nologin
 fio:x:1000:1000::/home/fio:/bin/sh
 nobody:x:65534:65534:nobody:/nonexistent:/bin/sh


### PR DESCRIPTION
Both can be required depending on the packageconfig used by the systemd
recipe.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>