### PR TITLE
bsp: linux-firmware: stm32: fix brcmfmac43430-sdio.txt

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-lmp-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -56,6 +56,11 @@ do_install:append:imx-nxp-bsp () {
     install -m 0644 ${WORKDIR}/imx-firmware/nxp/FwImage_8997/txpwrlimit_cfg_8997.conf  ${D}${nonarch_base_libdir}/firmware/nxp
 }
 
+do_install:append:stm32mpcommon() {
+    # Set BFL3_EXT_LPO_ISCLOCK for wifi to work with upstream 5.15
+    sed -i "s/^boardflags3=0x08/boardflags3=0x02/g" ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.st,stm32mp157*
+}
+
 PACKAGES =+ "${PN}-nxp89xx"
 
 FILES:${PN}-nxp89xx = " \


### PR DESCRIPTION
Latest firmware with latest kernel won't work with the default settings,
but it is fully functional after switching to EXT_LPO_ISCLOCK (using the
external LPO as clock - 32kHz).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>