### PR TITLE
lmp: default image format should really be a default

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -56,8 +56,7 @@ USERADD_GID_TABLES = "files/lmp-group-table"
 USERADD_ERROR_DYNAMIC = "error"
 
 # Default image formats
-IMAGE_FSTYPES = "wic wic.gz wic.bmap"
-IMAGE_FSTYPES_remove = "tar.gz tar.bz2"
+IMAGE_FSTYPES ?= "wic wic.gz wic.bmap"
 
 # No Ostree tarball by default (prefer ota instead)
 BUILD_OSTREE_TARBALL ?= "0"

--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -13,19 +13,19 @@ TCLIBCAPPEND = ""
 require conf/distro/include/arm-defaults.inc
 require conf/distro/include/security_flags.inc
 
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-lmp"
-PREFERRED_PROVIDER_virtual/optee-os ?= "optee-os-fio"
-PREFERRED_PROVIDER_u-boot-fw-utils ?= "libubootenv"
-PREFERRED_RPROVIDER_u-boot-fw-utils ?= "libubootenv"
-PREFERRED_PROVIDER_zlib ?= "zlib"
-PREFERRED_PROVIDER_zlib-native ?= "zlib-native"
-PREFERRED_PROVIDER_nativesdk-zlib ?= "nativesdk-zlib"
-PREFERRED_PROVIDER_qemu-native ?= "qemu-native"
-PREFERRED_PROVIDER_nativesdk-qemu ?= "nativesdk-qemu"
+PREFERRED_PROVIDER_virtual/kernel ??= "linux-lmp"
+PREFERRED_PROVIDER_virtual/optee-os ??= "optee-os-fio"
+PREFERRED_PROVIDER_u-boot-fw-utils ??= "libubootenv"
+PREFERRED_RPROVIDER_u-boot-fw-utils ??= "libubootenv"
+PREFERRED_PROVIDER_zlib ??= "zlib"
+PREFERRED_PROVIDER_zlib-native ??= "zlib-native"
+PREFERRED_PROVIDER_nativesdk-zlib ??= "nativesdk-zlib"
+PREFERRED_PROVIDER_qemu-native ??= "qemu-native"
+PREFERRED_PROVIDER_nativesdk-qemu ??= "nativesdk-qemu"
 PREFERRED_PROVIDER_virtual/docker = "docker-moby"
 
-PREFERRED_VERSION_gcc-arm-none-eabi ?= "9-2019-q4-major"
-PREFERRED_VERSION_gcc-arm-none-eabi-native ?= "9-2019-q4-major"
+PREFERRED_VERSION_gcc-arm-none-eabi ??= "9-2019-q4-major"
+PREFERRED_VERSION_gcc-arm-none-eabi-native ??= "9-2019-q4-major"
 
 # Default distro features for LMP (can be extended by the user if needed)
 INIT_MANAGER = "systemd"


### PR DESCRIPTION
Forcing the IMAGE_FSTYPES is bad because it overrides the BSP actual
default values, which is more likely to be appropriate for the device than
the one provides by lmp.

Doing so forces the BSP adaptation to IMAGE_FSTYPES:append to restore a
sensible default. This brings another problem with initramfs which tries to
reset the IMAGE_FSTYPES for a good reason. Because of the append, another
image type is added to the initramfs, when all we added is probably a cpio.

A good example of that in meta-lmp-bsp is tegra which needs "tegraflash"
for the actual image and because it is added through an append, it needs to
removed from the initramfs. Such approach, while kinda working, really
don't scale well. It would be better to let the BSP (and its adaptation to
LmP) deal with the default fstype.

Signed-off-by: Jerome Brunet <jbrunet@baylibre.com>