### PR TITLE
base: lmp-feature-docker: create docker group before adding users to them

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-feature-docker.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-docker.inc
@@ -6,5 +6,6 @@ CORE_IMAGE_BASE_INSTALL += " \
 "
 
 EXTRA_USERS_PARAMS += "\
+groupadd docker; \
 usermod -a -G docker ${LMP_USER}; \
 "


### PR DESCRIPTION
Fix the following When running do_rootfs task twice: bitbake lmp-factory-image -c do_rootfs

| ERROR: lmp-factory-image-1.0-r0 do_rootfs: lmp-factory-image: usermod command did not succeed.
| ERROR: lmp-factory-image-1.0-r0 do_rootfs: ExecutionError('/build/tmp-lmp/work/intel_corei7_64-lmp-linux/lmp-factory-image/1.0-r0/temp/run.set_user_group.249799', 1, None, None)
| ERROR: Logfile of failure stored in: /build/tmp-lmp/work/intel_corei7_64-lmp-linux/lmp-factory-image/1.0-r0/temp/log.do_rootfs.249799
| ERROR: Task (/build/conf/../../layers/meta-subscriber-overrides/recipes-samples/images/lmp-factory-image.bb:do_rootfs) failed with exit code '1'

Analyzing the log gives:

| NOTE: lmp-factory-image: Performing usermod with [-R /build/tmp-lmp/work/intel_corei7_64-lmp-linux/lmp-factory-image/1.0-r0/rootfs -a -G docker fio]
| usermod: group 'docker' does not exist
| ERROR: lmp-factory-image: usermod command did not succeed.

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>