### PR TITLE
The patch to docker cli package needed to make `docker compose` work

### DIFF
--- a/meta-lmp-base/recipes-containers/docker-compose/docker-compose/cli-config-support-default-system-config.patch
+++ b/meta-lmp-base/recipes-containers/docker-compose/docker-compose/cli-config-support-default-system-config.patch
@@ -1,0 +1,41 @@
+From 15e560830117514adc825c80326e7db66192e717 Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo@foundries.io>
+Date: Wed, 25 Sep 2019 17:08:35 -0300
+Subject: [PATCH] cli/config: support default system config
+
+Support reading configuration from system config when available. This
+allows the OS to control and update a base config.
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+---
+ cli/cli/cli/config/config.go | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/github.com/docker/cli/cli/config/config.go b/src/github.com/docker/cli/cli/config/config.go
+index 703fa30f48..79c324bfb1 100644
+--- a/src/github.com/docker/cli/cli/config/config.go
++++ b/src/github.com/docker/cli/cli/config/config.go
+@@ -21,6 +21,7 @@ const (
+ 	configFileDir  = ".docker"
+ 	oldConfigfile  = ".dockercfg"
+ 	contextsDir    = "contexts"
++	defaultSystemConfig = "/usr/lib/docker/config.json"
+ )
+
+ var (
+@@ -94,6 +95,15 @@ func Load(configDir string) (*configfile.ConfigFile, error) {
+ 	filename := filepath.Join(configDir, ConfigFileName)
+ 	configFile := configfile.New(filename)
+
++	// LmP: Load values from system config by default
++	if _, err := os.Stat(defaultSystemConfig); err == nil {
++		file, err := os.Open(defaultSystemConfig)
++		if err == nil {
++			configFile.LoadFromReader(file)
++			file.Close()
++		}
++	}
++
+ 	// Try happy path first - latest config file
+ 	if file, err := os.Open(filename); err == nil {
+ 		defer file.Close()

--- a/meta-lmp-base/recipes-containers/docker-compose/docker-compose_2.4.1.bb
+++ b/meta-lmp-base/recipes-containers/docker-compose/docker-compose_2.4.1.bb
@@ -6,8 +6,14 @@ SECTION = "devel"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
-SRC_URI = "git://github.com/docker/compose.git;branch=v2;protocol=https"
-SRCREV = "8d815ff587d7d5da90835a5007859edb9fafff61"
+SRC_URI = "\
+	git://github.com/docker/compose.git;branch=v2;protocol=https;name=compose \
+	git://github.com/docker/cli.git;branch=master;protocol=https;name=cli;destsuffix=${S}/src/github.com/docker/cli \
+	file://cli-config-support-default-system-config.patch \
+	"
+
+SRCREV_compose = "8d815ff587d7d5da90835a5007859edb9fafff61"
+SRCREV_cli = "2b52f62e962783ef39b53d1cb95e1d435b33f3cd"
 
 UPSTREAM_CHECK_COMMITS = "1"
 
@@ -20,6 +26,8 @@ GO_EXTRA_LDFLAGS = "-w -X ${GO_IMPORT}/internal.Version=${PV}"
 go_do_compile() {
 	export TMPDIR="${GOTMPDIR}"
 	mkdir -p ${B}/cli-plugins/bin
+	${GO} mod download -modcacherw
+	cp -f ${S}/src/github.com/docker/cli/cli/config/config.go ${B}/pkg/mod/github.com/docker/cli@v20.10.3-0.20220309205733-2b52f62e9627+incompatible/cli/config/config.go
 	${GO} build ${GOBUILDFLAGS} -o ${B}/cli-plugins/bin/docker-compose ./cmd
 }
 


### PR DESCRIPTION
I've just created a pull request out of the Andy's commit, which is basically copy-paste of the patch to `docker cli` needed for building of `docker` itself https://github.com/foundriesio/meta-lmp/blob/main/meta-lmp-base/recipes-containers/docker/files/cli-config-support-default-system-config.patch.


Signed-off-by: Andy Doan <andy@foundries.io>