### PR TITLE
base: aktualizr: use updated pkcs11 engines path for openssl 3

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -22,6 +22,8 @@ PACKAGECONFIG[fiovb] = ",,,optee-fiovb aktualizr-fiovb-env-rollback"
 PACKAGECONFIG[ubootenv] = ",,u-boot-fw-utils,u-boot-fw-utils u-boot-default-env aktualizr-uboot-env-rollback"
 PACKAGECONFIG[libfyaml] = ",,,libfyaml"
 
+PKCS11_ENGINE_PATH = "${libdir}/engines-3/pkcs11.so"
+
 SYSTEMD_PACKAGES += "${PN}-lite"
 SYSTEMD_SERVICE:${PN}-lite = "aktualizr-lite.service"
 


### PR DESCRIPTION
Due switch to OpenSSL 3 (>= kirkstone), the pkcs11 engine path needs
to be changed to follow the correct version id.

Upstream meta-updater PR:
https://github.com/uptane/meta-updater/pull/43

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>