### PR TITLE
base: optee*: python3-pycrypto: Remove obsolete pycrypto module

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-examples-fio.inc
+++ b/meta-lmp-base/recipes-security/optee/optee-examples-fio.inc
@@ -5,7 +5,7 @@ HOMEPAGE = "https://github.com/linaro-swg/optee_examples"
 LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=cd95ab417e23b94f381dafc453d70c30"
 
-DEPENDS = "optee-client virtual/optee-os python3-pycryptodomex-native python3-pycrypto-native"
+DEPENDS = "optee-client virtual/optee-os python3-pycryptodomex-native"
 
 inherit python3native
 

--- a/meta-lmp-base/recipes-security/optee/optee-sks_git.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-sks_git.bb
@@ -7,7 +7,7 @@ inherit python3native
 
 require optee-fio.inc
 
-DEPENDS = "python3-pycryptodomex-native python3-pycrypto-native virtual/optee-os optee-client"
+DEPENDS = "python3-pycryptodomex-native virtual/optee-os optee-client"
 
 SRC_URI = "git://github.com/foundriesio/optee-sks.git;protocol=https;branch=master"
 SRCREV = "c5e0ae747c84b496585c4de7e4bded025e24959b"

--- a/meta-lmp-base/recipes-security/optee/optee-test-fio.inc
+++ b/meta-lmp-base/recipes-security/optee/optee-test-fio.inc
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://${S}/LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
 inherit python3native
 require optee-fio.inc
 
-DEPENDS = "optee-client virtual/optee-os python3-pycryptodomex-native python3-pycrypto-native openssl"
+DEPENDS = "optee-client virtual/optee-os python3-pycryptodomex-native openssl"
 
 SRC_URI = "git://github.com/OP-TEE/optee_test.git;protocol=https;branch=master"
 


### PR DESCRIPTION
Since [1] python3-pycrypto is removed

[1] http://cgit.openembedded.org/meta-openembedded/commit/meta-python/recipes-devtools/python?id=84769a963974cffc5d877e57a46a289a84bc293d

Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>