### PR TITLE
bsp: u-boot-fio-mfgtool: mx8mp: fix SPL size overrun

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio-mfgtool_%.bbappend
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio-mfgtool_%.bbappend
@@ -40,3 +40,6 @@ do_deploy:append:mx8() {
         ln -sf u-boot-spl.bin-${MACHINE} u-boot-spl.bin-${MACHINE}-
     fi
 }
+
+# disable branch protection to fix SPL size overrun issue
+TOOLCHAIN_OPTIONS:append:mx8mp = ' -mbranch-protection=none'


### PR DESCRIPTION
Due to a recent change in GCC configuration, the size of SPL for mx8mp
is causing an SRAM overrun.

Disable the new setting to reduce the SPL back to an acceptable size.

Signed-off-by: Michael Scott <mike@foundries.io>