### PR TITLE
bsp: kernel-module-imx-gpu-viv: depend on virtual/kernel

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p2.4.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p2.4.bbappend
@@ -1,0 +1,1 @@
+DEPENDS += "virtual/kernel"

--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p2.4.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p2.4.bbappend
@@ -1,1 +1,3 @@
 DEPENDS += "virtual/kernel"
+
+inherit ${@bb.utils.contains('DISTRO_FEATURES', 'modsign', 'kernel-modsign', '', d)}


### PR DESCRIPTION
Make sure to explicitly depend on virtual/kernel in order to link the
spdx chain correctly and avoid broken task dependencies.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>