### PR TITLE
base: optee-fio: use CFLAGS{32,64} to pass --sysroot

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-fio.inc
+++ b/meta-lmp-base/recipes-security/optee/optee-fio.inc
@@ -23,7 +23,8 @@ OPTEE_TA_SIGN_KEY ?= ""
 EXTRA_OEMAKE += "${@oe.utils.ifelse('${OPTEE_TA_SIGN_KEY}' != '', 'TA_SIGN_KEY=${OPTEE_TA_SIGN_KEY}', '')}"
 
 EXTRA_OEMAKE += "V=1 \
-                 LIBGCC_LOCATE_CFLAGS=--sysroot=${STAGING_DIR_HOST} \
+                 CFLAGS32=--sysroot=${STAGING_DIR_HOST} \
+                 CFLAGS64=--sysroot=${STAGING_DIR_HOST} \
                  COMPILER=${OPTEE_COMPILER} \
                  OPTEE_CLIENT_EXPORT=${STAGING_DIR_HOST}${prefix} \
                  TEEC_EXPORT=${STAGING_DIR_HOST}${prefix} \


### PR DESCRIPTION
Since OP-TEE 3.16.0 we can leverage CFLAGS32/64 for setting sysroot
option, reducing the need for a custom option and custom patches.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>