### PR TITLE
base: kmeta-linux-lmp-5.10.y: bump to bc94558a

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.10.y"
-KERNEL_META_COMMIT ?= "15c0657d63fad7aa802fac88dc61401b0d41f267"
+KERNEL_META_COMMIT ?= "bc94558a20f0f12c93e7f28cd6e4a5c725104d00"


### PR DESCRIPTION
Relevant changes:
- bc94558a bsp: imx: imx8mm/mp/mq: add back CONFIG_DRM_IMX_SEC_DSIM
- a172480e bsp: imx: enable DesignWare PCI host platform
- 3f98e242 bsp: imx: imx8m: enable PCIEPHY reset control

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>