### PR TITLE
bsp: u-boot-fio: mx8: fix deploy for multiple UBOOT_CONFIG

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio_%.bbappend
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio_%.bbappend
@@ -18,8 +18,8 @@ do_deploy:append:mx8() {
                     else
                         install -m 0644 ${B}/${config}/arch/arm/dts/${UBOOT_DTB_NAME} ${DEPLOYDIR}/${BOOT_TOOLS}
                     fi
-                    install -m 0644 ${B}/${config}/spl/u-boot-spl-nodtb.bin ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-spl-nodtb.bin-${MACHINE}-${UBOOT_CONFIG}
-                    install -m 0644 ${B}/${config}/u-boot-nodtb.bin ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG}
+                    install -m 0644 ${B}/${config}/spl/u-boot-spl-nodtb.bin ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-spl-nodtb.bin-${MACHINE}-${type}
+                    install -m 0644 ${B}/${config}/u-boot-nodtb.bin ${DEPLOYDIR}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${type}
                 fi
             done
             unset type_idx


### PR DESCRIPTION
Follow the fix applied in meta-freescale (999f5d25a2) to fix the
conflict issue when there are multiple entries in UBOOT_CONFIG.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>