### PR TITLE
bsp: imx-atf: imx8mp: enable sip call for secondary boot

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-atf/imx-atf/0001-plat-imx8mp-SiP-call-for-secondary-boot.patch
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-atf/imx-atf/0001-plat-imx8mp-SiP-call-for-secondary-boot.patch
@@ -1,0 +1,54 @@
+From b86e3cf3748729533b0272f514a03f2372e1723f Mon Sep 17 00:00:00 2001
+From: Vanessa Maegima <vanessa.maegima@foundries.io>
+Date: Fri, 18 Mar 2022 14:52:22 -0300
+Subject: [PATCH] plat: imx8mp: SiP call for secondary boot
+
+Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>
+---
+ plat/imx/imx8m/gpc_common.c                  | 13 +++++++++++++
+ plat/imx/imx8m/imx8mp/include/platform_def.h |  2 ++
+ 2 files changed, 15 insertions(+)
+
+diff --git a/plat/imx/imx8m/gpc_common.c b/plat/imx/imx8m/gpc_common.c
+index 6ef4387e2..be1a650c8 100644
+--- a/plat/imx/imx8m/gpc_common.c
++++ b/plat/imx/imx8m/gpc_common.c
+@@ -414,6 +414,19 @@ int imx_src_handler(uint32_t smc_fid, u_register_t x1, u_register_t x2,
+ 		SMC_SET_GP(handle, CTX_GPREG_X1, ret1);
+ 		SMC_SET_GP(handle, CTX_GPREG_X2, ret2);
+ 		break;
++#if defined(PLAT_imx8mp)
++	case IMX_SIP_SRC_SET_SECONDARY_BOOT:
++		if (x2)
++			mmio_setbits_32(IMX_SRC_BASE + SRC_GPR10_OFFSET,
++					SRC_GPR10_PERSIST_SECONDARY_BOOT);
++		else
++			mmio_clrbits_32(IMX_SRC_BASE + SRC_GPR10_OFFSET,
++					SRC_GPR10_PERSIST_SECONDARY_BOOT);
++		break;
++	case IMX_SIP_SRC_GET_SECONDARY_BOOT:
++		val = mmio_read_32(IMX_SRC_BASE + SRC_GPR10_OFFSET);
++		return !!(val & SRC_GPR10_PERSIST_SECONDARY_BOOT);
++#endif
+ 	default:
+ 		return SMC_UNK;
+ 
+diff --git a/plat/imx/imx8m/imx8mp/include/platform_def.h b/plat/imx/imx8m/imx8mp/include/platform_def.h
+index 39f0bee4f..4b6d535dd 100644
+--- a/plat/imx/imx8m/imx8mp/include/platform_def.h
++++ b/plat/imx/imx8m/imx8mp/include/platform_def.h
+@@ -136,9 +136,11 @@
+ #define SRC_OTG1PHY_SCR			U(0x20)
+ #define SRC_OTG2PHY_SCR			U(0x24)
+ #define SRC_GPR1_OFFSET			U(0x74)
++#define SRC_GPR10_OFFSET		U(0x98)
+ 
+ #define SRC_SCR_M4_ENABLE_MASK		BIT(3)
+ #define SRC_SCR_M4C_NON_SCLR_RST_MASK  	BIT(0)
++#define SRC_GPR10_PERSIST_SECONDARY_BOOT	BIT(30)
+ 
+ #define SNVS_LPCR			U(0x38)
+ #define SNVS_LPCR_SRTC_ENV		BIT(0)
+-- 
+2.25.1
+

--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-atf/imx-atf_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-atf/imx-atf_%.bbappend
@@ -11,6 +11,7 @@ SRC_URI_append = " \
     file://0002-plat-imx8m-add-SiP-call-for-SRC-PERSIST_SECONDARY_BO.patch \
     file://0003-feat-plat-imx8m-add-system_reset2-implementation.patch \
     file://0004-plat-imx8mq-SiP-call-for-secondary-boot.patch \
+    file://0001-plat-imx8mp-SiP-call-for-secondary-boot.patch \
 "
 
 SRC_URI_append_toradex = " \


### PR DESCRIPTION
This fixes rollback support in imx8mp-lpddr4-evk.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>