### PR TITLE
bsp: mfgtool-files: clear fiovb variables for -sec targets in full_image

### DIFF
--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6-sec/full_image.uuu.in
@@ -1,0 +1,30 @@
+uuu_version 1.2.39
+
+SDP: boot -f SPL-mfgtool.signed
+
+SDPV: delay 1000
+SDPV: write -f u-boot-mfgtool.itb
+SDPV: jump
+
+FB: ucmd setenv fastboot_dev mmc
+FB: ucmd setenv mmcdev ${emmc_dev}
+FB: ucmd mmc dev ${emmc_dev} 1; mmc erase 0 0x2000
+
+# Clear fiovb vars
+FB: ucmd fiovb init ${mmc_dev}
+FB[-t 50000]: ucmd fiovb write_pvalue bootcount 0
+FB[-t 50000]: ucmd fiovb write_pvalue rollback 0
+FB[-t 50000]: ucmd fiovb write_pvalue upgrade_available 0
+FB[-t 50000]: ucmd fiovb write_pvalue bootupgrade_available 0
+FB[-t 50000]: ucmd fiovb write_pvalue bootfirmware_version 0
+FB[-t 50000]: ucmd fiovb write_pvalue debug 0
+
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash bootloader ../SPL-@@MACHINE@@.signed
+FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
+FB: flash bootloader_s ../SPL-@@MACHINE@@.signed
+FB: flash bootloader2_s ../u-boot-@@MACHINE@@.itb
+FB: flash sit ../sit-@@MACHINE@@.bin
+FB: ucmd if env exists emmc_ack; then ; else setenv emmc_ack 0; fi;
+FB: ucmd mmc partconf ${emmc_dev} ${emmc_ack} 1 0
+FB: done

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx8-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx8-sec/full_image.uuu.in
@@ -1,0 +1,41 @@
+uuu_version 1.3.102
+
+SDPS: boot -f imx-boot-mfgtool.signed
+CFG: FB: -vid 0x0525 -pid 0x4000
+CFG: FB: -vid 0x0525 -pid 0x4025
+CFG: FB: -vid 0x0525 -pid 0x402F
+CFG: FB: -vid 0x0525 -pid 0x4030
+CFG: FB: -vid 0x0525 -pid 0x4031
+
+SDPU: delay 1000
+SDPU: write -f u-boot-mfgtool.itb
+SDPU: jump
+
+# These commands will be run when use SPL and will be skipped if no spl
+# if (SPL support SDPV)
+# {
+SDPV: delay 1000
+SDPV: write -f u-boot-mfgtool.itb
+SDPV: jump
+# }
+
+FB: ucmd setenv fastboot_dev mmc
+FB: ucmd setenv mmcdev 0
+FB: ucmd mmc dev ${mmcdev} 1; mmc erase 0 0x3C00
+
+# Clear fiovb vars
+FB: ucmd fiovb init ${mmc_dev}
+FB[-t 50000]: ucmd fiovb write_pvalue bootcount 0
+FB[-t 50000]: ucmd fiovb write_pvalue rollback 0
+FB[-t 50000]: ucmd fiovb write_pvalue upgrade_available 0
+FB[-t 50000]: ucmd fiovb write_pvalue bootupgrade_available 0
+FB[-t 50000]: ucmd fiovb write_pvalue bootfirmware_version 0
+FB[-t 50000]: ucmd fiovb write_pvalue debug 0
+
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash bootloader ../imx-boot-@@MACHINE@@.signed
+FB: flash bootloader_s ../imx-boot-@@MACHINE@@.signed
+FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
+FB: flash bootloader2_s ../u-boot-@@MACHINE@@.itb
+FB: ucmd mmc partconf 0 0 1 0
+FB: done

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mm-lpddr4-evk-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mm-lpddr4-evk-sec/full_image.uuu.in
@@ -1,0 +1,30 @@
+uuu_version 1.2.39
+
+SDP: boot -f imx-boot-mfgtool.signed
+
+SDPV: delay 1000
+SDPV: write -f u-boot-mfgtool.itb
+SDPV: jump
+
+FB: ucmd setenv fastboot_dev mmc
+FB: ucmd setenv mmcdev ${emmc_dev}
+FB: ucmd mmc dev ${emmc_dev} 1; mmc erase 0 0x2000
+
+# Clear fiovb vars
+FB: ucmd fiovb init ${mmc_dev}
+FB[-t 50000]: ucmd fiovb write_pvalue bootcount 0
+FB[-t 50000]: ucmd fiovb write_pvalue rollback 0
+FB[-t 50000]: ucmd fiovb write_pvalue upgrade_available 0
+FB[-t 50000]: ucmd fiovb write_pvalue bootupgrade_available 0
+FB[-t 50000]: ucmd fiovb write_pvalue bootfirmware_version 0
+FB[-t 50000]: ucmd fiovb write_pvalue debug 0
+
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash bootloader ../imx-boot-@@MACHINE@@.signed
+FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
+FB: flash bootloader_s ../imx-boot-@@MACHINE@@.signed
+FB: flash bootloader2_s ../u-boot-@@MACHINE@@.itb
+FB: flash sit ../sit-@@MACHINE@@.bin
+FB: ucmd if env exists emmc_ack; then ; else setenv emmc_ack 0; fi;
+FB: ucmd mmc partconf ${emmc_dev} ${emmc_ack} 1 0
+FB: done

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files_%.bbappend
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files_%.bbappend
@@ -80,7 +80,6 @@ do_deploy_prepend_apalis-imx6() {
 
 do_compile_append_apalis-imx6-sec() {
     sed -i 's/SPL.*/&.signed/g' bootloader.uuu
-    sed -i 's/SPL.*/&.signed/g' full_image.uuu
 }
 
 do_deploy_prepend_apalis-imx6-sec() {
@@ -92,7 +91,6 @@ do_deploy_prepend_apalis-imx6-sec() {
 
 do_compile_append_apalis-imx8-sec() {
     sed -i 's/imx-boot.*/&.signed/g' bootloader.uuu
-    sed -i 's/imx-boot.*/&.signed/g' full_image.uuu
 }
 
 do_deploy_prepend_apalis-imx8-sec() {
@@ -104,7 +102,6 @@ do_deploy_prepend_apalis-imx8-sec() {
 
 do_compile_append_imx8mm-lpddr4-evk-sec() {
     sed -i 's/imx-boot.*/&.signed/g' bootloader.uuu
-    sed -i 's/imx-boot.*/&.signed/g' full_image.uuu
 }
 
 do_deploy_prepend_imx8mm-lpddr4-evk-sec() {


### PR DESCRIPTION
We need to clear the fiovb variables when re-flashing images for -sec targets
otherwise it will boot with old values, which might not be intetional.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>