### PR TITLE
base: security: optee: allow upstream optee-os as preferred provider

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-feature-optee.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-optee.inc
@@ -1,6 +1,6 @@
 # OP-TEE/SKS packages
 CORE_IMAGE_BASE_INSTALL += " \
     optee-client \
-    optee-os-fio-ta \
+    ${@bb.utils.contains('PREFERRED_PROVIDER_virtual/optee-os', 'optee-os-fio', 'optee-os-fio-ta', '', d)} \
     optee-test \
 "

--- a/meta-lmp-base/recipes-security/optee/optee-os-tadevkit_3.17.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-tadevkit_3.17.0.bb
@@ -1,11 +1,18 @@
+# tadevkit requires a matching version on the base recipe
+# meta-arm kirkstone is using 3.16 by default
+DEFAULT_PREFERENCE = "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/optee-os', 'optee-os', '-1', '0', d)}"
+
 # Compatible with optee-os-fio and optee-os from meta-arm
-require ${@bb.utils.contains('PREFERRED_PROVIDER_virtual/optee-os', 'optee-os', 'recipes-security/optee/optee-os_${PV}.bb', '', d)}
-require ${@bb.utils.contains('PREFERRED_PROVIDER_virtual/optee-os', 'optee-os-fio', 'optee-os-fio_${PV}.bb', '', d)}
-require ${@bb.utils.contains('PREFERRED_PROVIDER_virtual/optee-os', 'optee-os-fio-mfgtool', 'optee-os-fio-mfgtool_${PV}.bb', '', d)}
+include ${@bb.utils.contains('PREFERRED_PROVIDER_virtual/optee-os', 'optee-os', 'recipes-security/optee/optee-os_${PV}.bb', '', d)}
+include ${@bb.utils.contains('PREFERRED_PROVIDER_virtual/optee-os', 'optee-os-fio', 'optee-os-fio_${PV}.bb', '', d)}
+include ${@bb.utils.contains('PREFERRED_PROVIDER_virtual/optee-os', 'optee-os-fio-mfgtool', 'optee-os-fio-mfgtool_${PV}.bb', '', d)}
 
 SUMMARY = "OP-TEE Trusted OS TA devkit"
 DESCRIPTION = "OP-TEE TA devkit for build TAs"
 HOMEPAGE = "https://www.op-tee.org/"
+
+LICENSE ?= "BSD-2-Clause"
+LIC_FILES_CHKSUM ?= "file://${COMMON_LICENSE_DIR}/BSD-2-Clause;md5=cb641bc04cda31daea161b1bc15da69f"
 
 # Needed due provides from optee-os-fio (for virtual/optee-os)
 PROVIDES = "${PN}"


### PR DESCRIPTION
Fix compatibility issues when setting:
PREFERRED_PROVIDER_virtual/optee-os ?= "optee-os"

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>