### PR TITLE
bsp: lmp-machine-custom: am64xx: set different tmpdir for k3r5

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -514,6 +514,8 @@ IMAGE_BOOT_FILES:append:am64xx-evm = " boot.itb"
 UBOOT_ENTRYPOINT:am64xx-evm = "0x82000000"
 UBOOT_LOADADDRESS:am64xx-evm = "0x82000000"
 UBOOT_DTB_LOADADDRESS:am64xx-evm = "0x88000000"
+## Avoid tmp overlap with am64xx-evm
+TMPDIR:k3r5 = "${TOPDIR}/tmp-k3r5"
 
 # Nvidia Tegra
 DISTRO_FEATURES:append:tegra = " opengl"


### PR DESCRIPTION
Avoid tmp overlay with the main machine as that results in build
failures when running with multiple cpu threads (due competing tmp
folder access).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>