### PR TITLE
base: lmp-image-common: add curl util

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -34,6 +34,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     sudo \
     zram \
     i2c-tools \
+    curl \
 "
 
 # Additional packages when sota is available


### PR DESCRIPTION
This tool is pretty small and way useful for troubleshooting to be
included in all LmP images.

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>