### PR TITLE
bsp: linux-firmware: Include SRCREV for all the sources

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-lmp-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -12,15 +12,19 @@
 SRC_URI:append = "\
     https://git.ti.com/ti-bt/service-packs/blobs/raw/31a43dc1248a6c19bb886006f8c167e2fd21cb78/initscripts/TIInit_11.8.32.bts;name=TIInit_11.8.32 \
 "
+SRCREV_TIInit_11.8.32 ?= "31a43dc1248a6c19bb886006f8c167e2fd21cb78"
+
 IMX_FIRMWARE_BRANCH ?= "lf-5.10.52_2.1.0"
 SRC_URI:append:imx = "\
-    git://github.com/NXP/imx-firmware.git;protocol=https;branch=${IMX_FIRMWARE_BRANCH};destsuffix=imx-firmware;name=imx-firmware;rev=${IMX_FIRMWARE_BRANCH} \
+    git://github.com/NXP/imx-firmware.git;protocol=https;branch=${IMX_FIRMWARE_BRANCH};destsuffix=imx-firmware;name=imx-firmware; \
 "
-SRCREV:imx-firmware ?= "6d7f77b83164b08334806c4aa2034bc1f7da7b7d"
+SRCREV_imx-firmware ?= "6d7f77b83164b08334806c4aa2034bc1f7da7b7d"
 
 SRC_URI:append:beaglebone-yocto = "\
     https://github.com/beagleboard/beaglebone-black-wireless/raw/d9135000a223228158d92fd2e3f00e495f642fee/firmware/wl18xx-conf.bin;name=wl18xx-conf \
 "
+
+SRCREV_wl18xx-conf ?= "d9135000a223228158d92fd2e3f00e495f642fee"
 
 # WiLink8
 SRC_URI[TIInit_11.8.32.md5sum] = "8c47a23f3f3d745b7f475a2db4eedb98"


### PR DESCRIPTION
I have *not* tested it during boot, but I don't change the hashes, only how they are configured.

I have built it the lmp-base-console-image for:
* beaglebone-yocto
* imx6ullevk-sec
* imx8mm-lpddr4-evk

During the work to convert meta-lmp to kirkstone, a (QA) build error highlighted that some information is not set for those SRC_URI, but I think it would be a good fit for main as well