### PR TITLE
Imx8mp wifi fix

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-feature-wifi.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-wifi.inc
@@ -1,5 +1,5 @@
 # Wifi packages
-MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8987', 'linux-firmware-nxp89xx', '', d)}"
+MACHINE_FIRMWARE:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'nxp89xx', 'linux-firmware-nxp89xx', '', d)}"
 
 CORE_IMAGE_BASE_INSTALL += " \
     hostapd \
@@ -12,5 +12,5 @@ CORE_IMAGE_BASE_INSTALL += " \
     ${@bb.utils.contains('MACHINE_EXTRA_RRECOMMENDS', 'linux-firmware-rpidistro-bcm43455', 'linux-firmware-rpidistro-bcm43455', 'linux-firmware-bcm43455', d)} \
     ${@bb.utils.contains('MACHINE_EXTRA_RRECOMMENDS', 'linux-firmware-nxp89xx', 'linux-firmware-nxp89xx', '', d)} \
     ${@bb.utils.contains('MACHINE_FEATURES', 'mxm-mwifiex-load', 'mxm-mwifiex-setup', '', d)} \
-    ${@bb.utils.contains('MACHINE_FEATURES', 'nxp8987', 'kernel-module-nxp89xx', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'nxp89xx', 'kernel-module-nxp89xx', '', d)} \
 "

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -440,6 +440,8 @@ EFI_PROVIDER:imx8mp-lpddr4-evk-ebbr ?= "grub-efi"
 OSTREE_BOOTLOADER:imx8mp-lpddr4-evk-ebbr ?= "grub"
 IMAGE_EFI_BOOT_FILES:sota:imx8mp-lpddr4-evk-ebbr ?= "${@make_efi_dtb_boot_files(d)}"
 WKS_FILE:sota:imx8mp-lpddr4-evk-ebbr ?= "efidisk-sota.wks"
+# imx8mp comes with an AzureWave CM276MA PCIe Card
+MACHINE_FEATURES:append:imx8mp-lpddr4-evk = " nxp89xx mxm-mwifiex-load"
 
 # STM32MP1
 PREFERRED_PROVIDER_virtual/kernel:stm32mp1common ?= "linux-lmp-stm32"

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -403,7 +403,7 @@ OSTREE_BOOTLOADER:imx8mm-lpddr4-evk-ebbr ?= "grub"
 IMAGE_EFI_BOOT_FILES:sota:imx8mm-lpddr4-evk-ebbr ?= "${@make_efi_dtb_boot_files(d)}"
 WKS_FILE:sota:imx8mm-lpddr4-evk-ebbr ?= "efidisk-sota.wks"
 # iMX8MM EVKB revision
-MACHINE_FEATURES:append:imx8mm-lpddr4-evk = " nxp8987 mxm-mwifiex-load"
+MACHINE_FEATURES:append:imx8mm-lpddr4-evk = " nxp89xx mxm-mwifiex-load"
 
 # iMX8MP
 UBOOT_SIGN_ENABLE:sota:mx8mp = "1"

--- a/meta-lmp-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-lmp-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -45,6 +45,11 @@ do_install:append:imx () {
     install -m 0644 ${WORKDIR}/imx-firmware/nxp/FwImage_8987/ed_mac_ctrl_V3_8987.conf  ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 ${WORKDIR}/imx-firmware/nxp/FwImage_8987/sdiouart8987_combo_v0.bin ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 ${WORKDIR}/imx-firmware/nxp/FwImage_8987/txpwrlimit_cfg_8987.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+
+    # Install NXP Connectivity 8997PCIE firmware
+    install -m 0644 ${WORKDIR}/imx-firmware/nxp/FwImage_8997/ed_mac_ctrl_V3_8997.conf  ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 ${WORKDIR}/imx-firmware/nxp/FwImage_8997/pcieuart8997_combo_v4.bin ${D}${nonarch_base_libdir}/firmware/nxp
+    install -m 0644 ${WORKDIR}/imx-firmware/nxp/FwImage_8997/txpwrlimit_cfg_8997.conf  ${D}${nonarch_base_libdir}/firmware/nxp
 }
 
 PACKAGES =+ "${PN}-nxp89xx"
@@ -53,5 +58,8 @@ FILES:${PN}-nxp89xx = " \
        ${nonarch_base_libdir}/firmware/nxp/ed_mac_ctrl_V3_8987.conf \
        ${nonarch_base_libdir}/firmware/nxp/sdiouart8987_combo_v0.bin \
        ${nonarch_base_libdir}/firmware/nxp/txpwrlimit_cfg_8987.conf \
+       ${nonarch_base_libdir}/firmware/nxp/ed_mac_ctrl_V3_8997.conf \
+       ${nonarch_base_libdir}/firmware/nxp/pcieuart8997_combo_v4.bin \
+       ${nonarch_base_libdir}/firmware/nxp/txpwrlimit_cfg_8997.conf \
        ${nonarch_base_libdir}/firmware/nxp/wifi_mod_para.conf \
 "


### PR DESCRIPTION
- move generic nxp89xx feature
- add files to support 8997 PCIE
- enable nxp89xx on imx8mp-lpddr4-evk