### PR TITLE
base: lmp-image-common: only add ostree-recovery-initramfs with sota

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -33,6 +33,10 @@ CORE_IMAGE_BASE_INSTALL += " \
     mtd-utils \
     sudo \
     zram \
+"
+
+# Additional packages when sota is available
+CORE_IMAGE_BASE_INSTALL:append:sota = " \
     ostree-recovery-initramfs \
 "
 


### PR DESCRIPTION
ostree-recovery-initramfs package should only be included when sota is
available as a distro feature, as it is sota/ostree specific.

This fixes a lmp-base distro build error.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>