### PR TITLE
bsp: cboot-t19x: drop total bytes read check

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-bsp/cboot/cboot-t19x_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-bsp/cboot/cboot-t19x_%.bbappend
@@ -2,4 +2,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/cboot:"
 
 SRC_URI:append = " \
     file://0001-extlinux-add-support-for-syslinux-ostree.patch \
+    file://0001-ext4-drop-total-bytes-read-check.patch \
 "

--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-bsp/cboot/cboot/0001-ext4-drop-total-bytes-read-check.patch
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-bsp/cboot/cboot/0001-ext4-drop-total-bytes-read-check.patch
@@ -1,0 +1,45 @@
+From 0ff3b1b971b6f979b40637c2e8e7d1551a57266d Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo@foundries.io>
+Date: Thu, 7 Jul 2022 19:43:01 -0300
+Subject: [PATCH] ext4: drop total bytes read check
+
+Check is not correct as it is not taking into account the block size, so
+just revert in order to unblock boot.
+
+No need for the proper implementation as we will be soon switching to
+JetPack 5.0.
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+---
+ bootloader/partner/common/lib/fs/ext4/ext4.c | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+diff --git a/bootloader/partner/common/lib/fs/ext4/ext4.c b/bootloader/partner/common/lib/fs/ext4/ext4.c
+index 403fc77..362f7c0 100644
+--- a/bootloader/partner/common/lib/fs/ext4/ext4.c
++++ b/bootloader/partner/common/lib/fs/ext4/ext4.c
+@@ -294,21 +294,11 @@ static ssize_t ext4_read_data_from_extent(ext2_t *ext2, struct ext2fs_dinode *in
+             err = ext4_read_extent(ext2, (struct ext4_extent_header *)buf2, buf_ptr, &bytes_read);
+             total_bytes_read += bytes_read;
+             buf_ptr += bytes_read;
+-			if ((len != 0) && (total_bytes_read > len)) {
+-				TRACEF("Total file read should not be larger than file stat size\n");
+-				err = ERR_NOT_VALID;
+-				goto fail;
+-			}
+         }
+     } else {
+         /* Read leaf node */
+         err = ext4_read_extent(ext2, extent_header, buf_ptr, &bytes_read);
+         total_bytes_read += bytes_read;
+-		if ((len != 0) && (total_bytes_read > len)) {
+-			TRACEF("Total file read should not be larger than file stat size\n");
+-			err = ERR_NOT_VALID;
+-			goto fail;
+-		}
+     }
+ 
+     LTRACEF("err %d, bytes_read %lu\n", err, total_bytes_read);
+-- 
+2.34.1
+


### PR DESCRIPTION
Check is not correct as it is not taking into account the block size, so
just revert in order to unblock boot.

No need for the proper implementation as we will be soon switching to
JetPack 5.0.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>