### PR TITLE
base: wireguard-tools: add nostamp for create_runtime_spdx

### DIFF
--- a/meta-lmp-base/recipes-kernel/wireguard/wireguard-tools_%.bbappend
+++ b/meta-lmp-base/recipes-kernel/wireguard/wireguard-tools_%.bbappend
@@ -11,3 +11,6 @@ FILES:${PN}-wg-quick = " \
 
 RDEPENDS:${PN} = "kernel-module-wireguard"
 RDEPENDS:${PN}-wg-quick = "${PN} bash"
+
+# SPDX data can miss updates due caching
+do_create_runtime_spdx[nostamp] = "1"


### PR DESCRIPTION
SPDX data requires all runtime dependencies to be updated in order to
reflect the correct json files, and as it is depending on a kernel
module recipe (wireguard-module), we need to force nostamp for
create_runtime_spdx otherwise it will be ignored due sstate cache
filtering (siggen).

This can be reverted once the correct fix lands upstream.

For more information:
https://www.yoctoproject.org/irc/%23yocto.2022-07-06.log.html#t2022-07-06T20:25:15

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>