### PR TITLE
base: lmp-passwd/group: add systemd-coredump user and group

### DIFF
--- a/meta-lmp-base/files/lmp-group-table
+++ b/meta-lmp-base/files/lmp-group-table
@@ -75,5 +75,6 @@ systemd-journal:x:994:
 systemd-network:x:995:
 systemd-journal-gateway:x:996:
 systemd-journal-remote:x:997:
+systemd-coredump:x:998:
 fio:x:1000:
 nogroup:x:65534:

--- a/meta-lmp-base/files/lmp-passwd-table
+++ b/meta-lmp-base/files/lmp-passwd-table
@@ -37,5 +37,6 @@ systemd-resolve:x:993:993::/:/sbin/nologin
 systemd-network:x:995:995::/:/sbin/nologin
 systemd-journal-gateway:x:996:996::/:/sbin/nologin
 systemd-journal-remote:x:997:997::/:/sbin/nologin
+systemd-coredump:x:998:998::/:/sbin/nologin
 fio:x:1000:1000::/home/fio:/bin/sh
 nobody:x:65534:65534:nobody:/nonexistent:/bin/sh


### PR DESCRIPTION
This is required if you enable coredump in systemd PACKAGECONFIG
variable.

Signed-off-by: Matija Tudan <tudan.matija@gmail.com>