### PR TITLE
base: recipes-sota: Add aklite offline update cmd

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "632b6c10aaa596c69b19d3338d17c1ac3ecc9fca"
+SRCREV:lmp = "797963113a5d5d2876df8e5fc138a3b787e8f81c"
 
 SRC_URI:lmp = "gitsm://github.com/foundriesio/aktualizr-lite;protocol=https;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -21,6 +21,7 @@ PACKAGECONFIG += "${@bb.utils.filter('MACHINE_FEATURES', 'fiovb', d)} libfyaml"
 PACKAGECONFIG[fiovb] = ",,,optee-fiovb aktualizr-fiovb-env-rollback"
 PACKAGECONFIG[ubootenv] = ",,u-boot-fw-utils,u-boot-fw-utils u-boot-default-env aktualizr-uboot-env-rollback"
 PACKAGECONFIG[libfyaml] = ",,,libfyaml"
+PACKAGECONFIG[aklite-offline] = "-DBUILD_AKLITE_OFFLINE=ON,-DBUILD_AKLITE_OFFLINE=OFF,"
 
 PKCS11_ENGINE_PATH = "${libdir}/engines-3/pkcs11.so"
 
@@ -63,6 +64,7 @@ FILES:${PN}-get = "${bindir}/${PN}-get"
 FILES:${PN}-lite = " \
                     ${bindir}/${PN}-lite \
                     ${bindir}/aklite-apps \
+                    ${bindir}/aklite-offline \
                     ${nonarch_libdir}/tmpfiles.d/${PN}-lite.conf \
                     "
 FILES:${PN}-lite-lib = "${nonarch_libdir}/lib${PN}_lite.so"


### PR DESCRIPTION
- Add `aklite-offline` command to the aktualizr-lite package if `aklite-offline` feature is enabled/added to the package config.
  
- Bump aklite version that supports an offline update.


Signed-off-by: Mike <mike.sul@foundries.io>