### PR TITLE
Support for UEFI Secure Boot

### DIFF
--- a/meta-lmp-base/classes/kernel-lmp-efi.bbclass
+++ b/meta-lmp-base/classes/kernel-lmp-efi.bbclass
@@ -1,0 +1,24 @@
+inherit kernel-artifact-names
+
+# Simple kernel image signing (no unified kernel image)
+do_efi_sign() {
+	if [ "${UEFI_SIGN_ENABLE}" = "1" ]; then
+		if [ ! -f "${UEFI_SIGN_KEYDIR}/DB.key" -o ! -f "${UEFI_SIGN_KEYDIR}/DB.crt" ]; then
+			bbfatal "UEFI_SIGN_KEYDIR or DB.key/crt is invalid"
+		fi
+
+		for imageType in ${KERNEL_IMAGETYPES}; do
+			if [ -s ${B}/${KERNEL_OUTPUT_DIR}/$imageType.stripped ]; then
+				kernel=${B}/${KERNEL_OUTPUT_DIR}/$imageType.stripped
+			else
+				kernel=${B}/${KERNEL_OUTPUT_DIR}/$imageType
+			fi
+			sbsign --key ${UEFI_SIGN_KEYDIR}/DB.key --cert ${UEFI_SIGN_KEYDIR}/DB.crt $kernel
+			sbverify --cert ${UEFI_SIGN_KEYDIR}/DB.crt $kernel.signed
+			mv $kernel.signed $kernel
+		done
+	fi
+}
+do_efi_sign[depends] += "sbsigntool-native:do_populate_sysroot"
+do_efi_sign[vardeps] += "UEFI_SIGN_ENABLE UEFI_SIGN_KEYDIR"
+addtask efi_sign before do_deploy after do_bundle_initramfs

--- a/meta-lmp-base/classes/lmp.bbclass
+++ b/meta-lmp-base/classes/lmp.bbclass
@@ -150,3 +150,18 @@ def make_efi_dtb_boot_files(d):
         return os.path.basename(dtb) + ';dtb/' + os.path.basename(dtb)
 
     return ' '.join([transform(dtb) for dtb in alldtbs.split() if dtb])
+
+def make_efi_cer_boot_files(d):
+    # Generate IMAGE_EFI_BOOT_FILES entries for certificate files available
+    # at the UEFI_SIGN_KEYDIR folder.
+    keydir = d.getVar('UEFI_SIGN_KEYDIR')
+    if not keydir:
+        return ''
+
+    def transform(cer):
+        cer_path = os.path.join(keydir, cer + '.cer')
+        if not os.access(cer_path, os.R_OK):
+            bb.fatal("Unable to find certificate '%s.cer' in '%s'" % (cer, keydir))
+        return cer_path + ';uefi_certs/' + os.path.basename(cer_path)
+
+    return ' '.join([transform(cer) for cer in ['PK', 'KEK', 'DB', 'DBX']])

--- a/meta-lmp-base/recipes-core/systemd/systemd-boot_%.bbappend
+++ b/meta-lmp-base/recipes-core/systemd/systemd-boot_%.bbappend
@@ -8,3 +8,20 @@ do_install:append() {
 }
 
 FILES:${PN} += "${nonarch_base_libdir}/systemd/boot/efi"
+
+do_efi_sign() {
+	if [ "${UEFI_SIGN_ENABLE}" = "1" ]; then
+		if [ ! -f "${UEFI_SIGN_KEYDIR}/DB.key" -o ! -f "${UEFI_SIGN_KEYDIR}/DB.crt" ]; then
+			bbfatal "UEFI_SIGN_KEYDIR or DB.key/crt is invalid"
+		fi
+
+		for efi in `find ${B}/src/boot/efi -name '*.efi'`; do
+			sbsign --key ${UEFI_SIGN_KEYDIR}/DB.key --cert ${UEFI_SIGN_KEYDIR}/DB.crt $efi
+			sbverify --cert ${UEFI_SIGN_KEYDIR}/DB.crt $efi.signed
+			mv $efi.signed $efi
+		done
+	fi
+}
+do_efi_sign[depends] += "sbsigntool-native:do_populate_sysroot"
+do_efi_sign[vardeps] += "UEFI_SIGN_ENABLE UEFI_SIGN_KEYDIR"
+addtask efi_sign after do_compile before do_install do_deploy

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -123,6 +123,7 @@ OSTREE_KERNEL_ARGS:intel-corei7-64 ?= "console=ttyS0,115200 ${OSTREE_KERNEL_ARGS
 EFI_PROVIDER:intel-corei7-64 = "systemd-boot"
 OSTREE_SPLIT_BOOT:intel-corei7-64 = "1"
 OSTREE_LOADER_LINK:intel-corei7-64 = "0"
+KERNEL_CLASSES:intel-corei7-64 = " kernel-lmp-efi "
 WKS_FILE:intel-corei7-64:sota ?= "efidisk-sota.wks.in"
 WKS_FILE_DEPENDS:append:intel-corei7-64 = " ${INITRD_IMAGE_LIVE}"
 ## wic-based installer requires image to be available via IMAGE_BOOT_FILES

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -118,6 +118,7 @@ WKS_FILE_DEPENDS:append:generic-arm64 = " ${INITRD_IMAGE_LIVE}"
 IMAGE_BOOT_FILES:generic-arm64 = "${@bb.utils.contains('WKS_FILE', 'image-efi-installer.wks.in', 'systemd-bootaa64.efi;EFI/BOOT/bootaa64.efi systemd-bootaa64.efi;EFI/systemd/systemd-bootaa64.efi ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ota-ext4;rootfs.img', '', d)}"
 
 # Intel
+UEFI_SIGN_ENABLE:intel-corei7-64 = "1"
 OSTREE_BOOTLOADER:intel-corei7-64 ?= "none"
 OSTREE_KERNEL_ARGS:intel-corei7-64 ?= "console=ttyS0,115200 ${OSTREE_KERNEL_ARGS_COMMON}"
 EFI_PROVIDER:intel-corei7-64 = "systemd-boot"

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -128,6 +128,7 @@ WKS_FILE:intel-corei7-64:sota ?= "efidisk-sota.wks.in"
 WKS_FILE_DEPENDS:append:intel-corei7-64 = " ${INITRD_IMAGE_LIVE}"
 ## wic-based installer requires image to be available via IMAGE_BOOT_FILES
 IMAGE_BOOT_FILES:intel-corei7-64 = "${@bb.utils.contains('WKS_FILE', 'image-efi-installer.wks.in', 'systemd-bootx64.efi;EFI/BOOT/bootx64.efi systemd-bootx64.efi;EFI/systemd/systemd-bootx64.efi startup.nsh ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ota-ext4;rootfs.img', '', d)}"
+IMAGE_EFI_BOOT_FILES:append:intel-corei7-64 = " ${@make_efi_cer_boot_files(d)}"
 
 # Common for iMX targets
 ## Prefer IMX_DEFAULT_BSP=nxp as mainline removes every common machine override


### PR DESCRIPTION
Add logic to sign both systemd-boot and kernel, for adding initial support for UEFI secure boot.

This is not yet using the unified EFI format, which will implemented later.