### PR TITLE
base: kmeta-linux-lmp-5.10.y: bump to abe5439

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.10.y"
-KERNEL_META_COMMIT ?= "38a542bd83e78682f88061d1bc2d89159dde4022"
+KERNEL_META_COMMIT ?= "abe5439380cd5b7fc4c97c63042ed9826d425f2f"


### PR DESCRIPTION
Relevant changes:
  - abe5439: versal: preempt: preempt_none

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>