### PR TITLE
base: u-boot-fio: 2021.04: bump to 16568dac1a

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2021.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2021.04.bb
@@ -1,5 +1,5 @@
 require u-boot-fio-common.inc
 
-SRCREV = "0b31afc7bd0f1382f6c621403863fc4bbaf1595a"
+SRCREV = "16568dac1a5124d3a21b6875b592ea7c3a8846e1"
 SRCBRANCH = "2021.04+imx_5.10.35-2.0.0-fio"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"


### PR DESCRIPTION
Relevant changes:
- 16568dac1a [FIO fromtree] imx8m: drivers/ddr: Change padding of DDR4 and LPDDR4

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>