### PR TITLE
Early startup for oe builtin preloaded apps

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -60,6 +60,7 @@ PACKAGES += "${PN}-get ${PN}-lite ${PN}-lite-lib ${PN}-lite-dev"
 FILES:${PN}-get = "${bindir}/${PN}-get"
 FILES:${PN}-lite = " \
                     ${bindir}/${PN}-lite \
+                    ${bindir}/aklite-apps \
                     ${nonarch_libdir}/tmpfiles.d/${PN}-lite.conf \
                     "
 FILES:${PN}-lite-lib = "${nonarch_libdir}/lib${PN}_lite.so"

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "96640d24be97b597e2bfb545c22b255427888f60"
+SRCREV:lmp = "e05f7eb7a852491c2812b89b60af9979aca44501"
 
 SRC_URI:lmp = "gitsm://github.com/foundriesio/aktualizr-lite;protocol=https;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \

--- a/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start.bb
+++ b/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start.bb
@@ -7,16 +7,18 @@ SRC_URI = " \
 	file://compose-apps-early-start.service \
 	file://compose-apps-early-start-recovery \
 	file://compose-apps-early-start \
+	file://compose-apps-register-images.service \
 "
 
 inherit systemd
 
-SYSTEMD_SERVICE:${PN} = "compose-apps-early-start.service"
+SYSTEMD_SERVICE:${PN} = "compose-apps-early-start.service compose-apps-register-images.service"
 
 do_install() {
 	install -d ${D}${systemd_system_unitdir}
 	install -m 0644 ${WORKDIR}/compose-apps-early-start.service ${D}${systemd_system_unitdir}/
 	install -m 0644 ${WORKDIR}/compose-apps-early-start-recovery.service ${D}${systemd_system_unitdir}/
+	install -m 0644 ${WORKDIR}/compose-apps-register-images.service ${D}${systemd_system_unitdir}/
 	install -d ${D}${bindir}
 	install -m 0755 ${WORKDIR}/compose-apps-early-start ${D}${bindir}/
 	install -m 0755 ${WORKDIR}/compose-apps-early-start-recovery ${D}${bindir}/

--- a/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start
+++ b/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-function start_compose_app() {
+start_compose_app() {
 	app=$1
 	cd /var/sota/compose-apps/${app}
 
@@ -14,21 +14,45 @@ function start_compose_app() {
 	fi
 }
 
-if [ -f /var/lmp/default-apps ] ; then
-	if [ -d /var/sota/compose-apps ] ; then
-		for x in $(ls /var/sota/compose-apps) ; do
-			if ! grep -q $x /var/lmp/default-apps 2>/dev/null ; then
-				echo "Disabling preloaded app: $x"
-				rm -rf /var/sota/compose-apps/$x
-			fi
-		done
+start_compose_apps() {
+	if [ -f /var/lmp/default-apps ] ; then
+		if [ -d /var/sota/compose-apps ] ; then
+			for x in $(ls /var/sota/compose-apps) ; do
+				if ! grep -q $x /var/lmp/default-apps 2>/dev/null ; then
+					echo "Disabling preloaded app: $x"
+					rm -rf /var/sota/compose-apps/$x
+				fi
+			done
+		fi
 	fi
-fi
 
-if [ -d /var/sota/compose-apps ] ; then
-	for app in `ls /var/sota/compose-apps` ; do
-		start_compose_app ${app}
-	done
+	if [ -d /var/sota/compose-apps ] ; then
+		for app in `ls /var/sota/compose-apps` ; do
+			start_compose_app ${app}
+		done
+	else
+		echo "No apps defined"
+	fi
+}
+
+start_restorable_apps() {
+	default_apps_path="/var/lmp/default-apps"
+	shortlist=""
+
+	if [ -f $default_apps_path ] ; then
+		for app in `cat $default_apps_path`; do
+			shortlist="${shortlist}${app},"
+		done
+		if [ ! -z $shortlist ] ; then
+			shortlist=${shortlist::-1}
+                fi
+	fi
+
+	aklite-apps run --apps "${shortlist}"
+}
+
+if [ -d /var/sota/reset-apps ] ; then
+	start_restorable_apps
 else
-	echo "No apps defined"
+	start_compose_apps
 fi

--- a/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start-recovery
+++ b/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start-recovery
@@ -1,15 +1,31 @@
 #!/bin/sh
 
-# Force compose down, restart docker and try again
+recover_compose_apps() {
+	# Force compose down, restart docker and try again
 
-for app in `ls /var/sota/compose-apps` ; do
-	cd /var/sota/compose-apps/${app}
-	docker compose down
-done
+	for app in `ls /var/sota/compose-apps` ; do
+		cd /var/sota/compose-apps/${app}
+		docker compose down
+	done
 
-# TODO: extend with support for restorable-apps, which should
-# allow us to remove /var/lib/docker completely
+	systemctl restart docker
+}
 
-systemctl restart docker
+recover_restorable_apps() {
+	systemctl stop docker
+	rm -rf /var/sota/compose-apps/*
+	rm -rf /var/lib/docker
+
+	systemctl restart compose-apps-register-images.service
+	systemctl start docker
+}
+
+if [ -d /var/sota/reset-apps ] ; then
+	recover_restorable_apps
+else
+	recover_compose_apps
+fi
+
 systemctl reset-failed compose-apps-early-start.service
+sleep 60
 systemctl restart compose-apps-early-start.service

--- a/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-register-images.service
+++ b/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-register-images.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Register images of Apps at a docker store repository
+Before=docker.service
+Before=lmp-device-auto-register.service
+ConditionPathExists=/var/sota/reset-apps
+ConditionPathExists=!/var/sota/sql.db
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/bin/aklite-apps register
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add early App startup for preloaded *Restorable* Apps.

1. One-shot systemd service aimed to populate the dockerd repository with Registry referencies of the preloaded Apps' images. It makes `dockerd` avoid making any call to Registries during Apps startup.

2. Adjust existing one-shot systemd service that does Apps early start in such a way that it can start both type of Apps, *restorable* and *compose*.