### PR TITLE
Add support of u-boot imx 2022.04

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
@@ -6,7 +6,7 @@ application code."
 SECTION = "bootloaders"
 LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
-DEPENDS += "flex-native bison-native bc-native dtc-native python3-setuptools-native"
+DEPENDS += "flex-native bison-native bc-native dtc-native python3-setuptools-native gnutls-native"
 
 UBOOT_REPO ??= "git://github.com/foundriesio/u-boot.git"
 

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
@@ -8,7 +8,9 @@ LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
 DEPENDS += "flex-native bison-native bc-native dtc-native python3-setuptools-native"
 
-SRC_URI = "git://github.com/foundriesio/u-boot.git;protocol=https;branch=${SRCBRANCH} \
+UBOOT_REPO ??= "git://github.com/foundriesio/u-boot.git"
+
+SRC_URI = "${UBOOT_REPO};protocol=https;branch=${SRCBRANCH} \
     file://fw_env.config \
     ${@bb.utils.contains('MACHINE_FEATURES', 'ebbr', 'file://lmp-ebbr.cfg', 'file://lmp.cfg', d)} \
 "

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-mfgtool_imx-2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-mfgtool_imx-2022.04.bb
@@ -1,0 +1,10 @@
+SUMMARY = "Produces a Manufacturing Tool compatible U-Boot"
+DESCRIPTION = "U-Boot recipe that produces a Manufacturing Tool compatible \
+binary to be used in updater environment"
+
+require recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
+
+# Environment config is not required for mfgtool
+SRC_URI:remove = "file://fw_env.config"
+
+DEFAULT_PREFERENCE = "-1"

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
@@ -1,0 +1,5 @@
+require u-boot-fio-common.inc
+
+SRCREV = "edc7a363c9fcfa9b20c0dbbdf4d902fef595947b"
+SRCBRANCH = "2022.04+lf-5.15.32-2.0.0-fio"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"


### PR DESCRIPTION
Prepare recipes for enabling u-boot imx-2022.04 for imx boards.
Reduce the PR to only adding the u-boot imx-2022.04 support without switching boards to use it.
There will be other PRs for switching boards to this u-boot as long as they are ready.