### PR TITLE
bsp: opensbi: drop custom fdt function

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/opensbi/opensbi_0.9.bbappend
+++ b/meta-lmp-bsp/recipes-bsp/opensbi/opensbi_0.9.bbappend
@@ -1,7 +1,7 @@
 # freedom-u540 has a default setting for RISCV_SBI_PAYLOAD
 # This default means we can't let it equal None for the python check.
 # Instead, we're forced to cleanup the broken setting here.
-EXTRA_OEMAKE:remove:freedom-u540 = " ${@riscv_get_extra_oemake_image(d)}"
+EXTRA_OEMAKE:remove:freedom-u540 = "${@riscv_get_extra_oemake_image(d)} ${@riscv_get_extra_oemake_fdt(d)}"
 
 # Export fw_payloads to sysroot
 SYSROOT_DIRS += "/share"


### PR DESCRIPTION
Same issue as happened with riscv_get_extra_oemake_image (can't be set
to "" as that won't match None), so remove riscv_get_extra_oemake_fdt
since we expect the dtb to be provided via u-boot fit.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>