### PR TITLE
Fix basic support for intel + TPM2

### DIFF
--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-abrmd/tpm2-abrmd_%.bbappend
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-abrmd/tpm2-abrmd_%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS:${PN} += "libtss2-tcti-device"

--- a/meta-lmp-base/recipes-core/ovmf/ovmf_git.bbappend
+++ b/meta-lmp-base/recipes-core/ovmf/ovmf_git.bbappend
@@ -1,0 +1,2 @@
+PACKAGECONFIG += "${@bb.utils.contains('MACHINE_FEATURES', 'tpm2', 'tpm2', '', d)}"
+PACKAGECONFIG[tpm2] = "-D TPM2_ENABLE=TRUE,-D TPM2_ENABLE=FALSE,,"

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -118,6 +118,7 @@ WKS_FILE_DEPENDS:append:generic-arm64 = " ${INITRD_IMAGE_LIVE}"
 IMAGE_BOOT_FILES:generic-arm64 = "${@bb.utils.contains('WKS_FILE', 'image-efi-installer.wks.in', 'systemd-bootaa64.efi;EFI/BOOT/bootaa64.efi systemd-bootaa64.efi;EFI/systemd/systemd-bootaa64.efi ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ota-ext4;rootfs.img', '', d)}"
 
 # Intel
+MACHINE_FEATURES:append:intel-corei7-64 = " tpm2"
 UEFI_SIGN_ENABLE:intel-corei7-64 = "1"
 OSTREE_BOOTLOADER:intel-corei7-64 ?= "none"
 OSTREE_KERNEL_ARGS:intel-corei7-64 ?= "console=ttyS0,115200 ${OSTREE_KERNEL_ARGS_COMMON}"


### PR DESCRIPTION
Base changes should be sent upstream as well, but need to check when we get a master-next that is functional as the base versions are not the same.