### PR TITLE
base: systemd: only enable gnu-efi when efi is available

### DIFF
--- a/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
@@ -6,9 +6,9 @@ PACKAGECONFIG ?= " \
     ${@bb.utils.filter('DISTRO_FEATURES', 'acl audit efi ldconfig pam selinux smack usrmerge polkit seccomp', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'rfkill', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'xkbcommon', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'efi', 'gnu-efi', '', d)} \
     backlight \
     binfmt \
-    gnu-efi \
     gshadow \
     hibernate \
     hostnamed \


### PR DESCRIPTION
Systemd cannot build with gnu-efi support when support for efi is not
enabled, so make it depend on it.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>