### PR TITLE
bsp: lmp-machine-custom: versal: fix WKS_FILES settings

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -517,6 +517,7 @@ OSTREE_KERNEL_ARGS:versal ?= "console=ttyAMA0,115200 ${OSTREE_KERNEL_ARGS_COMMON
 KERNEL_IMAGETYPE:sota:versal = "fitImage"
 KERNEL_CLASSES:sota:versal = "kernel-lmp-fitimage"
 IMAGE_BOOT_FILES:sota:versal = "boot.bin boot.itb"
+WKS_FILES:sota:versal = "sdimage-sota.wks"
 
 # TI AM64x
 MACHINE_FEATURES:append:am64xx-evm = " optee"


### PR DESCRIPTION
meta-xilinx-core sets a default WKS_FILES (versal-generic.conf) which is
not compatible with sota-based images (ostree).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>