### PR TITLE
base: tpm2-pkcs11: set default storedir to /var/tpm2_pkcs11

### DIFF
--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/tmpfiles.conf
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/tmpfiles.conf
@@ -1,0 +1,1 @@
+d /var/tpm2_pkcs11 0750 root root -

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_%.bbappend
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_%.bbappend
@@ -1,0 +1,13 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://tmpfiles.conf"
+
+EXTRA_OECONF += "--with-storedir=${localstatedir}/tpm2_pkcs11"
+
+do_install:append() {
+	if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+		install -D -m 0644 ${WORKDIR}/tmpfiles.conf ${D}${nonarch_libdir}/tmpfiles.d/tpm2-pkcs11.conf
+	fi
+}
+
+FILES:${PN} += "${nonarch_libdir}/tmpfiles.d/tpm2-pkcs11.conf"


### PR DESCRIPTION
Upstream uses /etc/tpm2-pkcs11 by default, which is not really ideal (as
the default location for the store sqlite databse), so set to
/var/tpm2_pkcs11 instead, and create the respective tmpfiles logic in
order for the system to create the required dir during boot.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>