### PR TITLE
Spdx convert

### DIFF
--- a/meta-lmp-base/recipes-bsp/device-tree/lmp-device-tree.bb
+++ b/meta-lmp-base/recipes-bsp/device-tree/lmp-device-tree.bb
@@ -2,7 +2,7 @@ SUMMARY = "Linux microPlatform BSP device trees"
 DESCRIPTION = "Linux microPlatform BSP device trees available from within layer"
 SECTION = "bsp"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
 inherit devicetree

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
@@ -4,7 +4,7 @@ ARM, MIPS and several other processors, which can be installed in a boot \
 ROM and used to initialize and test the hardware or to download and run \
 application code."
 SECTION = "bootloaders"
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
 DEPENDS += "flex-native bison-native bc-native dtc-native python3-setuptools-native"
 

--- a/meta-lmp-base/recipes-core/nss-altfiles/nss-altfiles_git.bb
+++ b/meta-lmp-base/recipes-core/nss-altfiles/nss-altfiles_git.bb
@@ -1,5 +1,5 @@
 SUMMARY = "NSS module which can read user information from files in an alternative location"
-LICENSE = "LGPL-2.1"
+LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=fb1949d8d807e528c1673da700aff41f"
 
 # Use upstream used and maintained by Flatcar

--- a/meta-lmp-base/recipes-devtools/python/python3-func-timeout_4.3.5.bb
+++ b/meta-lmp-base/recipes-devtools/python/python3-func-timeout_4.3.5.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Support running any existing function with a given timeout"
 HOMEPAGE = "https://github.com/kata198/func_timeout"
 SECTION = "devel/python"
-LICENSE = "LGPL-3.0-only & LGPL-2.0-only"
+LICENSE = "LGPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e6a600fd5e1d9cbde2d983680233ad02"
 
 inherit pypi setuptools3

--- a/meta-lmp-base/recipes-devtools/python/python3-func-timeout_4.3.5.bb
+++ b/meta-lmp-base/recipes-devtools/python/python3-func-timeout_4.3.5.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Support running any existing function with a given timeout"
 HOMEPAGE = "https://github.com/kata198/func_timeout"
 SECTION = "devel/python"
-LICENSE = "LGPLv3 & LGPL-2.0"
+LICENSE = "LGPL-3.0-only & LGPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e6a600fd5e1d9cbde2d983680233ad02"
 
 inherit pypi setuptools3

--- a/meta-lmp-base/recipes-kernel/jool/jool_git.bb
+++ b/meta-lmp-base/recipes-kernel/jool/jool_git.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "Jool is an Open Source SIIT and NAT64 for Linux"
 SUMMARY = "SIIT and NAT64 for Linux"
 HOMEPAGE = "https://www.jool.mx"
 SECTION = "kernel/network"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRC_URI = "git://github.com/NICMx/Jool.git;protocol=https;branch=master"

--- a/meta-lmp-base/recipes-kernel/wpanusb/wpanusb_git.bb
+++ b/meta-lmp-base/recipes-kernel/wpanusb/wpanusb_git.bb
@@ -3,7 +3,7 @@ on atusb driver for ATUSB IEEE 802.15.4 dongle."
 SUMMARY = "SoftMAC 802.15.4 kernel driver"
 HOMEPAGE = "https://github.com/foundriesio/wpanusb"
 SECTION = "kernel/network"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
 SRC_URI = "git://github.com/foundriesio/wpanusb.git;protocol=https;branch=master"

--- a/meta-lmp-base/recipes-security/optee/optee-fiovb_git.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-fiovb_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "OP-TEE Foundries.IO Verified Boot Client Application"
 HOMEPAGE = "https://github.com/foundriesio/optee-fiovb"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=92d506fc36dda404ceb608cdc34b7a99"
 
 DEPENDS = "optee-client"

--- a/meta-lmp-base/recipes-security/optee/optee-fiovb_git.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-fiovb_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "OP-TEE Foundries.IO Verified Boot Client Application"
 HOMEPAGE = "https://github.com/foundriesio/optee-fiovb"
-LICENSE = "GPL-2.0-only"
+LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=92d506fc36dda404ceb608cdc34b7a99"
 
 DEPENDS = "optee-client"

--- a/meta-lmp-base/recipes-security/optee/optee-test-fio.inc
+++ b/meta-lmp-base/recipes-security/optee/optee-test-fio.inc
@@ -2,7 +2,7 @@ SUMMARY = "OP-TEE sanity testsuite"
 DESCRIPTION = "Open Portable Trusted Execution Environment - Test suite"
 HOMEPAGE = "https://www.op-tee.org/"
 
