### PR TITLE
Revert "bsp: imx-gpu-g2d: install samples at datadir instead of opt"

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-graphics/imx-gpu-g2d/imx-gpu-g2d_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-graphics/imx-gpu-g2d/imx-gpu-g2d_%.bbappend
@@ -1,7 +1,0 @@
-# /opt is not valid under ostree
-do_install:append() {
-    install -d ${D}${datadir}/${PN}
-    mv ${D}/opt/* ${D}${datadir}/${PN}
-}
-
-FILES:${PN} += "${datadir}"


### PR DESCRIPTION
It appears that there is no longer any files being installed
in the /opt directory.

This reverts commit 444e446e607ba4fae211c5b5512916654f079734.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>