### PR TITLE
Revert "base: nerdctl: install the binaries in OE standard places"

### DIFF
--- a/meta-lmp-base/recipes-containers/nerdctl/nerdctl_git.bb
+++ b/meta-lmp-base/recipes-containers/nerdctl/nerdctl_git.bb
@@ -75,8 +75,8 @@ do_compile() {
 }
 
 do_install() {
-        install -d "${D}${BIN_PREFIX}/bin"
-        install -m 755 "${S}/src/import/_output/nerdctl" "${D}${BIN_PREFIX}/bin"
+        install -d "${D}${BIN_PREFIX}${base_bindir}"
+        install -m 755 "${S}/src/import/_output/nerdctl" "${D}${BIN_PREFIX}${base_bindir}"
 }
 
 INHIBIT_PACKAGE_STRIP = "1"

--- a/meta-lmp-base/recipes-containers/nerdctl/nerdctl_git.bbappend
+++ b/meta-lmp-base/recipes-containers/nerdctl/nerdctl_git.bbappend
@@ -5,9 +5,4 @@ SRC_URI:append = "\
 	file://0001-extend-ps-output.patch;patchdir=src/import \
 	"
 
-do_install() {
-	install -d ${D}${bindir}
-	install -m 755 ${S}/src/import/_output/nerdctl ${D}${bindir}
-}
-
 RDEPENDS:${PN} += "cni"


### PR DESCRIPTION
This reverts commit dd33a569bd0ab62552f7dcaf2590f6a081f88f92.

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>