### PR TITLE
base: optee-os-fio: 3.17: bump to 9fed2c40b

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.17.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.17.0.bb
@@ -1,5 +1,5 @@
 require optee-os-fio.inc
 
 PV = "3.17.0+git"
-SRCREV = "7d80513fbec1c224ee35b3a6aca76d5b94b8ed7c"
+SRCREV = "9fed2c40b2cf86212ddd3538e2bc88e3f20b55a4"
 SRCBRANCH = "3.17+fio"


### PR DESCRIPTION
Relevant changes:
- 9fed2c40b [FIO toup] core: imx: enable IMX_SNVS on MX8MP
- 1e96d41d4 [FIO fromtree] drivers: imx_snvs: fix the is_otpmk_valid() logic
- 86eb07ac5 [FIO fromtree] drivers: imx_snvs: fix SNVS register read operation
- de8e54538 [FIO fromtree] drivers: imx_snvs: use snvs_is_device_closed() for RPMB key status
- d8f2772c3 [FIO fromtree] drivers: caam: set OTP as master key
- 5bb285a0a [FIO fromtree] plat: imx: enable SNVS driver by default
- 3699e1418 [FIO fromtree] drivers: imx_snvs: fix SNVS_SSM_MODE_SECURE value
- 363119a90 [FIO fromtree] drivers: imx_snvs: fix SNVS security configuration values
- 02d51963e [FIO fromtree] drivers: imx_snvs: add master key selection
- e2d58048e [FIO fromtree] core: imx8m: add SNVS_SIZE value
- 11716cd17 [FIO fromtree] plat: imx7: add SNVS_SIZE value
- 26d20f049 [FIO fromtree] core: imx6: add SNVS_SIZE value
- 0195b8079 [FIO fromtree] core: drivers: merge i.MX SNVS driver files
- 9f20c1b22 [FIO fromtree] drivers: caam: fix cache operation on SGT table

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>