### PR TITLE
base: lmp-passwd/group: add ntp user and group

### DIFF
--- a/meta-lmp-base/files/lmp-group-table
+++ b/meta-lmp-base/files/lmp-group-table
@@ -50,6 +50,7 @@ shutdown:x:70:
 nobody:*:99:
 users:x:100:
 pulse:x:171:
+ntp:x:971:
 parsec:x:972:
 pulse-access:x:973:
 pulse-rt:x:974:

--- a/meta-lmp-base/files/lmp-passwd-table
+++ b/meta-lmp-base/files/lmp-passwd-table
@@ -17,6 +17,7 @@ irc:x:39:39:ircd:/var/run/ircd:/bin/sh
 gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/bin/sh
 weston:x:63:63::/home/weston:/bin/false
 pulse:x:171:171:PulseAudio System Daemon:/var/run/pulse:/sbin/nologin
+ntp:x:971:971::/var/lib/ntp:/bin/false
 parsec:x:972:972::/var/lib/parsec:/bin/false
 nm-openvpn:x:975:975::/home/nm-openvpn:/bin/sh
 mosquitto:x:976:976::/home/mosquitto:/bin/false


### PR DESCRIPTION
Required by the ntp recipe.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>