### PR TITLE
recipes-samples: lmp-feature-optee fiovb is set with separate feature

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-feature-optee.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-optee.inc
@@ -1,7 +1,6 @@
 # OP-TEE/SKS packages
 CORE_IMAGE_BASE_INSTALL += " \
     optee-client \
-    optee-fiovb \
     optee-os-fio-ta \
     optee-test \
 "


### PR DESCRIPTION
Currently the lmp-feature-optee includes optee-fiovb but that should
only be enabled if there is an RPMB available (i.e. secured).

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>