### PR TITLE
bsp: linux-lmp-xlnx: update to v5.15.36

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-xlnx_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-xlnx_git.bb
@@ -1,8 +1,8 @@
 include recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
 
-LINUX_VERSION ?= "5.15.19"
+LINUX_VERSION ?= "5.15.36"
 KBRANCH = "xlnx_v5.15.y"
-SRCREV_machine = "3076249fc30bf463f8390f89009de928ad3e95ff"
+SRCREV_machine = "28cd4306cc939a3c769b245ae248b80a22aa097d"
 SRCREV_meta = "${KERNEL_META_COMMIT}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"


### PR DESCRIPTION
Includes latest from the 2022.1 Xilinx BSP release.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>