### PR TITLE
bsp: kernel: linux-lmp-fslc-imx: update to 5.15.44

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-FIO-extras-arm64-dts-imx8mm-evk-use-imx8mm-evkb-for-.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-FIO-extras-arm64-dts-imx8mm-evk-use-imx8mm-evkb-for-.patch
@@ -1,7 +1,7 @@
-From 0f03bc70b5c57920cb42dbb78578272be60ac4fe Mon Sep 17 00:00:00 2001
+From 33e609962f348f52815e641fdb1d590297cd0456 Mon Sep 17 00:00:00 2001
 From: Ricardo Salveti <ricardo@foundries.io>
 Date: Fri, 14 May 2021 13:36:10 -0300
-Subject: [PATCH] arm64: dts: imx8mm-evk: use imx8mm-evkb for the new EVKs
+Subject: [PATCH 1/3] arm64: dts: imx8mm-evk: use imx8mm-evkb for the new EVKs
 
 Allow older EVKs to be transitioned properly by using a new dtb for the
 EVKB variant.
@@ -31,7 +31,7 @@ Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
  create mode 100755 arch/arm64/boot/dts/freescale/imx8mm-evkb.dts
 
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-8mic-revE.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-8mic-revE.dts
-index ec4108c4c2178..4b79d0e6b2cfc 100644
+index ec4108c4c217..4b79d0e6b2cf 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-8mic-revE.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-8mic-revE.dts
 @@ -3,7 +3,7 @@
