### PR TITLE
base: lmp: provision TUF root metadata

### DIFF
--- a/meta-lmp-base/classes/lmp.bbclass
+++ b/meta-lmp-base/classes/lmp.bbclass
@@ -22,7 +22,7 @@ provision_root_meta () {
 			LOG_FILE="${SOTA_TUF_ROOT_LOG_FILE}" \
 				${SOTA_TUF_ROOT_FETCHER}
 		else
-			bbfatal "Provisioning of TUF root role metadata is turned ON, but the specified metadata fetcher is either doesn't exist or is not executable: ${TUF_ROOT_FETCHER}"
+			bbfatal "Provisioning of TUF root role metadata is turned ON, but the specified metadata fetcher is either doesn't exist or is not executable: ${SOTA_TUF_ROOT_FETCHER}"
 		fi
 	else
 		bbfatal "Provisioning of TUF root role metadata is turned ON, but a metadata fetcher `SOTA_TUF_ROOT_FETCHER` is not defined"

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "797963113a5d5d2876df8e5fc138a3b787e8f81c"
+SRCREV:lmp = "8f67b6ac2248687e53e049568d928790c98c2b4b"
 
 SRC_URI:lmp = "gitsm://github.com/foundriesio/aktualizr-lite;protocol=https;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
Fetch and store root metadata on an ostree-based rootfs during bitbaking.