### PR TITLE
base: kmeta-linux-lmp-5.10.y: bump to c914d691

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.10.y"
-KERNEL_META_COMMIT ?= "4c245b8e85ef300058339696eaafffbab39a6a14"
+KERNEL_META_COMMIT ?= "c914d69114b9aefa9197ad52b5941f7ef79bd06d"


### PR DESCRIPTION
Relevant changes:
- c914d691 bsp: imx: imx8mp: enable missing functionality

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>