### PR TITLE
lmp-device-register: Bump version

### DIFF
--- a/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl glib-2.0"
 
-SRCREV = "b54dfa3469e98334c0bcf0781d7374790ccb77b1"
+SRCREV = "09a9a2572f7752d9b165eeab99f2fc5fd13ad046"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https;branch=master"
 


### PR DESCRIPTION
Pulls in:

 https://github.com/foundriesio/lmp-device-register/commit/09a9a2572f7752d9b165eeab99f2fc5fd13ad046

to allow setting a device-group when registering.

Signed-off-by: Andy Doan <andy@foundries.io>