### PR TITLE
base: optee-os-fio: 3.15: bump to 9b9bf5daa

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.15.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.15.0.bb
@@ -4,7 +4,7 @@ require ${@bb.utils.contains('MACHINE_FEATURES', 'se05x', 'optee-os-fio-se05x.in
 require optee-os-fio.inc
 
 PV = "3.15.0+git"
-SRCREV = "bf6c3463abd7dfdff0e3f726b25bca34a9064a45"
+SRCREV = "9b9bf5daacf605a8f7343e55d13850e55fcbaaab"
 SRCBRANCH = "3.15+fio"
 
 ALLOW_EMPTY:${PN}-ta-pkcs11 = "1"


### PR DESCRIPTION
Relevant changes:
- 9b9bf5daa [FIO toup] drivers: dcp: fix HUK support

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>