### PR TITLE
Enable support for generating SPDX-based SBOM via create-spdx

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -72,6 +72,8 @@ BUILD_OSTREE_TARBALL ?= "0"
 # LMP default classes and overwrites
 INHERIT += "lmp"
 
+## Create SPDX (SBOM) by default
+INHERIT += "create-spdx"
 INHERIT += "buildhistory"
 INHERIT += "image-buildinfo"
 BUILDHISTORY_COMMIT = "1"

--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -8,6 +8,9 @@ MAINTAINER = "LMP Support <support@foundries.io>"
 
 TARGET_VENDOR = "-lmp"
 
+LMP_FACTORY ?= "lmp"
+SPDX_ORG = "Foundries.IO (factory ${LMP_FACTORY})"
+
 TCLIBCAPPEND = ""
 
 require conf/distro/include/arm-defaults.inc


### PR DESCRIPTION
Leverage the create-spdx upstream class (available in kirkstone) to generate the SPDX-based SBOM by default on every lmp build type.