### PR TITLE
base: initramfs-framework: factory_reset: handle immutable flag

### DIFF
--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework/ostree_factory_reset
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework/ostree_factory_reset
@@ -19,8 +19,12 @@ factory_reset() {
 	msg "Performing factory reset..."
 
 	# Replace /etc/ with /usr/etc (from deployment)
+	## Handle immutable flag (enable by ostree deploy)
+	chattr -i ${ROOTFS_DIR}
 	rm -rf ${ROOTFS_DIR}/etc
 	cp -a ${ROOTFS_DIR}/usr/etc ${ROOTFS_DIR}/
+	chattr +i ${ROOTFS_DIR}
+
 	# TODO: Handle use case when var is provided via a separated partition
 	OSTREE_VAR="${ROOTFS_DIR}/sysroot/ostree/deploy/${OSTREE_DISTRO}/var"
 


### PR DESCRIPTION
Ostree sets the immutable attribute to the deployment root folder during
ostree deploy, so make sure to handle the attribute during factory
reset.

This fixes the "Operation not permitted" error during factory reset.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>