### PR TITLE
Revert "base: wireguard-tools: add nostamp for create_runtime_spdx"

### DIFF
--- a/meta-lmp-base/recipes-kernel/wireguard/wireguard-tools_%.bbappend
+++ b/meta-lmp-base/recipes-kernel/wireguard/wireguard-tools_%.bbappend
@@ -11,6 +11,3 @@ FILES:${PN}-wg-quick = " \
 
 RDEPENDS:${PN} = "kernel-module-wireguard"
 RDEPENDS:${PN}-wg-quick = "${PN} bash"
-
-# SPDX data can miss updates due caching
-do_create_runtime_spdx[nostamp] = "1"


### PR DESCRIPTION
This reverts commit eb6758553b97559b0c156d5db9d63bc6b4507465.

Correct fix now available in kirkstone oe-core
(7549429fc93218dee33b216010b2c36a9f814091).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>