### PR TITLE
base: wayland/xwayland: add vulkan to DISTRO_FEATURES

### DIFF
--- a/meta-lmp-base/conf/distro/lmp-wayland.conf
+++ b/meta-lmp-base/conf/distro/lmp-wayland.conf
@@ -4,4 +4,4 @@ DISTRO = "lmp-wayland"
 DISTROOVERRIDES = "lmp:lmp-wayland"
 DISTRO_NAME = "Linux-microPlatform Wayland"
 
-DISTRO_FEATURES:append = " wayland opengl"
+DISTRO_FEATURES:append = " wayland opengl vulkan"

--- a/meta-lmp-base/conf/distro/lmp-xwayland.conf
+++ b/meta-lmp-base/conf/distro/lmp-xwayland.conf
@@ -4,7 +4,7 @@ DISTRO = "lmp-xwayland"
 DISTROOVERRIDES = "lmp:lmp-wayland:lmp-xwayland"
 DISTRO_NAME = "Linux-microPlatform XWayland"
 
-DISTRO_FEATURES:append = " x11 wayland opengl"
+DISTRO_FEATURES:append = " x11 wayland opengl vulkan"
 
 # meta-freescale: remove append which drops x11 from gtk+3 PACKAGECONFIG if wayland is selected
 BBMASK += " \


### PR DESCRIPTION
Have both opengl and vulkan enabled by default on wayland/xwayland
builds.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>