@@ -44,7 +44,7 @@ index ec4108c4c2178..4b79d0e6b2cfc 100644
  / {
  	mic_leds {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-ak4497.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-ak4497.dts
-index 18aacba546f63..e2611cc23a286 100644
+index 18aacba546f6..e2611cc23a28 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-ak4497.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-ak4497.dts
 @@ -3,7 +3,7 @@
@@ -57,7 +57,7 @@ index 18aacba546f63..e2611cc23a286 100644
  / {
  	sound-ak4458 {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-ak5558.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-ak5558.dts
-index 4d3da8e33688c..149b5cf67ce76 100644
+index 4d3da8e33688..149b5cf67ce7 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-ak5558.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-ak5558.dts
 @@ -4,7 +4,7 @@
@@ -70,7 +70,7 @@ index 4d3da8e33688c..149b5cf67ce76 100644
  / {
  	sound-ak5558 {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-dpdk.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-dpdk.dts
-index 3b5503933a35a..ff497006ca07a 100644
+index 3b5503933a35..ff497006ca07 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-dpdk.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-dpdk.dts
 @@ -3,7 +3,7 @@
@@ -83,7 +83,7 @@ index 3b5503933a35a..ff497006ca07a 100644
  &fec1 {
  	compatible = "fsl,imx8mm-fec-uio";
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-ecspi-slave.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-ecspi-slave.dts
-index e06dbc00d9dc7..b0670f2cde372 100644
+index e06dbc00d9dc..b0670f2cde37 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-ecspi-slave.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-ecspi-slave.dts
 @@ -2,7 +2,7 @@
@@ -96,7 +96,7 @@ index e06dbc00d9dc7..b0670f2cde372 100644
  /delete-node/&spidev0;
  
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-hifiberry-dacplus.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-hifiberry-dacplus.dts
-index 847ce29dbaf24..57b1ccb82ad98 100644
+index 847ce29dbaf2..57b1ccb82ad9 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-hifiberry-dacplus.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-hifiberry-dacplus.dts
 @@ -3,7 +3,7 @@
@@ -109,7 +109,7 @@ index 847ce29dbaf24..57b1ccb82ad98 100644
  / {
  	ext_osc_22m: ext-osc-22m {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacplus.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacplus.dts
-index 170db23316572..8b152d2a44362 100644
+index 170db2331657..8b152d2a4436 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacplus.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacplus.dts
 @@ -3,7 +3,7 @@
@@ -122,7 +122,7 @@ index 170db23316572..8b152d2a44362 100644
  / {
  	reg_3v3_vext: regulator-3v3-vext {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacpro.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacpro.dts
-index 3d1398c1280bc..85b3ec59fef30 100644
+index 3d1398c1280b..85b3ec59fef3 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacpro.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacpro.dts
 @@ -3,7 +3,7 @@
@@ -135,7 +135,7 @@ index 3d1398c1280bc..85b3ec59fef30 100644
  / {
  	reg_3v3_vext: regulator-3v3-vext {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-lk.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-lk.dts
-index ccf3e9901e323..16e32e7f1aed0 100644
+index ccf3e9901e32..16e32e7f1aed 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-lk.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-lk.dts
 @@ -3,7 +3,7 @@
@@ -148,7 +148,7 @@ index ccf3e9901e323..16e32e7f1aed0 100644
  / {
  	interrupt-parent = <&gic>;
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-pcie-ep.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-pcie-ep.dts
-index 2f96420e3230e..61202cae7f3b8 100644
+index 2f96420e3230..61202cae7f3b 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-pcie-ep.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-pcie-ep.dts
 @@ -5,7 +5,7 @@
@@ -161,7 +161,7 @@ index 2f96420e3230e..61202cae7f3b8 100644
  &pcie0{
  	status = "disabled";
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts
-index a5965c6875e1e..1b271d1babaa9 100755
+index a5965c6875e1..1b271d1babaa 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts
 @@ -5,7 +5,7 @@
@@ -174,7 +174,7 @@ index a5965c6875e1e..1b271d1babaa9 100755
  / {
  	model = "FSL i.MX8MM LPDDR4 EVK with QCA WIFI revC board ";
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-rm67191.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-rm67191.dts
-index 925f67255b9bd..83855ae5ca55c 100644
+index 958912c409b2..d6563b7a41da 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-rm67191.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-rm67191.dts
 @@ -3,7 +3,7 @@
@@ -187,7 +187,7 @@ index 925f67255b9bd..83855ae5ca55c 100644
  &adv_bridge {
  	status = "disabled";
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-root.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-root.dts
-index 426b0adc31ce6..3986daaec096f 100644
+index 426b0adc31ce..3986daaec096 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-root.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-root.dts
 @@ -3,7 +3,7 @@
@@ -200,7 +200,7 @@ index 426b0adc31ce6..3986daaec096f 100644
  / {
  	interrupt-parent = <&gic>;
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-rpmsg.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-rpmsg.dts
-index 89ba5b6fb4d0a..bc4f1483f7187 100644
+index 0b10547edd52..47417d0771c7 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-rpmsg.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-rpmsg.dts
 @@ -5,7 +5,7 @@
@@ -213,7 +213,7 @@ index 89ba5b6fb4d0a..bc4f1483f7187 100644
  / {
  	reserved-memory {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-usd-wifi.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-usd-wifi.dts
-index d6a5cfcf580ab..893daae1230f5 100644
+index 9bf4ce755d5c..c9c792ca4c3d 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-usd-wifi.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-usd-wifi.dts
 @@ -5,7 +5,7 @@
@@ -226,7 +226,7 @@ index d6a5cfcf580ab..893daae1230f5 100644
  &pinctrl_usdhc2 {
  	fsl,pins = <
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk.dts
-index 86922c4520663..c5e542942aaf6 100755
+index 8540d71b5eef..c5e542942aaf 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk.dts
 @@ -1,163 +1,8 @@
@@ -303,7 +303,7 @@ index 86922c4520663..c5e542942aaf6 100755
 -	non-removable;
 -	wakeup-source;
 -	mmc-pwrseq = <&usdhc1_pwrseq>;
--	fsl,sdio-interrupt-enabled;
+-	fsl,sdio-async-interrupt-enabled;
 -	status = "okay";
 -
 -	wifi_wake_host {
@@ -397,7 +397,7 @@ index 86922c4520663..c5e542942aaf6 100755
 +#include "imx8mm-evk-qca-wifi.dts"
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evkb.dts b/arch/arm64/boot/dts/freescale/imx8mm-evkb.dts
 new file mode 100755
-index 0000000000000..86922c4520663
+index 000000000000..86922c452066
 --- /dev/null
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evkb.dts
 @@ -0,0 +1,163 @@
@@ -565,5 +565,5 @@ index 0000000000000..86922c4520663
 +	};
 +};
 -- 
-2.33.0
+2.25.1
 

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-arm64-dts-imx8mq-drop-cpu-idle-states.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-arm64-dts-imx8mq-drop-cpu-idle-states.patch
@@ -1,7 +1,7 @@
-From b70aac80c227a6469f509b58d76285d2367f2d64 Mon Sep 17 00:00:00 2001
+From 395e824b55ecbb9329771a107eb7d954bff93bc8 Mon Sep 17 00:00:00 2001
 From: Ricardo Salveti <ricardo@foundries.io>
 Date: Wed, 13 Oct 2021 19:43:22 -0300
-Subject: [PATCH] arm64: dts: imx8mq: drop cpu-idle-states
+Subject: [PATCH 3/3] arm64: dts: imx8mq: drop cpu-idle-states
 
 This partially reverts commit 30181937c470a5e08c5b94ca416d97fbf7c4293c.
 
@@ -17,7 +17,7 @@ Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
  1 file changed, 4 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/freescale/imx8mq.dtsi b/arch/arm64/boot/dts/freescale/imx8mq.dtsi
-index 9f15c03b31d42..407c62a59839f 100755
+index 62ccb6eeff6a..7d748deb258c 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mq.dtsi
 +++ b/arch/arm64/boot/dts/freescale/imx8mq.dtsi
 @@ -108,7 +108,6 @@ A53_0: cpu@0 {
@@ -53,5 +53,5 @@ index 9f15c03b31d42..407c62a59839f 100755
  
  		A53_L2: l2-cache0 {
 -- 
-2.33.0
+2.25.1
 

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0004-FIO-toup-hwrng-optee-support-generic-crypto.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0004-FIO-toup-hwrng-optee-support-generic-crypto.patch
@@ -1,7 +1,7 @@
-From 64d71235c0986924c15365979992f93ade66c122 Mon Sep 17 00:00:00 2001
+From 952f4b90ceee9deb3f266f17623e718272306105 Mon Sep 17 00:00:00 2001
 From: Jorge Ramirez-Ortiz <jorge@foundries.io>
 Date: Fri, 17 Jul 2020 09:09:37 +0200
-Subject: [PATCH 4/4] [FIO toup] hwrng: optee: support generic crypto
+Subject: [PATCH] hwrng: optee: support generic crypto
 
 Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
 Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
@@ -10,10 +10,10 @@ Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/char/hw_random/optee-rng.c b/drivers/char/hw_random/optee-rng.c
-index a99d829499818..725c6ea489d62 100644
+index 135a82590923..bb21e025687f 100644
 --- a/drivers/char/hw_random/optee-rng.c
 +++ b/drivers/char/hw_random/optee-rng.c
-@@ -273,6 +273,8 @@ static int optee_rng_remove(struct device *dev)
+@@ -272,6 +272,8 @@ static int optee_rng_remove(struct device *dev)
  static const struct tee_client_device_id optee_rng_id_table[] = {
  	{UUID_INIT(0xab7a617c, 0xb8e7, 0x4d8f,
  		   0x83, 0x01, 0xd0, 0x9b, 0x61, 0x03, 0x6b, 0x64)},
@@ -23,5 +23,5 @@ index a99d829499818..725c6ea489d62 100644
  };
  
 -- 
-2.28.0
+2.25.1
 

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_git.bb
@@ -3,10 +3,10 @@ include recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
 # Use Freescale kernel by default
 KERNEL_REPO ?= "git://github.com/Freescale/linux-fslc.git"
 KERNEL_REPO_PROTOCOL ?= "https"
-LINUX_VERSION ?= "5.10.93"
-KERNEL_BRANCH ?= "5.10-2.1.x-imx"
+LINUX_VERSION ?= "5.15.45"
+KERNEL_BRANCH ?= "5.15-1.0.x-imx"
 
-SRCREV_machine = "f28a9b90c506241e614212f2ce314d8f5460819d"
+SRCREV_machine = "e6ad415b02af0d025969cbf0ba1d48870b6687bf"
 SRCREV_meta = "${KERNEL_META_COMMIT}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"


### PR DESCRIPTION
Upstream stable update to NXP BSP lf-5.15.5-1.0.0.

meta-freescale: 5b6422e863b68ad9b5989179872d9789bf03150b

Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>