### PR TITLE
drop the use of INHIBIT_PACKAGE_DEBUG_SPLIT for kernel modsign

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp.inc
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp.inc
@@ -16,9 +16,6 @@ LINUX_VERSION_EXTENSION ?= "-lmp-${LINUX_KERNEL_TYPE}"
 KERNEL_CONFIG_NAME ?= "${KERNEL_PACKAGE_NAME}-config-${KERNEL_ARTIFACT_NAME}"
 KERNEL_CONFIG_LINK_NAME ?= "${KERNEL_PACKAGE_NAME}-config"
 
-# Skip debug split if modsign is enabled (to avoid invalidating signatures)
-INHIBIT_PACKAGE_DEBUG_SPLIT = "${@bb.utils.contains('DISTRO_FEATURES', 'modsign', '1', '', d)}"
-
 do_deploy:append() {
     # Publish final kernel config with a proper datetime-based link
     cp -a ${B}/.config ${DEPLOYDIR}/${KERNEL_CONFIG_NAME}

--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bbappend
@@ -1,3 +1,3 @@
 DEPENDS += "virtual/kernel"
 
-INHIBIT_PACKAGE_DEBUG_SPLIT = "${@bb.utils.contains('DISTRO_FEATURES', 'modsign', '1', '', d)}"
+inherit ${@bb.utils.contains('DISTRO_FEATURES', 'modsign', 'kernel-modsign', '', d)}


### PR DESCRIPTION
- Revert "base: linux-lmp: skip debug split with modsign"
- bsp: kernel: modules: nxp89xx: inherit the kernel-modsign