### PR TITLE
linux: kmeta-linux-lmp: 5.10: bump to 423dc80

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.10.y"
-KERNEL_META_COMMIT ?= "abe5439380cd5b7fc4c97c63042ed9826d425f2f"
+KERNEL_META_COMMIT ?= "423dc805720f60c4bba147c337b9908c89b1f25f"


### PR DESCRIPTION
```
Relevant changes:
- 423dc80 bsp: imx8qm-mek: add CONFIG_AT803X_PHY=y
- abe5439 versal: preempt: preempt_none
- 38a542b versal: cpufreq: enforce the performance governor
- f4e09fd (tag: mp-86-linux-v5.10.y) bsp: imx8qm-mek: add CONFIG_GPIO_MAX732X=y
- c914d69 bsp: imx: imx8mp: enable missing functionality

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>
```