### PR TITLE
base: recipe-support: use golang `compose` for apps early startup

### DIFF
--- a/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start
+++ b/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start
@@ -6,11 +6,11 @@ function start_compose_app() {
 
 	echo "Starting app ${app}"
 	ret=0
-	docker-compose up -d || ret=${?}
+	docker compose up -d || ret=${?}
 	if [ ${ret} -ne 0 ] ; then
 		echo "Failed to start app ${app}, trying compose down / up"
-		docker-compose down
-		docker-compose up -d
+		docker compose down
+		docker compose up -d
 	fi
 }
 

--- a/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start-recovery
+++ b/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start-recovery
@@ -4,7 +4,7 @@
 
 for app in `ls /var/sota/compose-apps` ; do
 	cd /var/sota/compose-apps/${app}
-	docker-compose down
+	docker compose down
 done
 
 # TODO: extend with support for restorable-apps, which should


### PR DESCRIPTION
Switch to usage of the golang `compose` for the apps early startup script since we switched to it at a system level https://github.com/foundriesio/meta-lmp/commit/4e73d1310125c083ce41ebca0a2abe97ebe2b936.

Signed-off-by: Mike <mike.sul@foundries.io>