### PR TITLE
base: resize-helper fix error exit when no PART_ENTRY_NAME exists

### DIFF
--- a/meta-lmp-base/recipes-support/resize-helper/resize-helper/resize-helper
+++ b/meta-lmp-base/recipes-support/resize-helper/resize-helper/resize-helper
@@ -43,7 +43,7 @@ ROOT_DEVICE=$(realpath ${ROOT_DEVICE})
 # get the partition number and type
 INFO=$(udevadm info --query=property --name=${ROOT_DEVICE})
 PART_ENTRY_NUMBER=$(echo "${INFO}" | grep '^ID_PART_ENTRY_NUMBER=' | cut -d'=' -f2)
-PART_ENTRY_NAME=$(echo "${INFO}" | grep '^ID_PART_ENTRY_NAME=' | cut -d'=' -f2)
+PART_ENTRY_NAME=$(echo "${INFO}" | grep '^ID_PART_ENTRY_NAME=' || true | cut -d'=' -f2)
 
 # in case the root device is not on a partitioned media
 if [ "x$PART_ENTRY_NUMBER" = "x" ]; then


### PR DESCRIPTION
Signed-off-by: Tim Anderson <tim.anderson@foundries.io>