### PR TITLE
base: systemd: add back xz support

### DIFF
--- a/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
@@ -35,6 +35,7 @@ PACKAGECONFIG ?= " \
     utmp \
     vconsole \
     wheel-group \
+    xz \
     zstd \
 "
 


### PR DESCRIPTION
We need to keep xz support enabled along with zstd otherwise devices
based on honister won't be able to read logs produced by hardknott (or
older) based images.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>