### PR TITLE
base: recipe-sota: aktualizr-lite: bump to 96640d2

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-BRANCH:lmp = "v85"
-SRCREV:lmp = "35ebc64154c4bcc60f1108c228c0446e1c4940d7"
+BRANCH:lmp = "master"
+SRCREV:lmp = "96640d24be97b597e2bfb545c22b255427888f60"
 
 SRC_URI:lmp = "gitsm://github.com/foundriesio/aktualizr-lite;protocol=https;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
Relevant changes:
- 5b0a792 apps: prune stopped containers after successful update
- 09070c8 aklite: httpclient: follow redirects
- 8680360 apps: make a storage high watermark configurable
- e507c3f apps: Use `docker compose` by default
- 5b922e2 apps: Inform a caller if no space while fetching
- a499ebd ostree: Detect and return no space error if pull fails
- 2db28ef aklite: Skip update download if failed before
- 96640d2 apps: Fallback to python's compose if no docker's