### PR TITLE
Fixes for the external kernel modules signing issue

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -118,6 +118,9 @@ WARN_QA:remove = "${WARN_TO_ERROR_QA}"
 ERROR_QA:append = " ${WARN_TO_ERROR_QA}"
 ERROR_QA:remove = "version-going-backwards"
 
+# Required to avoid removing libraries used during signing
+RM_WORK_EXCLUDE += "make-mod-scripts"
+
 LMP_USER ?= "fio"
 # LMP_PASSWORD is a hassed password. To generate the hash use the following command on a host machine
 # mkpasswd -m sha512crypt

--- a/meta-lmp-bsp/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/kernel-modules/kernel-module-nxp89xx_git.bb
@@ -7,6 +7,8 @@ MRVL_SRC ?= "git://source.codeaurora.org/external/imx/mwifiex.git;protocol=https
 SRC_URI = "${MRVL_SRC};branch=${SRCBRANCH}"
 SRCREV = "3c2a3c2cd25e9dce95f34c21bb4e728647eb64ee"
 
+DEPENDS += "virtual/kernel"
+
 S = "${WORKDIR}/git/mxm_wifiex/wlan_src"
 
 inherit module


### PR DESCRIPTION
This is to fix the module not signed issue we noticed on imx8mm evk (wifi module is external).

This was caused by a race condition during the rm_work step, which erased the sysroot for make-mod-scripts, causing sign-file to error out due missing openssl library.