### PR TITLE
base/bsp: u-boot-fio-mfgtool: drop default preference and preferred v…

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-mfgtool_2021.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-mfgtool_2021.04.bb
@@ -6,5 +6,3 @@ require recipes-bsp/u-boot/u-boot-fio_2021.04.bb
 
 # Environment config is not required for mfgtool
 SRC_URI_remove = "file://fw_env.config"
-
-DEFAULT_PREFERENCE = "-1"

--- a/meta-lmp-bsp/conf/machine/include/lmp-mfgtool-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-mfgtool-machine-custom.inc
@@ -1,6 +1,3 @@
-## iMX targets should use the u-boot release based on the NXP BSP
-PREFERRED_VERSION_u-boot-fio-mfgtool_imx ?= "2021.04"
-
 # Embedded Artists i.MX7ULP COM
 UBOOT_SIGN_ENABLE_imx7ulpea-ucom = "1"
 PREFERRED_PROVIDER_virtual/kernel_imx7ulpea-ucom = "linux-lmp-dev-mfgtool"


### PR DESCRIPTION
…ersion

Since we are already setting 2021.04 as the preferred version for
u-boot-fio-mfgtool, drop the old default preference -1 (created during
the initial port to the latest BSP) and assume the latest as the
default.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>