-LICENSE = "BSD & GPLv2"
+LICENSE = "BSD & GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
 
 inherit python3native

--- a/meta-lmp-base/recipes-security/optee/optee-test-fio.inc
+++ b/meta-lmp-base/recipes-security/optee/optee-test-fio.inc
@@ -2,7 +2,7 @@ SUMMARY = "OP-TEE sanity testsuite"
 DESCRIPTION = "Open Portable Trusted Execution Environment - Test suite"
 HOMEPAGE = "https://www.op-tee.org/"
 
-LICENSE = "BSD & GPL-2.0-only"
+LICENSE = "BSD-2-Clause & GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
 
 inherit python3native

--- a/meta-lmp-base/recipes-support/crucible/crucible_git.bb
+++ b/meta-lmp-base/recipes-support/crucible/crucible_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "One-Time-Programmable (OTP) fusing tool"
 HOMEPAGE = "https://github.com/f-secure-foundry/crucible"
 SECTION = "devel"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=f10c6a44a73c48e5edb8daddd89517ba"
 
 GO_IMPORT = "github.com/f-secure-foundry/crucible"

--- a/meta-lmp-base/recipes-support/dnsmasq/dnsmasq_2.86.bbappend
+++ b/meta-lmp-base/recipes-support/dnsmasq/dnsmasq_2.86.bbappend
@@ -1,6 +1,6 @@
 # Upstream is dual licensed on GPLv2 | GPLv3, so force GPLv2 in order
 # to allow safe checks via image-license-checker
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 
 # Disabled by default to avoid conflicts with NM/systemd
 SYSTEMD_AUTO_ENABLE = "disable"

--- a/meta-lmp-base/recipes-support/ima-inspect/ima-inspect_0.14.bb
+++ b/meta-lmp-base/recipes-support/ima-inspect/ima-inspect_0.14.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Output IMA/EVM extended attributes in a human readable format"
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=a23a74b3f4caf9616230789d94217acb"
 
 DEPENDS += "attr ima-evm-utils tclap"

--- a/meta-lmp-base/recipes-support/lshw/lshw_git.bb
+++ b/meta-lmp-base/recipes-support/lshw/lshw_git.bb
@@ -5,7 +5,7 @@ configuration, bus speed, etc. on DMI-capable or EFI systems."
 SUMMARY = "Hardware lister"
 HOMEPAGE = "http://ezix.org/project/wiki/HardwareLiSter"
 SECTION = "console/tools"
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 DEPENDS = "gettext-native pciutils usbutils"

--- a/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb
+++ b/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb
@@ -1,5 +1,5 @@
 SUMMARY = "MFGTOOL Support Files and Binaries"
-LICENSE = "BSD-3-Clause & LGPLv2.1+"
+LICENSE = "BSD-3-Clause & LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9 \
                     file://${COMMON_LICENSE_DIR}/LGPL-2.1-or-later;md5=2a4f4fd2128ea2f65047ee63fbca9f68"
 

--- a/meta-lmp-bsp/dynamic-layers/xilinx-tools/recipes-bsp/bitstream/bitstream-signed.bb
+++ b/meta-lmp-bsp/dynamic-layers/xilinx-tools/recipes-bsp/bitstream/bitstream-signed.bb
@@ -1,5 +1,4 @@
 DESCRIPTION = "Recipe to deploy a signed bitstream"
-LICENSE = "MIT"
 SECTION = "firmware"
 
 # Proprietary by default, correct license depends on the bistream

--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx_2022.01.bb
+++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx_2022.01.bb
@@ -11,7 +11,7 @@ include recipes-bsp/u-boot/u-boot-lmp-common.inc
 
 PROVIDES += "u-boot"
 
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://README;beginline=1;endline=4;md5=744e7e3bb0c94b4b9f6b3db3bf893897"
 
 # u-boot-xlnx has support for these

--- a/meta-lmp-bsp/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bb
@@ -1,5 +1,5 @@
 SUMMARY = "NXP Wi-Fi driver for module 88w8997/8987"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://gpl-2.0.txt;md5=ab04ac0f249af12befccb94447c08b77"
 
 SRCBRANCH = "lf-5.10.72_2.2.0"


### PR DESCRIPTION
Converts the LICENSE to use SPDX tags instead.

The script used to convert: https://git.openembedded.org/openembedded-core/tree/scripts/contrib/convert-spdx-licenses.py