### PR TITLE
base: systemd: use nonarch_libdir instead of nonarch_base_libdir

### DIFF
--- a/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
@@ -89,5 +89,7 @@ do_install:append() {
 	ln -sf ../systemd-timesyncd-update.service ${D}${systemd_system_unitdir}/sysinit.target.wants/systemd-timesyncd-update.service
 
 	# Remove systemd-boot as it is provided by a separated recipe and we can't disable via pkgconfig
-	rm -rf ${D}${nonarch_base_libdir}/systemd/boot
+	if ${@bb.utils.contains('PACKAGECONFIG', 'efi', 'true', 'false', d)}; then
+		rm -r ${D}${nonarch_libdir}/systemd/boot
+	fi
 }


### PR DESCRIPTION
Systemd expects to install the systemd-boot files under /usr/lib, so use
nonarch_libdir instead of nonarch_base_libdir in order to be compatible
with builds that are not using usrmerge.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>