### PR TITLE
bsp: linux-lmp-ti-staging: update to 5.10.65

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-ti-staging_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-ti-staging_git.bb
@@ -1,8 +1,8 @@
 include recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
 
-LINUX_VERSION ?= "5.10.41"
+LINUX_VERSION ?= "5.10.65"
 KBRANCH = "ti-linux-5.10.y"
-SRCREV_machine = "4c2eade9f722838b0e457650368cba1c6c7483c2"
+SRCREV_machine = "dcc6bedb2c2bdb509709e4ae08303206e95ce6c2"
 SRCREV_meta = "${KERNEL_META_COMMIT}"
 
 TI_DEFCONFIG_BUILDER_TARGET ?= "ti_sdk_arm64_release"


### PR DESCRIPTION
Follow changes from meta-ti master/honister and update kernel
to 5.10.65.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>