### PR TITLE
base:uboot-fitimage.bbclass: Test if UBOOT_SPL_SIGN_KEYDIR exists

### DIFF
--- a/meta-lmp-base/classes/uboot-fitimage.bbclass
+++ b/meta-lmp-base/classes/uboot-fitimage.bbclass
@@ -258,7 +258,10 @@ EOF
 # $1 ... .itb filename
 uboot_fitimage_sign() {
 	if [ "x${UBOOT_SPL_SIGN_ENABLE}" = "x1" ]; then
-		tools/mkimage -F -k "${UBOOT_SIGN_KEYDIR}" -K spl/u-boot-spl.dtb -r ${1}
+		if [ ! -f "${UBOOT_SPL_SIGN_KEYDIR}/${UBOOT_SPL_SIGN_KEYNAME}.crt"  -o  ! -f "${UBOOT_SPL_SIGN_KEYDIR}/${UBOOT_SPL_SIGN_KEYNAME}.key" ]; then
+			bbfatal "UBOOT_SPL_SIGN_KEYDIR or UBOOT_SPL_SIGN_KEYNAME is invalid"
+		fi
+		tools/mkimage -F -k "${UBOOT_SPL_SIGN_KEYDIR}" -K spl/u-boot-spl.dtb -r ${1}
 	fi
 	cat spl/u-boot-spl-nodtb.bin spl/u-boot-spl.dtb > ${SPL_BINARY}
 }

--- a/meta-lmp-base/classes/uboot-fitimage.bbclass
+++ b/meta-lmp-base/classes/uboot-fitimage.bbclass
@@ -6,6 +6,7 @@ inherit kernel-arch
 # Share same key as used by U-Boot by default
 UBOOT_SPL_SIGN_ENABLE ??= "${UBOOT_SIGN_ENABLE}"
 UBOOT_SPL_SIGN_KEYNAME ??= "${UBOOT_SIGN_KEYNAME}"
+UBOOT_SPL_SIGN_KEYDIR ??= "${UBOOT_SIGN_KEYDIR}"
 
 # Default value for deployment filenames
 UBOOT_SPL_DTB_IMAGE ?= "${SPL_BINARYNAME}-${MACHINE}-${PV}-${PR}.dtb"


### PR DESCRIPTION
In case the file path is invalid, it is important to alert the user
as when the file is not present it will result in a invalid boot.

Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>