### PR TITLE
bsp: drop orange-pi-r1.conf

### DIFF
--- a/meta-lmp-bsp/conf/machine/orange-pi-r1.conf
+++ b/meta-lmp-bsp/conf/machine/orange-pi-r1.conf
@@ -1,9 +1,0 @@
-#@TYPE: Machine
-#@NAME: orange-pi-r1
-#@DESCRIPTION: Machine configuration for the orange-pi-r1, base on allwinner H2+ CPU
-
-require conf/machine/include/sun8i.inc
-
-KERNEL_DEVICETREE = "sun8i-h2-plus-orangepi-r1.dtb"
-UBOOT_MACHINE = "orangepi_r1_defconfig"
-


### PR DESCRIPTION
Now available via meta-sunxi upstream.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>