### PR TITLE
base: docker-ce: restore riscv64 support

### DIFF
--- a/meta-lmp-base/recipes-containers/docker/docker-ce/0001-dynbinary-use-go-cross-compiler.patch
+++ b/meta-lmp-base/recipes-containers/docker/docker-ce/0001-dynbinary-use-go-cross-compiler.patch
@@ -4,15 +4,23 @@ Date: Tue, 30 Jun 2020 22:23:33 -0400
 Subject: [PATCH] dynbinary: use go cross compiler
 
 Signed-off-by: Bruce Ashfield <bruce.ashfield@gmail.com>
----
- hack/make/.binary | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
 
-Index: git/src/import/hack/make/.binary
-===================================================================
---- git.orig/src/import/hack/make/.binary
-+++ git/src/import/hack/make/.binary
-@@ -81,7 +81,7 @@
+diff --git a/src/import/hack/make/.binary b/src/import/hack/make/.binary
+index d56e3f3126..bb310a3085 100644
+--- a/src/import/hack/make/.binary
++++ b/src/import/hack/make/.binary
+@@ -67,6 +67,10 @@ hash_files() {
+ 				export CC="${CC:-x86_64-linux-gnu-gcc}"
+ 				export CGO_ENABLED=1
+ 				;;
++			linux/riscv64)
++				export CC="${CC:-riscv64-linux-gnu-gcc}"
++				export CGO_ENABLED=1
++				;;
+ 		esac
+ 	fi
+ 
+@@ -81,7 +85,7 @@ hash_files() {
  
  	echo "Building: $DEST/$BINARY_FULLNAME"
  	echo "GOOS=\"${GOOS}\" GOARCH=\"${GOARCH}\" GOARM=\"${GOARM}\""

--- a/meta-lmp-base/recipes-containers/docker/docker-ce/0001-libnetwork-use-GO-instead-of-go.patch
+++ b/meta-lmp-base/recipes-containers/docker/docker-ce/0001-libnetwork-use-GO-instead-of-go.patch
@@ -34,8 +34,8 @@ Index: git/libnetwork/Makefile
  	@echo "🐳 $@"
 -	go build -o "bin/dnet-$$GOOS-$$GOARCH" ./cmd/dnet
 -	go build -o "bin/docker-proxy-$$GOOS-$$GOARCH" ./cmd/proxy
-+	@$(GO) build -linkshared $(GOBUILDFLAGS) -o "bin/docker-proxy-$$GOOS-$$GOARCH" ./cmd/proxy
-+	@$(GO) build -linkshared $(GOBUILDFLAGS) -o "bin/dnet-$$GOOS-$$GOARCH" ./cmd/dnet
++	@$(GO) build $(GOBUILDFLAGS) -o "bin/docker-proxy-$$GOOS-$$GOARCH" ./cmd/proxy
++	@$(GO) build $(GOBUILDFLAGS) -o "bin/dnet-$$GOOS-$$GOARCH" ./cmd/dnet
  
  # Rebuild protocol buffers.
  # These may need to be rebuilt after vendoring updates, so .proto files are declared .PHONY so they are always rebuilt.


### PR DESCRIPTION
Restore patch content from what was already used by docker-moby, which
is required for proper risc-v support.

This is needed as linkshared is not yet supported on this arch.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>