### PR TITLE
bsp: mfgtool-files: imx: delete bootfirmware_version during provisioning

### DIFF
--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx6-sec/full_image.uuu.in
@@ -25,7 +25,7 @@ FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue bootcount
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue rollback 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue upgrade_available 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue bootupgrade_available 0; else true; fi
-FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue bootfirmware_version 0; else true; fi
+FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb delete_pvalue bootfirmware_version; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue debug 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue is_secondary_boot 0; else true; fi
 

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx8-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx8-sec/full_image.uuu.in
@@ -30,7 +30,7 @@ FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue bootcount
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue rollback 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue upgrade_available 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue bootupgrade_available 0; else true; fi
-FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue bootfirmware_version 0; else true; fi
+FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb delete_pvalue bootfirmware_version; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue debug 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue is_secondary_boot 0; else true; fi
 

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mm-lpddr4-evk-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mm-lpddr4-evk-sec/full_image.uuu.in
@@ -17,7 +17,7 @@ FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue bootcount
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue rollback 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue upgrade_available 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue bootupgrade_available 0; else true; fi
-FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue bootfirmware_version 0; else true; fi
+FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb delete_pvalue bootfirmware_version; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue debug 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue is_secondary_boot 0; else true; fi
 

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mp-lpddr4-evk-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mp-lpddr4-evk-sec/full_image.uuu.in
@@ -17,7 +17,7 @@ FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue bootcount
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue rollback 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue upgrade_available 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue bootupgrade_available 0; else true; fi
-FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue bootfirmware_version 0; else true; fi
+FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb delete_pvalue bootfirmware_version; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue debug 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue is_secondary_boot 0; else true; fi
 


### PR DESCRIPTION
Prefer to delete bootfirmware_version instead of writing a default value
at provisioning to allow the correct initial value to be set during
first boot instead.

By setting to a default value (0) every first update will also cause the
boot firmware to be updated as a consequence, since the firmware version
will differ.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>