### PR TITLE
base: optee-os-fio: 3.17: bump to b2b258efe

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.17.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.17.0.bb
@@ -1,5 +1,5 @@
 require optee-os-fio.inc
 
 PV = "3.17.0+git"
-SRCREV = "9fed2c40b2cf86212ddd3538e2bc88e3f20b55a4"
+SRCREV = "b2b258efe83997eb5d927744bd38bf89f93bbfab"
 SRCBRANCH = "3.17+fio"


### PR DESCRIPTION
Relevant changes:
- b2b258efe [FIO fromtree] drivers: imx: dcp: disable the use of UNIQUE KEY after HUK generation
- dca14164c [FIO fromtree] drivers: imx: dcp: clear OTP_KEY bit for unique key selection
- 4100c4aba [FIO fromtree] drivers: imx: dcp: workaround DCP errata 051292
- 987e21245 Revert "[FIO toup] drivers: dcp: fix HUK support"
- b943189fa [FIO toup] imx_ocotp: correct ocotp fuse address computation

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>