### PR TITLE
base: recipe-sota: aktualizr-lite: bump to 632b6c1

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "e05f7eb7a852491c2812b89b60af9979aca44501"
+SRCREV:lmp = "632b6c10aaa596c69b19d3338d17c1ac3ecc9fca"
 
 SRC_URI:lmp = "gitsm://github.com/foundriesio/aktualizr-lite;protocol=https;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
Relevant changes:
 - 632b6c1 aklite-apps: Set deps on `c++17` explicitly
 - fafa4d1 Use clang by default in dev and test env

Signed-off-by: Mike <mike.sul@foundries.io>