### PR TITLE
base: lmp: add meta-virt xilinx xen_4.14 to BBMASK

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -89,6 +89,7 @@ MIRRORS =+ "\
 # Compatibility with other layers
 BBMASK += " \
     /meta-virtualization/recipes-kernel/linux/linux-%.bbappend \
+    /meta-virtualization/dynamic-layers/xilinx/recipes-extended/xen/xen_4.14.bbappend \
     /meta-security/meta-integrity/recipes-core/systemd/systemd_%.bbappend \
     /meta-updater/recipes-connectivity/nfs-utils/nfs-utils_%.bbappend \
 "


### PR DESCRIPTION
Base version not available anymore, so add BBMASK in order to remove a
parsing warning until this is fixed at the meta-virtualization layer.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>