### PR TITLE
bsp: kernel: modules: nxp89xx: skip debug split

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bb
@@ -12,3 +12,5 @@ S = "${WORKDIR}/git/mxm_wifiex/wlan_src"
 inherit module
 
 EXTRA_OEMAKE = "KERNELDIR=${STAGING_KERNEL_BUILDDIR} -C ${STAGING_KERNEL_BUILDDIR} M=${S}"
+
+INHIBIT_PACKAGE_DEBUG_SPLIT = "${@bb.utils.contains('DISTRO_FEATURES', 'modsign', '1', '', d)}"


### PR DESCRIPTION
This fixes the mlan/moal driver loading and wifi support on imx8mm-lpddr4-evk.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>