### PR TITLE
bsp: lmp-machine-custom: am64xx-evm: unset EFI_PROVIDER

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -514,6 +514,7 @@ IMAGE_BOOT_FILES:append:am64xx-evm = " boot.itb"
 UBOOT_ENTRYPOINT:am64xx-evm = "0x82000000"
 UBOOT_LOADADDRESS:am64xx-evm = "0x82000000"
 UBOOT_DTB_LOADADDRESS:am64xx-evm = "0x88000000"
+EFI_PROVIDER:am64xx-evm = ""
 ## Avoid tmp overlap with am64xx-evm
 TMPDIR:k3r5 = "${TOPDIR}/tmp-k3r5"
 


### PR DESCRIPTION
EFI_PROVIDER should only be set by ebbr targets to avoid having fstab
and other related configs to be set even when not really required.

This is only required because meta-ti sets this by default at k3.inc.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>