### PR TITLE
base: lmp-feature-optee: drop sks, examples and pkcs11test

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-feature-optee.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-optee.inc
@@ -1,10 +1,7 @@
 # OP-TEE/SKS packages
 CORE_IMAGE_BASE_INSTALL += " \
     optee-client \
-    optee-examples \
     optee-fiovb \
     optee-os-fio-ta \
-    optee-sks \
     optee-test \
-    pkcs11test \
 "


### PR DESCRIPTION
They are not strictly required, so remove in order to make them optional
based on the user needs.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>