### PR TITLE
base: docker-compose: update to 2.6.0

### DIFF
--- a/meta-lmp-base/recipes-containers/docker-compose/docker-compose_2.6.0.bb
+++ b/meta-lmp-base/recipes-containers/docker-compose/docker-compose_2.6.0.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
 	file://cli-config-support-default-system-config.patch \
 	"
 
-SRCREV_compose = "41b3967cb521a7c7254155a70fbafa5f5ae02aad"
+SRCREV_compose = "6756732fe45285f61d459809c36eed0f28fdd58b"
 SRCREV_cli = "2b52f62e962783ef39b53d1cb95e1d435b33f3cd"
 
 UPSTREAM_CHECK_COMMITS = "1"


### PR DESCRIPTION
What's changed in 2.6.0:
* fix TestLocalComposeUp which fail locally and bump compose-go to 1.2.7
* attach only to services declared by project applying profiles
* Add ddev's e2e test
* Fix local run of make e2e-compose-standalone
* fix: prevent flickering prompt when pulling same image from N services
* add tags property to build section
* update golang version to 1.18
* bump compose-go to 1.2.6
* add e2e tests to verify env variables priority
* Import dotenv file to os environment

What's changed in 2.5.1:
* Fix relative paths on envfile label
* down: Reject all arguments
* Clarify what default work dir is when multiple compose files
* compose down exit=0 if nothing to remove
* cp command: copy to all containers of a service as default behaviour
* Fix extra space printed with --no-log-prefix option
* bump compose-go to 1.2.5

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>