### PR TITLE
bsp: imx-boot: change DDR DMEM firmware padding

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-mkimage/imx-boot/0001-iMX8M-change-DDR-DMEM-padding.patch
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-mkimage/imx-boot/0001-iMX8M-change-DDR-DMEM-padding.patch
@@ -1,0 +1,32 @@
+From 31cb17bb67d2af4d944f259c7b9928e9349e31e3 Mon Sep 17 00:00:00 2001
+From: Nate Drude <nate.d@variscite.com>
+Date: Mon, 14 Sep 2020 15:10:16 -0500
+Subject: [PATCH] iMX8M: change DDR DMEM padding
+
+Following U-boot's change 4332fdd (Change padding of DDR4 and LPDDR4 DMEM)
+align the padding of DDR DMEM fw in imx-mkimage as well.
+
+From meta-variscite-fslc ad930227.
+
+Signed-off-by: Nate Drude <nate.d@variscite.com>
+Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>
+---
+ iMX8M/soc.mak | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/iMX8M/soc.mak b/iMX8M/soc.mak
+index edcc397..b03455e 100644
+--- a/iMX8M/soc.mak
++++ b/iMX8M/soc.mak
+@@ -97,7 +97,7 @@ u-boot-spl-combine:
+ 
+ u-boot-spl-ddr.bin: u-boot-spl.bin $(lpddr4_imem_1d) $(lpddr4_dmem_1d) $(lpddr4_imem_2d) $(lpddr4_dmem_2d)
+ 	@objcopy -I binary -O binary --pad-to 0x8000 --gap-fill=0x0 $(lpddr4_imem_1d) lpddr4_pmu_train_1d_imem_pad.bin
+-	@objcopy -I binary -O binary --pad-to 0x4000 --gap-fill=0x0 $(lpddr4_dmem_1d) lpddr4_pmu_train_1d_dmem_pad.bin
++	@objcopy -I binary -O binary --pad-to 0x1000 --gap-fill=0x0 $(lpddr4_dmem_1d) lpddr4_pmu_train_1d_dmem_pad.bin
+ 	@objcopy -I binary -O binary --pad-to 0x8000 --gap-fill=0x0 $(lpddr4_imem_2d) lpddr4_pmu_train_2d_imem_pad.bin
+ 	@cat lpddr4_pmu_train_1d_imem_pad.bin lpddr4_pmu_train_1d_dmem_pad.bin > lpddr4_pmu_train_1d_fw.bin
+ 	@cat lpddr4_pmu_train_2d_imem_pad.bin $(lpddr4_dmem_2d) > lpddr4_pmu_train_2d_fw.bin
+-- 
+2.25.1
+

--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-mkimage/imx-boot_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-mkimage/imx-boot_%.bbappend
@@ -18,6 +18,7 @@ SRC_URI_append_mx8m = " \
      file://0002-iMX8M-add-SPL-only-build.patch \
      file://0003-iMX8M-add-support-for-packing-HDMI-fw-in-SPL-only-bo.patch \
      file://0004-iMX8M-also-create-nohdmi-boot-image.patch \
+     file://0001-iMX8M-change-DDR-DMEM-padding.patch \
 "
 
 SRC_URI_append_mx8qm = " \


### PR DESCRIPTION
Change padding of DMEM DDR firmware to save space in internal RAM.
DMEM is padded to 16KB but the actual size of this fw is less than
4KB, so padding to 4KB is enough.

imx-mkimage and U-Boot should be aligned in this change.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>