### PR TITLE
Initial support for a generic recovery image

### DIFF
--- a/meta-lmp-base/recipes-core/images/initramfs-ostree-lmp-recovery.bb
+++ b/meta-lmp-base/recipes-core/images/initramfs-ostree-lmp-recovery.bb
@@ -1,0 +1,49 @@
+DESCRIPTION = "Linux microPlatform OSTree initramfs recovery image"
+
+inherit core-image nopackages
+
+PACKAGE_INSTALL = " \
+	aktualizr-lite \
+	base-files \
+	base-passwd \
+	busybox \
+	e2fsprogs-e2fsck \
+	e2fsprogs-mke2fs \
+	e2fsprogs-resize2fs \
+	initramfs-framework-base \
+	initramfs-module-ostree-recovery \
+	initramfs-module-udev \
+	ostree \
+	udev \
+	util-linux-mount \
+	${@bb.utils.contains('MACHINE_FEATURES', 'fiovb', 'optee-fiovb', '' , d)} \
+	${@bb.utils.contains('SOTA_CLIENT_FEATURES', 'ubootenv', 'u-boot-fw-utils', '' , d)} \
+	${ROOTFS_BOOTSTRAP_INSTALL}"
+
+
+# Do not pollute the initrd image with rootfs features
+IMAGE_FEATURES = ""
+IMAGE_LINGUAS = ""
+
+export IMAGE_BASENAME = "initramfs-ostree-lmp-recovery"
+
+LICENSE = "MIT"
+
+IMAGE_FSTYPES = "cpio.gz"
+IMAGE_FSTYPES:remove = "wic wic.gz wic.bmap wic.nopt ext4 ext4.gz"
+IMAGE_CLASSES:remove = "image_repo_manifest"
+
+# avoid circular dependencies
+EXTRA_IMAGEDEPENDS = ""
+
+IMAGE_ROOTFS_SIZE = "8192"
+
+# Users will often ask for extra space in their rootfs by setting this
+# globally.  Since this is a initramfs, we don't want to make it bigger
+IMAGE_ROOTFS_EXTRA_SPACE = "0"
+IMAGE_OVERHEAD_FACTOR = "1.0"
+
+# No need to automatically mount the rootfs
+BAD_RECOMMENDATIONS += " \
+	initramfs-module-rootfs \
+"

--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework/ostree_recovery
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework/ostree_recovery
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Copyright (C) 2022 Foundries.IO Ltd.
+# Licensed on MIT
+
+ostree_recovery_enabled() {
+	return 0
+}
+
+ostree_recovery_run() {
+	msg "Starting ostree recovery shell..."
+	sh
+	msg "Forcing reboot after recovery"
+	reboot -f
+}

--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -3,10 +3,15 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append = " \
 	file://ostree \
 	file://ostree_factory_reset \
+	file://ostree_recovery \
 	file://run-tmpfs.patch \
 "
 
-PACKAGES:append = " initramfs-module-ostree initramfs-module-ostree-factory-reset"
+PACKAGES:append = " \
+	initramfs-module-ostree \
+	initramfs-module-ostree-factory-reset \
+	initramfs-module-ostree-recovery \
+"
 
 SUMMARY:initramfs-module-ostree = "initramfs support for ostree based filesystems"
 RDEPENDS:initramfs-module-ostree = "${PN}-base ostree-switchroot"
@@ -16,7 +21,12 @@ SUMMARY:initramfs-module-ostree-factory-reset = "initramfs support for ostree ba
 RDEPENDS:initramfs-module-ostree-factory-reset = "${PN}-base ostree-switchroot"
 FILES:initramfs-module-ostree-factory-reset = "/init.d/98-ostree_factory_reset"
 
+SUMMARY:initramfs-module-ostree-recovery = "recovery initramfs for ostree based filesystems"
+RDEPENDS:initramfs-module-ostree-recovery = "${PN}-base ostree"
+FILES:initramfs-module-ostree-recovery = "/init.d/98-ostree_recovery"
+
 do_install:append() {
 	install -m 0755 ${WORKDIR}/ostree ${D}/init.d/98-ostree
 	install -m 0755 ${WORKDIR}/ostree_factory_reset ${D}/init.d/98-ostree_factory_reset
+	install -m 0755 ${WORKDIR}/ostree_recovery ${D}/init.d/98-ostree_recovery
 }

