### PR TITLE
Add generic config option for ostree-bootcsumdir-source

### DIFF
--- a/meta-lmp-base/classes/lmp.bbclass
+++ b/meta-lmp-base/classes/lmp.bbclass
@@ -61,6 +61,12 @@ IMAGE_CMD:ostree:append () {
 	if [ -f usr/lib/passwd ]; then
 		sed -i -e 's,:/home,:/var/rootdirs/home,g' usr/lib/passwd
 	fi
+
+	# Support enabling updating files in /boot from /usr/lib/ostree-boot
+	if [ "${OSTREE_DEPLOY_USR_OSTREE_BOOT}" = "1" ]; then
+		mkdir -p usr/lib/ostree-boot
+		touch usr/lib/ostree-boot/.ostree-bootcsumdir-source
+	fi
 }
 
 run_fiotool_cmd () {

--- a/meta-lmp-base/conf/distro/lmp.conf
+++ b/meta-lmp-base/conf/distro/lmp.conf
@@ -13,6 +13,7 @@ OSTREE_KERNEL ?= "${@oe.utils.conditional('KERNEL_IMAGETYPE', 'fitImage', '${KER
 OSTREE_KERNEL_ARGS_COMMON ?= "root=LABEL=otaroot rootfstype=ext4"
 OSTREE_KERNEL_ARGS ?= "${OSTREE_KERNEL_ARGS_COMMON}"
 OSTREE_SPLIT_BOOT ?= "0"
+OSTREE_DEPLOY_USR_OSTREE_BOOT ?= "0"
 DISTRO_FEATURES:append = " sota"
 DISTRO_FEATURES_NATIVE:append = " sota"
 INHERIT += "sota"

--- a/meta-lmp-base/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_%.bbappend
+++ b/meta-lmp-base/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_%.bbappend
@@ -7,9 +7,6 @@ do_install:append() {
     install -d $ostreeboot
 
     if [ -n "${INITRAMFS_RECOVERY_IMAGE}" ]; then
-        # Enable updating files in /boot from /usr/lib/ostree-boot when recovery is used
-        touch $ostreeboot/.ostree-bootcsumdir-source
-
         if [ "${KERNEL_IMAGETYPE}" = "fitImage" ]; then
             cp ${DEPLOY_DIR_IMAGE}/fitImage-${INITRAMFS_RECOVERY_IMAGE}-${MACHINE}-${KERNEL_FIT_LINK_NAME} $ostreeboot/recovery.img
         else


### PR DESCRIPTION
Make the trigger to enable ostree deploy copying content from
/usr/lib/ostree-boot a generic configuration, as then the user can
enable in a more generic fashion.