### PR TITLE
apalis-imx6-sec: fix flashing and booting

### DIFF
--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6-sec/full_image.uuu.in
@@ -7,11 +7,12 @@ SDPV: write -f u-boot-mfgtool.itb
 SDPV: jump
 
 FB: ucmd setenv fastboot_dev mmc
+FB: ucmd setenv emmc_dev 0
 FB: ucmd setenv mmcdev ${emmc_dev}
 FB: ucmd mmc dev ${emmc_dev} 1; mmc erase 0 0x2000
 
 # Clear fiovb vars
-FB: ucmd fiovb init ${mmc_dev}
+FB: ucmd fiovb init ${emmc_dev}
 FB[-t 50000]: ucmd fiovb write_pvalue bootcount 0
 FB[-t 50000]: ucmd fiovb write_pvalue rollback 0
 FB[-t 50000]: ucmd fiovb write_pvalue upgrade_available 0

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6-sec/full_image.uuu.in
@@ -33,6 +33,5 @@ FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
 FB: flash bootloader_s ../SPL-@@MACHINE@@.signed
 FB: flash bootloader2_s ../u-boot-@@MACHINE@@.itb
 FB: flash sit ../sit-@@MACHINE@@.bin
-FB: ucmd if env exists emmc_ack; then ; else setenv emmc_ack 0; fi;
-FB: ucmd mmc partconf ${emmc_dev} ${emmc_ack} 1 0
+FB: ucmd mmc partconf ${emmc_dev} 1 1 0
 FB: done

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6-sec/full_image.uuu.in
@@ -16,7 +16,7 @@ SDPV: jump
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd setenv emmc_dev 0
 FB: ucmd setenv mmcdev ${emmc_dev}
-FB: ucmd mmc dev ${emmc_dev} 1; mmc erase 0 0x2000
+FB: ucmd mmc dev ${emmc_dev} 1; mmc erase 0 0x7FF
 
 # Clear fiovb vars
 FB: ucmd fiovb init ${emmc_dev}

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6-sec/full_image.uuu.in
@@ -1,5 +1,12 @@
 uuu_version 1.2.39
 
+# Add Toradex PID for Fastboot in u-boot
+CFG: FB: -vid 0x0525 -pid 0x4000
+CFG: FB: -vid 0x0525 -pid 0x401b
+CFG: FB: -vid 0x0525 -pid 0x401c
+CFG: FB: -vid 0x0525 -pid 0x401d
+CFG: FB: -vid 0x0525 -pid 0x4023
+
 SDP: boot -f SPL-mfgtool.signed
 
 SDPV: delay 1000


### PR DESCRIPTION
There is a set of commits that fixes regression issues with flashing and booting an image.