--- a/meta-lmp-base/recipes-extended/ostree/ostree/0001-Allow-updating-files-in-the-boot-directory.patch
+++ b/meta-lmp-base/recipes-extended/ostree/ostree/0001-Allow-updating-files-in-the-boot-directory.patch
@@ -10,6 +10,8 @@ single partition systems) all files from the deployment's
 be enabled by 'touch .ostree-bootcsumdir-source' in
 /usr/lib/ostree-boot.
 
+Upstream-Status: Inappropriate [lmp specific]
+
 Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
 ---
  Makefile-tests.am                     |   1 +

--- a/meta-lmp-base/recipes-extended/ostree/ostree/0001-Allow-updating-files-in-the-boot-directory.patch
+++ b/meta-lmp-base/recipes-extended/ostree/ostree/0001-Allow-updating-files-in-the-boot-directory.patch
@@ -1,4 +1,4 @@
-From 74b2052e9a6e5a39c0c90d91fa481a477b9eb89f Mon Sep 17 00:00:00 2001
+From 4db0d7e240865d4a5cc13b492b38c6ff34f468ab Mon Sep 17 00:00:00 2001
 From: Gatis Paeglis <gatis.paeglis@qt.io>
 Date: Mon, 22 Aug 2016 11:32:16 +0200
 Subject: [PATCH 1/2] Allow updating files in the /boot directory
@@ -13,9 +13,9 @@ be enabled by 'touch .ostree-bootcsumdir-source' in
 Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
 ---
  Makefile-tests.am                     |   1 +
- src/libostree/ostree-sysroot-deploy.c | 137 ++++++++++++++++++++++++--
+ src/libostree/ostree-sysroot-deploy.c | 139 ++++++++++++++++++++++++--
  tests/test-bootdir-update.sh          |  39 ++++++++
- 3 files changed, 170 insertions(+), 7 deletions(-)
+ 3 files changed, 172 insertions(+), 7 deletions(-)
  create mode 100755 tests/test-bootdir-update.sh
 
 diff --git a/Makefile-tests.am b/Makefile-tests.am
@@ -31,7 +31,7 @@ index efbcad9a..5193a224 100644
  
  if USE_GPGME
 diff --git a/src/libostree/ostree-sysroot-deploy.c b/src/libostree/ostree-sysroot-deploy.c
-index a8bf9f44..a83e3ea1 100644
+index a8bf9f44..2793617b 100644
 --- a/src/libostree/ostree-sysroot-deploy.c
 +++ b/src/libostree/ostree-sysroot-deploy.c
 @@ -285,6 +285,37 @@ checksum_dir_recurse (int          dfd,
@@ -135,7 +135,7 @@ index a8bf9f44..a83e3ea1 100644
    OstreeBootconfigParser *bootconfig = ostree_deployment_get_bootconfig (deployment);
    g_autofree char *deployment_dirpath = ostree_sysroot_get_deployment_dirpath (sysroot, deployment);
    glnx_autofd int deployment_dfd = -1;
-@@ -1895,6 +1950,74 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
+@@ -1895,6 +1950,76 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
        g_ptr_array_add (overlay_initrds, g_steal_pointer (&destpath));
      }
  
@@ -159,7 +159,9 @@ index a8bf9f44..a83e3ea1 100644
 +                break;
 +
 +              /* Skip special files - vmlinuz-* and initramfs-* are handled separately */
-+              if (g_str_has_prefix (dent->d_name, "vmlinuz-") || g_str_has_prefix (dent->d_name, "initramfs-"))
++              if (g_str_has_prefix (dent->d_name, "vmlinuz-") ||
++			      g_str_has_prefix (dent->d_name, "initramfs-") ||
++			      g_str_has_prefix (dent->d_name, ".ostree-bootcsumdir-source"))
 +                continue;
 +
 +              if (fstatat (bootcsum_dfd, dent->d_name, &stbuf, AT_SYMLINK_NOFOLLOW) != 0)

--- a/meta-lmp-base/recipes-extended/ostree/ostree/0002-u-boot-add-bootdir-to-the-generated-uEnv.txt.patch
+++ b/meta-lmp-base/recipes-extended/ostree/ostree/0002-u-boot-add-bootdir-to-the-generated-uEnv.txt.patch
@@ -23,6 +23,8 @@ for example, can not read from BTRFS. So having
 bootdir=/boot/ostree/$os-$bootcsum/ is a better approach here, as
 /boot can be on a separate partition with its own file system type.
 
