### PR TITLE
base: nerdctl: add cni as runtime dependencie as it needed

### DIFF
--- a/meta-lmp-base/recipes-containers/nerdctl/nerdctl_git.bbappend
+++ b/meta-lmp-base/recipes-containers/nerdctl/nerdctl_git.bbappend
@@ -2,3 +2,5 @@ do_install() {
 	install -d ${D}${bindir}
 	install -m 755 ${S}/src/import/_output/nerdctl ${D}${bindir}
 }
+
+RDEPENDS:${PN} += "cni"


### PR DESCRIPTION
Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>