### PR TITLE
base: kmeta-linux-lmp-5.10.y: bump to 4c245b8e

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.10.y"
-KERNEL_META_COMMIT ?= "ce0dfe45c11f0f784c7ca31dd10f80d551d1e576"
+KERNEL_META_COMMIT ?= "4c245b8e85ef300058339696eaafffbab39a6a14"


### PR DESCRIPTION
Relevant changes:
- 4c245b8e bsp: imx: cleanup DesignWare PCI host platform settings

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>