### PR TITLE
base: u-boot-fio: add recipe for 2022.04

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2022.04.bb
@@ -1,0 +1,5 @@
+require u-boot-fio-common.inc
+
+SRCREV = "a312fe06e90a416fbe86ef1bc4bfb4545fe61371"
+SRCBRANCH = "2022.04+fio"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"


### PR DESCRIPTION
FIO-specific recipe based on the upstream u-boot 2022.04 release.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>