### PR TITLE
base: kmeta-linux-lmp-5.10.y: bump to cf3fa2a

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.10.y"
-KERNEL_META_COMMIT ?= "6b646d8f36af8d64ea68c37ad6b82e2d84f1a270"
+KERNEL_META_COMMIT ?= "cf3fa2a9cd915d4536da813b19f2e5481c5809c9"


### PR DESCRIPTION
Relevant changes:
- cf3fa2a bsp: ti: Add standard for am62xx-evm

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>