### PR TITLE
base: rpcbind: support for nss altfiles

### DIFF
--- a/meta-lmp-base/recipes-extended/rpcbind/rpcbind_%.bbappend
+++ b/meta-lmp-base/recipes-extended/rpcbind/rpcbind_%.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OECONF += "--with-nss-modules='files altfiles'"


### PR DESCRIPTION
We use nss altfiles by default in LmP, and without it being enabled
rpcbind is required to be in files (/etc/passwd).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>