### PR TITLE
lmp-machine-custom: Fix IMX_DEFAULT_BOOTLOADER override

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -311,7 +311,7 @@ WKS_FILE:sota:imx8mq-evk-ebbr ?= "efidisk-sota.wks"
 
 # iMX8MM
 UBOOT_SIGN_ENABLE:sota:mx8mm-generic-bsp = "1"
-IMX_DEFAULT_BOOTLOADER:mx8mm-nxp-bsp ?= "u-boot-fio"
+IMX_DEFAULT_BOOTLOADER:mx8mm-generic-bsp ?= "u-boot-fio"
 UBOOT_DTB_LOADADDRESS:mx8mm-generic-bsp = "0x43000000"
 PREFERRED_PROVIDER_virtual/trusted-firmware-a:mx8mm-nxp-bsp ?= "imx-atf"
 EXTRA_IMAGEDEPENDS:append:mx8mm-nxp-bsp = "virtual/trusted-firmware-a"
@@ -354,7 +354,7 @@ MACHINE_FEATURES:append:imx8mm-lpddr4-evk = " nxp89xx mxm-mwifiex-load"
 
 # iMX8MP
 UBOOT_SIGN_ENABLE:sota:mx8mp-generic-bsp = "1"
-IMX_DEFAULT_BOOTLOADER:mx8mp-nxp-bsp ?= "u-boot-fio"
+IMX_DEFAULT_BOOTLOADER:mx8mp-generic-bsp ?= "u-boot-fio"
 UBOOT_DTB_LOADADDRESS:mx8mp-generic-bsp = "0x43000000"
 PREFERRED_PROVIDER_virtual/trusted-firmware-a:mx8mp-nxp-bsp ?= "imx-atf"
 EXTRA_IMAGEDEPENDS:append:mx8mp-nxp-bsp = "virtual/trusted-firmware-a"


### PR DESCRIPTION
The variable IMX_DEFAULT_BOOTLOADER is defined in lmp-machine-custom.inc,
and, when DISTRO=lmp-mfgtool, it is also defined in lmp-mfgtool-machine-custom.inc.

And, because mfgtool should override the lmp value, we should use the
same override in both files.

Another point to remember is that MACHINEOVERRIDES_EXTENDER for mx8mm is

imx-generic-bsp:imx-nxp-bsp:imxdrm:imxvpu:imxgpu:imxgpu2d:imxgpu3d:mx8-generic-bsp:mx8-nxp-bsp:mx8m-generic-bsp:mx8m-nxp-bsp:mx8mm-generic-bsp:mx8mm-nxp-bsp

mx8mm-nxp-bsp is more specific than imx8mm-generic-bsp, which make it to
be choose instead of imx8mm-generic-bsp.

Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>