+Upstream-Status: Inappropriate [lmp specific]
+
 Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
 ---
  src/libostree/ostree-bootloader-uboot.c | 4 ++++

--- a/meta-lmp-base/recipes-extended/ostree/ostree/0002-u-boot-add-bootdir-to-the-generated-uEnv.txt.patch
+++ b/meta-lmp-base/recipes-extended/ostree/ostree/0002-u-boot-add-bootdir-to-the-generated-uEnv.txt.patch
@@ -1,4 +1,4 @@
-From 83472642c3abd66a22486f770e9946a89dc772a4 Mon Sep 17 00:00:00 2001
+From 40795e2dcf1bbb0a4c1e3a4b53925d970fb5c9ff Mon Sep 17 00:00:00 2001
 From: Gatis Paeglis <gatis.paeglis@qt.io>
 Date: Mon, 22 Aug 2016 15:52:21 +0200
 Subject: [PATCH 2/2] u-boot: add 'bootdir' to the generated uEnv.txt
@@ -30,7 +30,7 @@ Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
  2 files changed, 5 insertions(+)
 
 diff --git a/src/libostree/ostree-bootloader-uboot.c b/src/libostree/ostree-bootloader-uboot.c
-index 7e23001e..4cf86246 100644
+index 7e23001e..0ccb739f 100644
 --- a/src/libostree/ostree-bootloader-uboot.c
 +++ b/src/libostree/ostree-bootloader-uboot.c
 @@ -113,6 +113,7 @@ create_config_from_boot_loader_entries (OstreeBootloaderUboot     *self,
@@ -46,7 +46,7 @@ index 7e23001e..4cf86246 100644
        g_ptr_array_add (new_lines, g_strdup_printf ("kernel_image%s=/boot%s", index_suffix, val));
  
 +      bootdir = strndup (val, strrchr(val, '/') - val);
-+      g_ptr_array_add (new_lines, g_strdup_printf ("bootdir%s=%s/", index_suffix, bootdir));
++      g_ptr_array_add (new_lines, g_strdup_printf ("bootdir%s=/boot%s/", index_suffix, bootdir));
 +
        val = ostree_bootconfig_parser_get (config, "initrd");
        if (val)

--- a/meta-lmp-base/recipes-extended/ostree/ostree/update-default-grub-cfg-header.patch
+++ b/meta-lmp-base/recipes-extended/ostree/ostree/update-default-grub-cfg-header.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [lmp specific]
+
 diff --git a/src/boot/grub2/ostree-grub-generator b/src/boot/grub2/ostree-grub-generator
 index 97ef4d69..b418c2fb 100644
 --- a/src/boot/grub2/ostree-grub-generator

--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -33,6 +33,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     mtd-utils \
     sudo \
     zram \
+    ostree-recovery-initramfs \
 "
 
 # Configure NSS ALTFILES based on NSS_ALT_TYPES

--- a/meta-lmp-base/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_%.bbappend
+++ b/meta-lmp-base/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_%.bbappend
@@ -1,0 +1,22 @@
+PACKAGES += "ostree-recovery-initramfs"
+ALLOW_EMPTY:ostree-recovery-initramfs = "1"
+FILES:ostree-recovery-initramfs = "${nonarch_base_libdir}/ostree-boot"
+
+do_install:append() {
+    ostreeboot=${D}${nonarch_base_libdir}/ostree-boot
+    install -d $ostreeboot
+
+    if [ -n "${INITRAMFS_RECOVERY_IMAGE}" ]; then
+        # Enable updating files in /boot from /usr/lib/ostree-boot when recovery is used
+        touch $ostreeboot/.ostree-bootcsumdir-source
+
+        if [ "${KERNEL_IMAGETYPE}" = "fitImage" ]; then
+            cp ${DEPLOY_DIR_IMAGE}/fitImage-${INITRAMFS_RECOVERY_IMAGE}-${MACHINE}-${KERNEL_FIT_LINK_NAME} $ostreeboot/recovery.img
+        else
+            cp ${DEPLOY_DIR_IMAGE}/${INITRAMFS_RECOVERY_IMAGE}-${MACHINE}.${INITRAMFS_FSTYPES} $ostreeboot/recovery.img
+        fi
+    fi
+}
+
+INITRAMFS_RECOVERY_IMAGE ?= ""
+do_install[depends] += "virtual/kernel:do_deploy ${@['${INITRAMFS_RECOVERY_IMAGE}:do_image_complete', ''][d.getVar('INITRAMFS_RECOVERY_IMAGE') == '']}"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/qemuarm64/lmp.cfg
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/qemuarm64/lmp.cfg
@@ -9,6 +9,8 @@ CONFIG_USE_BOOTCOMMAND=y
 CONFIG_BOOTCOMMAND="fatload virtio 0:1 ${scriptaddr} /boot.itb; source ${scriptaddr}; reset"
 CONFIG_BOOTCOUNT_LIMIT=y
 CONFIG_BOOTCOUNT_ENV=y
+CONFIG_CMD_NVEDIT_LOAD=y
+CONFIG_PREBOOT="virtio scan; env load"
 # CONFIG_ENV_IS_IN_FLASH is not set
 # CONFIG_MTD is not set
 # CONFIG_MTD_NOR_FLASH is not set

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/qemuarm64/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/qemuarm64/boot.cmd
@@ -5,13 +5,14 @@ setenv devnum 0
 
 # Remove optee core reserved memory entry as secure-memory is already defined by QEMU
 setenv bootcmd_updfdt 'fdt addr ${fdt_addr}; fdt rm /reserved-memory/optee_core@0xe100000'
-setenv bootcmd_resetvars 'setenv kernel_image; setenv bootargs; setenv kernel_image2; setenv bootargs2'
-setenv bootcmd_otenv 'run bootcmd_resetvars; ext4load ${devtype} ${devnum}:2 ${scriptaddr} /boot/loader/uEnv.txt; env import -t ${scriptaddr} ${filesize} kernel_image bootargs kernel_image2 bootargs2'
+setenv bootcmd_resetvars 'setenv kernel_image; setenv bootdir; setenv bootargs; setenv kernel_image2; setenv bootdir2; setenv bootargs2'
+setenv bootcmd_otenv 'run bootcmd_resetvars; ext4load ${devtype} ${devnum}:2 ${scriptaddr} /boot/loader/uEnv.txt; env import -t ${scriptaddr} ${filesize} kernel_image bootdir bootargs kernel_image2 bootdir2 bootargs2'
 setenv bootcmd_load_f 'ext4load ${devtype} ${devnum}:2 ${ramdisk_addr_r} "/boot"${kernel_image}'
+setenv bootcmd_load_r 'ext4load ${devtype} ${devnum}:2 ${ramdisk_addr_r} "/boot"${bootdir}/recovery.img'
 setenv bootcmd_run 'bootm ${ramdisk_addr_r}#conf@@FIT_NODE_SEPARATOR@@ ${ramdisk_addr_r}#conf@@FIT_NODE_SEPARATOR@@ ${fdt_addr}'
-setenv bootcmd_rollbackenv 'setenv kernel_image ${kernel_image2}; setenv bootargs ${bootargs2}'
+setenv bootcmd_rollbackenv 'setenv kernel_image ${kernel_image2}; setenv bootdir ${bootdir2}; setenv bootargs ${bootargs2}'
 setenv bootcmd_set_rollback 'if test ! "${rollback}" = "1"; then setenv rollback 1; setenv upgrade_available 0; saveenv; fi'
-setenv bootostree 'run bootcmd_load_f; run bootcmd_run'
+setenv bootostree 'if test "${recovery}" = "1"; then run bootcmd_load_r; setenv recovery; saveenv; else run bootcmd_load_f; fi; run bootcmd_run'
 setenv altbootcmd 'run bootcmd_otenv; run bootcmd_set_rollback; if test -n "${kernel_image2}"; then run bootcmd_rollbackenv; fi; run bootcmd_updfdt; run bootostree; reset'
 
 if test ! -e ${devtype} ${devnum}:1 uboot.env; then saveenv; fi


### PR DESCRIPTION
Patch-set to add an initial support for a generic recovery image in LmP.

The idea is to offer a way for the user to build a custom initrd (separated fit when fitImage is used) that can behave as recovery (for restoring the system, performing firmware updates, etc).

Not enabled by default but the user can add by simply defining INITRAMFS_RECOVERY_IMAGE with the recovery intramfs image (e.g. initramfs-ostree-lmp-recovery).

Can be easily tested with qemuarm64-secureboot, by booting the target, running `fw_setenv recovery 1` and rebooting it again. There is currently no automatic way to identify when to set recovery as this can be specific to the hardware, and we can't necessarily use bootcount as this will stress the storage device (as a write will happen on every boot, even when there is no update).

