### PR TITLE
Add params to define fiopush/check value

### DIFF
--- a/meta-lmp-base/classes/lmp.bbclass
+++ b/meta-lmp-base/classes/lmp.bbclass
@@ -47,18 +47,18 @@ IMAGE_CMD:ostree:append () {
 
 run_fiotool_cmd () {
 	if [ -n "${SOTA_PACKED_CREDENTIALS}" ]; then
-                if [ -e "${SOTA_PACKED_CREDENTIALS}" ]; then
+		if [ -e "${SOTA_PACKED_CREDENTIALS}" ]; then
 			if [ "${OSTREE_API_VERSION}" = "v2" ]; then
 				"${1}" -repo "${OSTREE_REPO}" -creds "${SOTA_PACKED_CREDENTIALS}" -api-version "${OSTREE_API_VERSION}" -cor-id "${GARAGE_TARGET_NAME}-${GARAGE_TARGET_VERSION}"
 			else
 				"${1}" -repo "${OSTREE_REPO}" -creds "${SOTA_PACKED_CREDENTIALS}"
 			fi
-                else
-                        bbwarn "SOTA_PACKED_CREDENTIALS file does not exist."
-                fi
-        else
-                bbwarn "SOTA_PACKED_CREDENTIALS not set. Please add SOTA_PACKED_CREDENTIALS."
-        fi
+		else
+			bbwarn "SOTA_PACKED_CREDENTIALS file does not exist."
+		fi
+	else
+		bbwarn "SOTA_PACKED_CREDENTIALS not set. Please add SOTA_PACKED_CREDENTIALS."
+	fi
 }
 
 do_image_ostreepush[depends] += "ostreeuploader-native:do_populate_sysroot"

--- a/meta-lmp-base/classes/lmp.bbclass
+++ b/meta-lmp-base/classes/lmp.bbclass
@@ -1,3 +1,7 @@
+USE_FIOTOOLS ?= "1"
+FIO_PUSH_CMD ?= "fiopush"
+FIO_CHECK_CMD ?= "fiocheck"
+
 # Provided by meta-lmp-bsp or any other compatible BSP layer
 include conf/machine/include/lmp-machine-custom.inc
 
@@ -48,10 +52,17 @@ IMAGE_CMD:ostree:append () {
 run_fiotool_cmd () {
 	if [ -n "${SOTA_PACKED_CREDENTIALS}" ]; then
 		if [ -e "${SOTA_PACKED_CREDENTIALS}" ]; then
-			if [ "${OSTREE_API_VERSION}" = "v2" ]; then
-				"${1}" -repo "${OSTREE_REPO}" -creds "${SOTA_PACKED_CREDENTIALS}" -api-version "${OSTREE_API_VERSION}" -cor-id "${GARAGE_TARGET_NAME}-${GARAGE_TARGET_VERSION}"
+			# Fallback to the OE built fiopush/fiocheck if FIO_PUSH/CHECK_CMD is not defined or it refers to non-existing or non-executable
+			if [ -n "${1}" ] && [ -x "${1}" ]; then
+				cmd="${1}"
 			else
-				"${1}" -repo "${OSTREE_REPO}" -creds "${SOTA_PACKED_CREDENTIALS}"
+				cmd="${2}"
+			fi
+			bbplain "Pushing/checking an ostree repo, cmd: ${cmd}"
+			if [ "${OSTREE_API_VERSION}" = "v2" ]; then
+				"${cmd}" -repo "${OSTREE_REPO}" -creds "${SOTA_PACKED_CREDENTIALS}" -api-version "${OSTREE_API_VERSION}" -cor-id "${GARAGE_TARGET_NAME}-${GARAGE_TARGET_VERSION}"
+			else
+				"${cmd}" -repo "${OSTREE_REPO}" -creds "${SOTA_PACKED_CREDENTIALS}"
 			fi
 		else
 			bbwarn "SOTA_PACKED_CREDENTIALS file does not exist."
@@ -64,7 +75,7 @@ run_fiotool_cmd () {
 do_image_ostreepush[depends] += "ostreeuploader-native:do_populate_sysroot"
 IMAGE_CMD:ostreepush:prepend () {
 	if [ "${USE_FIOTOOLS}" = "1" ]; then
-		run_fiotool_cmd "fiopush"
+		run_fiotool_cmd "${FIO_PUSH_CMD}" "fiopush"
 		# force return so garage-push called from meta-updater's IMAGE_CMD:ostreepush is not executed
 		return
 	fi
@@ -73,7 +84,7 @@ IMAGE_CMD:ostreepush:prepend () {
 do_image_garagecheck[depends] += "ostreeuploader-native:do_populate_sysroot"
 IMAGE_CMD:garagecheck:prepend () {
 	if [ "${USE_FIOTOOLS}" = "1" ]; then
-		run_fiotool_cmd "fiocheck"
+		run_fiotool_cmd "${FIO_CHECK_CMD}" "fiocheck"
 		# force return so garage-check called from meta-updater's IMAGE_CMD:garagecheck is not executed
 		return
 	fi


### PR DESCRIPTION
New params to specify fiopush/fiocheck to use, by default or if the specified one are not valid/exist then fiopush/fiocheck built by OE are used.

Signed-off-by: Mike Sul <mike.sul@foundries.io>