### PR TITLE
base: python3-docker-vxcan: bump to 54e218b

### DIFF
--- a/meta-lmp-base/recipes-containers/docker/python3-docker-vxcan_1.0.2.bb
+++ b/meta-lmp-base/recipes-containers/docker/python3-docker-vxcan_1.0.2.bb
@@ -8,7 +8,7 @@ inherit setuptools3 systemd
 SRC_URI = "git://github.com/jhaws1982/docker-vxcan.git;branch=master;protocol=https \
            file://docker-vxcan.service \
 "
-SRCREV = "813370f5bf1ec3a5254a6541c25ea9db33fde8de"
+SRCREV = "54e7dd42d5d39fb3cf30a9c479081865fca42534"
 
 S = "${WORKDIR}/git"
 B = "${S}"


### PR DESCRIPTION
Relevant changes:
- 54e218b fix application routing for '/NetworkDriver.EndpointOperInfo'

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>