### PR TITLE
Initial patchset to include kirkstone support

### DIFF
--- a/meta-lmp-base/conf/distro/lmp-mfgtool.conf
+++ b/meta-lmp-base/conf/distro/lmp-mfgtool.conf
@@ -21,9 +21,6 @@ PREFERRED_PROVIDER_virtual/optee-os ?= "optee-os-fio-mfgtool"
 # Base settings from LMP
 require conf/distro/include/lmp.inc
 
-# Enable reproducible builds
-INHERIT += "reproducible_build"
-
 # Machine specific overrides
 include conf/machine/include/lmp-mfgtool-machine-custom.inc
 

--- a/meta-lmp-base/conf/distro/lmp.conf
+++ b/meta-lmp-base/conf/distro/lmp.conf
@@ -14,7 +14,7 @@ OSTREE_KERNEL_ARGS_COMMON ?= "root=LABEL=otaroot rootfstype=ext4"
 OSTREE_KERNEL_ARGS ?= "${OSTREE_KERNEL_ARGS_COMMON}"
 DISTRO_FEATURES:append = " sota"
 DISTRO_FEATURES_NATIVE:append = " sota"
-INHERIT += "sota reproducible_build"
+INHERIT += "sota"
 ## No need to install the kernel image into the boot partition
 IMAGE_BOOT_FILES:remove = " ${KERNEL_IMAGETYPE}"
 ## Prefer aktualizr-lite as the default SOTA_CLIENT

--- a/meta-lmp-base/conf/layer.conf
+++ b/meta-lmp-base/conf/layer.conf
@@ -19,7 +19,7 @@ LAYERDEPENDS_meta-lmp-base = " \
     sota \
     security \
 "
-LAYERSERIES_COMPAT_meta-lmp-base = "honister"
+LAYERSERIES_COMPAT_meta-lmp-base = "kirkstone"
 
 BBFILES_DYNAMIC += " \
     integrity:${LAYERDIR}/dynamic-layers/integrity/*/*/*.bb \

--- a/meta-lmp-bsp/conf/layer.conf
+++ b/meta-lmp-bsp/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_PATTERN_meta-lmp-bsp := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-lmp-bsp = "9"
 
 LAYERDEPENDS_meta-lmp-bsp = "core meta-lmp-base"
-LAYERSERIES_COMPAT_meta-lmp-bsp = "honister"
+LAYERSERIES_COMPAT_meta-lmp-bsp = "kirkstone"
 
 BBFILES_DYNAMIC += " \
     meta-arm:${LAYERDIR}/dynamic-layers/meta-arm/*/*/*.bb \


### PR DESCRIPTION
This is the initial patchset to start the work to convert meta-lmp to kirkstone.

It is not complete yet, by provides a good base to start working on BSP integration.