### PR TITLE
bsp: zynqmp: u-boot-xlnx: use correct device tree

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx/k26/lmp.cfg
+++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx/k26/lmp.cfg
@@ -1,4 +1,4 @@
-CONFIG_DEFAULT_DEVICE_TREE="zynqmp-zcu102-rev1.0"
+CONFIG_DEFAULT_DEVICE_TREE="zynqmp-zcu102-rev1.1"
 CONFIG_XILINX_PS_INIT_FILE="psu_init_gpl.c"
 CONFIG_BUILD_TARGET="u-boot.bin"
 CONFIG_BOOTCOMMAND="setenv script_addr 0x21000000; setenv verify 1; source ${script_addr}; reset"

--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx/uz/lmp.cfg
+++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx/uz/lmp.cfg
@@ -1,4 +1,4 @@
-CONFIG_DEFAULT_DEVICE_TREE="zynqmp-zcu102-rev1.0"
+CONFIG_DEFAULT_DEVICE_TREE="zynqmp-zcu102-rev1.1"
 CONFIG_XILINX_PS_INIT_FILE="psu_init_gpl.c"
 CONFIG_BUILD_TARGET="u-boot.bin"
 CONFIG_BOOTCOMMAND="setenv script_addr 0x21000000; setenv verify 1; source ${script_addr}; reset"


### PR DESCRIPTION
Use CONFIG_DEFAULT_DEVICE_TREE="zynqmp-zcu102-rev1.1" by default, which will
permit to unclude correct PSU init configuration, where some issues are
fixed (for example, providing proper debug UART configuration for PMU FW).

The way it's included:
board/xilinx/zynqmp/$(CONFIG_DEFAULT_DEVICE_TREE)/psu_init_gpl.c

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>