### PR TITLE
bsp: lmp-machine-custom: intel: add efitools to WKS_FILE_DEPENDS 

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -126,7 +126,7 @@ OSTREE_SPLIT_BOOT:intel-corei7-64 = "1"
 OSTREE_LOADER_LINK:intel-corei7-64 = "0"
 KERNEL_CLASSES:intel-corei7-64 = " kernel-lmp-efi "
 WKS_FILE:intel-corei7-64:sota ?= "efidisk-sota.wks.in"
-WKS_FILE_DEPENDS:append:intel-corei7-64 = " ${INITRD_IMAGE_LIVE}"
+WKS_FILE_DEPENDS:append:intel-corei7-64 = " ${INITRD_IMAGE_LIVE} efitools"
 ## wic-based installer requires image to be available via IMAGE_BOOT_FILES
 IMAGE_BOOT_FILES:intel-corei7-64 = "${@bb.utils.contains('WKS_FILE', 'image-efi-installer.wks.in', 'systemd-bootx64.efi;EFI/BOOT/bootx64.efi systemd-bootx64.efi;EFI/systemd/systemd-bootx64.efi startup.nsh ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ota-ext4;rootfs.img', '', d)}"
 IMAGE_EFI_BOOT_FILES:append:intel-corei7-64 = " LockDown.efi ${@make_efi_cer_boot_files(d)}"


### PR DESCRIPTION
The wic image depends on do_deploy from efitools that provides the LockDown.efi

```
| DEBUG: Executing shell function do_image_wic
| INFO: Creating image(s)...
|
| ERROR: _exec_cmd: install -m 0644 -D /srv/oe/build/deploy/images/intel-corei7-64/LockDown.efi /srv/oe/build/tmp-lmp/work/intel_corei7_64-lmp-linux/lmp-factory-image/1.0-r0/tmp-wic/hdd/boot/LockDown.efi returned '1' instead of 0
| output: install: cannot stat '/srv/oe/build/deploy/images/intel-corei7-64/LockDown.efi': No such file or directory
|
| WARNING: exit code 1 from a shell command.
| INFO: recipe lmp-factory-image-1.0-r0: task do_image_wic: Failed
| ERROR: Task (/srv/oe/build/conf/../../layers/meta-subscriber-overrides/recipes-samples/images/lmp-factory-image.bb:do_image_wic) failed with exit code '1'

```
Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>