### PR TITLE
Fix se05x support

### DIFF
--- a/meta-lmp-base/recipes-bsp/plug-and-trust-seteec/plug-and-trust-seteec_3.3.0.bb
+++ b/meta-lmp-base/recipes-bsp/plug-and-trust-seteec/plug-and-trust-seteec_3.3.0.bb
@@ -3,7 +3,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRC_URI = "git://github.com/foundriesio/plug-and-trust-seteec;branch=main;protocol=https"
-SRCREV = "a8034cf24968f4d23ca98fc9edc037b7372b0777"
+SRCREV = "f88be2ce7a35a8adb9a7bdd6f8cdb1907119d553"
 
 DEPENDS = "openssl optee-client"
 

--- a/meta-lmp-base/recipes-devtools/python/python3-plug-and-trust-ssscli_3.3.0.bb
+++ b/meta-lmp-base/recipes-devtools/python/python3-plug-and-trust-ssscli_3.3.0.bb
@@ -13,6 +13,8 @@ inherit setuptools3
 RDEPENDS:${PN} += "plug-and-trust-seteec \
     ${PYTHON_PN}-click \
     ${PYTHON_PN}-func-timeout \
+    ${PYTHON_PN}-logging \
+    ${PYTHON_PN}-cryptography \
 "
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Missing plug-and-trust-seteec bump after https://github.com/foundriesio/plug-and-trust-seteec/pull/2 is merged.