### PR TITLE
base: lmp: drop old meta-st-stm32mp bbmasks

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -105,10 +105,6 @@ BBMASK += " \
     /meta-xilinx-tools/recipes-bsp/ai-engine/aiefal_1.0.bb \
     /meta-xilinx-tools/recipes-bsp/u-boot/u-boot-xlnx_%.bbappend \
 "
-# meta-st-stm32mp: mask appends that are only compatible with gatesgarth
-BBMASK += " \
-    /meta-st-stm32mp/recipes-core/busybox/busybox_%.bbappend \
-"
 
 # disable xsct tarball by default (xilinx)
 USE_XSCT_TARBALL = "0"


### PR DESCRIPTION
Append removed in newer revisions of meta-st-stm32mp (honister).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>