### PR TITLE
Docker compose v2

### DIFF
--- a/meta-lmp-base/recipes-containers/docker-compose/docker-compose-switch_1.0.4.bb
+++ b/meta-lmp-base/recipes-containers/docker-compose/docker-compose-switch_1.0.4.bb
@@ -1,0 +1,30 @@
+HOMEPAGE = "https://github.com/docker/compose-switch"
+SUMMARY = "Compose Switch is a replacement to the Compose V1 \
+ docker-compose (python) executable. It translates the command \
+ line into Compose V2 docker compose then run the latter."
+SECTION = "devel"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+SRC_URI = "git://github.com/docker/compose-switch.git;branch=master;protocol=https"
+SRCREV = "2b8c6e31c6d1b172cd4b94f316a849558d755bcb"
+
+UPSTREAM_CHECK_COMMITS = "1"
+
+GO_IMPORT = "github.com/docker/compose-switch"
+
+inherit go-mod update-alternatives
+
+GO_EXTRA_LDFLAGS = "-w -X ${GO_IMPORT}/internal.Version=${PV}"
+
+go_do_compile() {
+	export TMPDIR="${GOTMPDIR}"
+	mkdir -p ${B}/${GO_BUILD_BINDIR}
+	${GO} build ${GOBUILDFLAGS} -o ${B}/${GO_BUILD_BINDIR}/docker-compose ./main.go
+}
+
+ALTERNATIVE:${PN} = "docker-compose"
+ALTERNATIVE_PRIORITY = "100"
+ALTERNATIVE_LINK_NAME[docker-compose] = "${base_bindir}/docker-compose"
+
+RDEPENDS:${PN} += "docker-compose"

--- a/meta-lmp-base/recipes-containers/docker-compose/docker-compose_2.4.1.bb
+++ b/meta-lmp-base/recipes-containers/docker-compose/docker-compose_2.4.1.bb
@@ -1,0 +1,33 @@
+HOMEPAGE = "https://github.com/docker/compose"
+SUMMARY = "Define and run multi-container applications with Docker"
+DESCRIPTION = "Docker Compose is a tool for running multi-container \
+ applications on Docker defined using the Compose file format."
+SECTION = "devel"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
+
+SRC_URI = "git://github.com/docker/compose.git;branch=v2;protocol=https"
+SRCREV = "8d815ff587d7d5da90835a5007859edb9fafff61"
+
+UPSTREAM_CHECK_COMMITS = "1"
+
+GO_IMPORT = "github.com/docker/compose/v2"
+
+inherit go-mod
+
+GO_EXTRA_LDFLAGS = "-w -X ${GO_IMPORT}/internal.Version=${PV}"
+
+go_do_compile() {
+	export TMPDIR="${GOTMPDIR}"
+	mkdir -p ${B}/cli-plugins/bin
+	${GO} build ${GOBUILDFLAGS} -o ${B}/cli-plugins/bin/docker-compose ./cmd
+}
+
+go_do_install:append() {
+	install -d ${D}${libdir}/docker/cli-plugins
+	install -m 755 ${B}/cli-plugins/bin/docker-compose ${D}${libdir}/docker/cli-plugins
+}
+
+FILES:${PN} += "${libdir}/docker/cli-plugins"
+
+RDEPENDS:${PN} += "docker"

--- a/meta-lmp-base/recipes-containers/docker-compose/python3-docker-compose_%.bbappend
+++ b/meta-lmp-base/recipes-containers/docker-compose/python3-docker-compose_%.bbappend
@@ -1,0 +1,6 @@
+inherit update-alternatives
+
+# Define alternative to allow compose switch to take over
+ALTERNATIVE:${PN} = "docker-compose"
+ALTERNATIVE_PRIORITY = "30"
+ALTERNATIVE_LINK_NAME[docker-compose] = "${base_bindir}/docker-compose"


### PR DESCRIPTION
V2 has a different set of commands, and it is not 100% compatible with V1, but this PR also includes compose-switch to facilitate testing V2 without changing any clients.

The main difference is that to call docker compose you now need to use `docker compose` instead of `docker-compose`.

The ideal scenario is to change all clients to use V2 by default, without requiring compose-switch to be installed, but we can do that migration later.