### PR TITLE
base: u-boot-ostree-scr-fit: add missing 'echo' command

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common-alternative.cmd.in
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common-alternative.cmd.in
@@ -12,7 +12,7 @@ setenv saveenv_mmc 'if test -z "${fiovb_rpmb}"; then saveenv; fi;'
 
 # Boot firmware update helpers
 setenv rollback_setup 'if test -n "${fiovb_rpmb}"; then fiovb write_pvalue rollback 1; fiovb write_pvalue upgrade_available 0; fiovb write_pvalue bootupgrade_available 0; fiovb write_pvalue bootupgrade_primary_updated 0; else setenv rollback 1; setenv upgrade_available 0; setenv bootupgrade_available 0; setenv bootupgrade_primary_updated 0; setenv fiovb.rollback "${rollback}"; setenv fiovb.upgrade_available "${upgrade_available}"; setenv fiovb.bootupgrade_available "${bootupgrade_available}"; setenv fiovb.bootupgrade_primary_updated "${bootupgrade_primary_updated}"; fi;'
-setenv load_image 'if ext4load ${devtype} ${devnum}:2 ${loadaddr} ${image_path}; then echo "${fio_msg} loaded ${image_path}"; else "${fio_msg} error occured while loading ${image_path}, scheduling rollback after reset ..."; run rollback_setup; run saveenv_mmc; run do_reboot; fi;'
+setenv load_image 'if ext4load ${devtype} ${devnum}:2 ${loadaddr} ${image_path}; then echo "${fio_msg} loaded ${image_path}"; else echo "${fio_msg} error occured while loading ${image_path}, scheduling rollback after reset ..."; run rollback_setup; run saveenv_mmc; run do_reboot; fi;'
 setenv set_blkcnt 'setexpr blkcnt ${filesize} + 0x1ff && setexpr blkcnt ${blkcnt} / 0x200'
 
 # Import uEnv.txt

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common.cmd.in
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common.cmd.in
@@ -12,7 +12,7 @@ setenv saveenv_mmc 'if test -z "${fiovb_rpmb}"; then saveenv; fi;'
 
 # Boot firmware update helpers
 setenv rollback_setup 'if test -n "${fiovb_rpmb}"; then fiovb write_pvalue rollback 1; fiovb write_pvalue upgrade_available 0; fiovb write_pvalue bootupgrade_available 0; else setenv rollback 1; setenv upgrade_available 0; setenv bootupgrade_available 0; setenv fiovb.rollback "${rollback}"; setenv fiovb.upgrade_available "${upgrade_available}"; setenv fiovb.bootupgrade_available "${bootupgrade_available}"; fi;'
-setenv load_image 'if ext4load ${devtype} ${devnum}:2 ${loadaddr} ${image_path}; then echo "${fio_msg} loaded ${image_path}"; else "${fio_msg} error occured while loading ${image_path}, scheduling rollback after reset ..."; run rollback_setup; run saveenv_mmc; run set_primary_boot; reset; fi;'
+setenv load_image 'if ext4load ${devtype} ${devnum}:2 ${loadaddr} ${image_path}; then echo "${fio_msg} loaded ${image_path}"; else echo "${fio_msg} error occured while loading ${image_path}, scheduling rollback after reset ..."; run rollback_setup; run saveenv_mmc; run set_primary_boot; reset; fi;'
 setenv set_blkcnt 'setexpr blkcnt ${filesize} + 0x1ff && setexpr blkcnt ${blkcnt} / 0x200'
 
 # Import uEnv.txt


### PR DESCRIPTION
If an image is not found during 'load_image', the board reports:
Unknown command 'FIO: error occured while loading ...'

Fix this by adding the 'echo' command before the string.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>