### PR TITLE
base: recipe-sota: aktualizr-lite: bump to 9c2277b

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "246edc4bd34cb55269334d7cce5565ed809fd36c"
+SRCREV:lmp = "9c2277b200bd2fc40ad0bde701799bf3ea98bc47"
 
 SRC_URI:lmp = "gitsm://github.com/foundriesio/aktualizr-lite;protocol=https;branch=${BRANCH};name=aktualizr \
     file://aktualizr.service \


### PR DESCRIPTION
Relevant changes:
- 9c2277b aklite: Send Apps status only if changed
- b4c4365 api: Send Apps status at checkin
- dd06811 aklite: Adjust to the latest changes to libaktualizr
- 76d51a9 docker: Switch to clang-* v11
- b08f0a4 aklite: Switch to libaktualizr 2022.7+fio

Signed-off-by: Mike <mike.sul@foundries.io>