### PR TITLE
bsp: linux-lmp-rpi: update to 5.10.83

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-rpi_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-rpi_git.bb
@@ -1,8 +1,8 @@
 include recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
 
-LINUX_VERSION ?= "5.10.31"
+LINUX_VERSION ?= "5.10.83"
 KBRANCH = "rpi-5.10.y"
-SRCREV_machine = "89399e6e7e33d6260a954603ca03857df594ffd3"
+SRCREV_machine = "111a297d94e361de88d04b574acbca1bd5858cdb"
 SRCREV_meta = "${KERNEL_META_COMMIT}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"


### PR DESCRIPTION
Align with the same version used by meta-rpi honister.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>