### PR TITLE
base: images: install i2c-tools package

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -33,6 +33,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     mtd-utils \
     sudo \
     zram \
+    i2c-tools \
 "
 
 # Additional packages when sota is available


### PR DESCRIPTION
Install i2c-tools package by default for all images, as this likely to
be used on all platforms when debugging/testing SE05X security chips.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>