### PR TITLE
bsp: u-boot-xlnx: 2022.01: bump to 071696ff7ce

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx_2022.01.bb
+++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx_2022.01.bb
@@ -3,7 +3,7 @@ UBOOT_VERSION = "v2022.01"
 UBRANCH = "xilinx-v2022.01-rebase"
 UBOOTURI = "git://github.com/foundriesio/u-boot.git;protocol=https"
 
-SRCREV = "7c9f39b98b23f77e2cb38b314b5ff5c954f98c04"
+SRCREV = "071696ff7ce8b8ecb79c96dbd7c3addde11960c0"
 
 include recipes-bsp/u-boot/u-boot-xlnx.inc
 include recipes-bsp/u-boot/u-boot-spl-zynq-init.inc


### PR DESCRIPTION
Relevant changes:
- 071696ff7ce fpga: zynqmp: support loading encrypted bitfiles
- dcf2c6b6d2b fpga: zynqmp: support loading authenticated images
- 67301a8f09a fpga: zynqmp: add bitstream compatible checking
- 8a592b8252c fpga: zynqmp: optimize zynqmppl_load() code
- d6465d67c10 fpga: xilinx: pass compatible flags to load() callback
- 387fe4404a7 spl: fit: pass real compatible flags to fpga_load()
- d08510a0f89 fpga: pass compatible flags to fpga_load()
- 162ed3404dd fpga: xilinx: pass compatible flags to xilinx_load()
- 50c9fee97ba fpga: add fpga_compatible2flag
- c8dce324a45 fpga: zynqmp: add str2flags call
- 8f3db2c3f48 fpga: xilinx: add bitstream flags to driver desc
- 4d1a011034f fpga: xilinx: add missed identifier names
- 715b08d3703 Revert "[FIO toup] cmd: fpga: Separating the support of fpga loads"
- 356cdf85d46 Revert "[FIO fromlist] fpga_load: pass compatible string"
- ccac9de5e87 Revert "[FIO toup] fpga: xilinx: store compatible attribute"
- 78d0abf5908 Revert "[FIO toup] fpga: zynqmp: support loading authenticated images"
- 848c5850188 fpga: fix SPL_FPGA_LOAD_SECURE dependecy

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>