### PR TITLE
base: lmp: kmod: add openssl to PACKAGECONFIG

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -49,6 +49,7 @@ PACKAGECONFIG:remove:pn-runc-opencontainers = "static"
 PACKAGECONFIG:append:pn-qemu-native = " libusb"
 PACKAGECONFIG:append:pn-networkmanager = " libedit"
 PACKAGECONFIG:remove:pn-networkmanager = " readline"
+PACKAGECONFIG:append:pn-kmod = " openssl"
 
 # Alternatives used by nss-altfiles
 NSS_ALT_TYPES ?= "hosts,pwd,grp,spwd,sgrp"


### PR DESCRIPTION
We use signed kernel modules by default, so enable openssl support in
kmod in order for it to be able to provide details about the signature
at runtime.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>