### PR TITLE
build with clang toolchain by default

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -83,6 +83,10 @@ INHERIT += "buildhistory"
 INHERIT += "image-buildinfo"
 BUILDHISTORY_COMMIT = "1"
 
+# Clang toolchain
+TOOLCHAIN ?= "clang"
+RUNTIME = "llvm"
+
 PREMIRRORS ??= "\
      git://.*/.* https://storage.googleapis.com/lmp-cache/downloads/ \n \
      ftp://.*/.* https://storage.googleapis.com/lmp-cache/downloads/ \n \


### PR DESCRIPTION
base: lmp: build with clang toolchain by default

For recipes that doesn't build we can go back to gcc toolchain
with TOOLCHAIN:pn-recipes = "gcc" in main local.conf or
TOOLCHAIN = "gcc" on himself in a bbappend

Depends on https://github.com/foundriesio/meta-lmp/pull/705