### PR TITLE
base: optee-test: 3.17: add back -Wno-error=deprecated-declarations

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-test_3.17.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-test_3.17.0.bb
@@ -1,3 +1,6 @@
 require optee-test-fio.inc
 
 SRCREV = "44a31d02379bd8e50762caa5e1592ad81e3339af"
+
+# Due OpenSSL 3.0 deprecated warnings
+CFLAGS += "-Wno-error=deprecated-declarations"


### PR DESCRIPTION
Got dropped when updating from optee-test 3.15 to 3.17, but it is still
required due OpenSSL 3.0.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>