### PR TITLE
base: lmp: mask gcc tegra when we don't use any tegra machine

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -100,6 +100,11 @@ BBMASK += " \
     /meta-xilinx-tools/recipes-bsp/u-boot/u-boot-xlnx_%.bbappend \
 "
 
+# mask gcc tegra when we don't use any tegra machine
+BBMASK_TEGRA_GCC = "/meta-tegra/recipes-devtools/gcc/"
+BBMASK_TEGRA_GCC:tegra = ""
+BBMASK += "${BBMASK_TEGRA_GCC}"
+
 # disable xsct tarball by default (xilinx)
 USE_XSCT_TARBALL = "0"
 


### PR DESCRIPTION
The meta-tegra layer when enabled is superimposing its gcc inc files [1]
and e currently don't use the oe-core file at [2].

[1] meta-tegra/recipes-devtools/gcc/gcc-source.inc
[2] openembedded-core/meta/recipes-devtools/gcc/gcc-source.inc

The gcc-source.inc has the same content currently but the probability of
all other inc being different is quite high.
Maybe they don't need the inc files and if they requires it, it needs to be
versioned to don't overlap the oe-core.

```
ls meta-tegra/recipes-devtools/gcc/ |grep inc
gcc-8.5.inc
gcc-common.inc
gcc-configure-common.inc
gcc-cross-canadian.inc
gcc-cross.inc
gcc-crosssdk.inc
gcc-multilib-config.inc
gcc-runtime.inc
gcc-shared-source.inc
gcc-source.inc
gcc-target.inc
libgcc-common.inc
libgcc.inc
libgcc-initial.inc
```

```
bitbake-getvar -r gcc-source-11.2.0 PN
#
# $PN [3 operations]
#   set /home/quaresmajose/factories/xilinx-kirkstone/lmp-manifest/build/conf/../../layers/openembedded-core/meta/conf/bitbake.conf:234
#     "${@bb.parse.vars_from_file(d.getVar('FILE', False),d)[0] or 'defaultpkgname'}"
#   set /home/quaresmajose/factories/xilinx-kirkstone/lmp-manifest/build/conf/../../layers/openembedded-core/meta/conf/documentation.conf:332
#     [doc] "PN refers to a recipe name in the context of a file used by the OpenEmbedded build system as input to create a package. It refers to a package name in the context of a file created or produced by the OpenEmbedded build system."
#   set /home/quaresmajose/factories/xilinx-kirkstone/lmp-manifest/build/conf/../../layers/meta-tegra/recipes-devtools/gcc/gcc-source.inc:10
#     "gcc-source-${PV}"
# pre-expansion value:
#   "gcc-source-${PV}"
PN="gcc-source-11.2.0"
```

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>