### PR TITLE
bsp: u-boot-xlnx: 2022.01: bump to 34fda873c0d

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx_2022.01.bb
+++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx_2022.01.bb
@@ -3,7 +3,7 @@ UBOOT_VERSION = "v2022.01"
 UBRANCH = "xilinx-v2022.01-rebase"
 UBOOTURI = "git://github.com/foundriesio/u-boot.git;protocol=https"
 
-SRCREV = "a056b687f497022ad2aeaf40ef44d550448c31ff"
+SRCREV = "34fda873c0df0849e78b9359f7e790d292f7d1ed"
 
 include recipes-bsp/u-boot/u-boot-xlnx.inc
 include recipes-bsp/u-boot/u-boot-spl-zynq-init.inc


### PR DESCRIPTION
Relevant changes:
- 34fda873c0d Revert "[FIO toup] usb: dwc3: zynqmp: fix reset usb ULPI phy"
- ec9702752dd Merge tag 'xlnx_rebase_v2022.01_2022.1' into xilinx-v2022.01-rebase
- c50d6c48f4e misc: usb5744: usb2244: Setup gpio reset lines as output
- 529e1f44259 arm64: zynqmp: Add dmas, gpu, rtc, watchdogs and opp nodes for SOM
- 4517d7caead arm64: zynqmp: Add power domain description for PL
- 56d126b3081 dt-bindings: xilinx: Add missing ids for PD
- 670aa32d57f Revert "arm64: zynqmp: Add zynqmp firmware specific DT nodes"
- 3afae727f4d Revert "arm64: xilinx: Set CONFIG_ZYNQMP_FIRMWARE config for mini emmc"
- d605ed7c871 mmc: zynq_sdhci: Add weak function prototype

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>