### PR TITLE
base: gnu-efi: enable for riscv64

### DIFF
--- a/meta-lmp-base/recipes-bsp/gnu-efi/gnu-efi_3.0.14.bbappend
+++ b/meta-lmp-base/recipes-bsp/gnu-efi/gnu-efi_3.0.14.bbappend
@@ -1,0 +1,2 @@
+# Enable support for riscv64
+COMPATIBLE_HOST = "(x86_64.*|i.86.*|aarch64.*|arm.*|riscv64.*)-linux"


### PR DESCRIPTION
The 3.0.14 release already includes support for riscv64.

Upstream patch:
https://lists.openembedded.org/g/openembedded-core/message/166809

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>