### PR TITLE
bsp: kv260: add tpm2 in MACHINE_FEATURES

### DIFF
--- a/meta-lmp-bsp/conf/machine/kv260.conf
+++ b/meta-lmp-bsp/conf/machine/kv260.conf
@@ -38,3 +38,6 @@ SPL_FPGA_LOAD_ADDR = "0x18000000"
 
 # Make image-update essential as it is required for bootfw updates
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "image-update"
+
+# SOM has infineon slb9670
+MACHINE_FEATURES += "tpm2"


### PR DESCRIPTION
SOM has infineon slb9670 by default.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>