### PR TITLE
base: lmp: Add KVM support to RPi4

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.10.y"
-KERNEL_META_COMMIT ?= "ac70bf091824dc59ca4ca7d54c71bd205fba8cbc"
+KERNEL_META_COMMIT ?= "6b646d8f36af8d64ea68c37ad6b82e2d84f1a270"


### PR DESCRIPTION
Enable KVM kernel configs on raspberrypi4-64 machine

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>