### PR TITLE
Fix imx8mm -sec boot

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-mkimage/imx-boot_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-mkimage/imx-boot_%.bbappend
@@ -8,10 +8,10 @@ SRCREV = "1112c88470f339dc631e2a7117087f416af6d6b5"
 
 # TODO: Need to figure out why this is breaking mfgtool builds on mx8mp
 # For now only apply the patch to mx8mm and mx8mq
-SRC_URL_append_mx8mm = " \
+SRC_URI_append_mx8mm = " \
      file://0001-iMX8M-support-SPL-ddr-sign.patch \
 "
-SRC_URL_append_mx8mq = " \
+SRC_URI_append_mx8mq = " \
      file://0001-iMX8M-support-SPL-ddr-sign.patch \
 "
 SRC_URI_append_mx8m = " \


### PR DESCRIPTION
Fix typo in imx-boot_%.bbappend.
Tested the mfgtool boot.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>