### PR TITLE
bsp: arm-trusted-firmware: versal: support raw.bin

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware/plat-versal-support-raw-bin.patch
+++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware/plat-versal-support-raw-bin.patch
@@ -1,0 +1,59 @@
+From 63df78ca5435ecdb3abf826ae977c5f39c305349 Mon Sep 17 00:00:00 2001
+From: Jorge Ramirez-Ortiz <jorge@foundries.io>
+Date: Tue, 16 Aug 2022 17:45:31 +0200
+Subject: [PATCH] plat: versal: support raw.bin
+
+This commit adds support for BL32 TEE-RAW.BIN by defaulting
+to built-time addresses when FSBL fails at providing a valid
+jump address.
+This happens when the bootimage contains a TEE.ELF: somehow
+Bootgen seems to fail at parsing the addressess.
+
+By default, BL32 is expected at 0x60000000.
+The BIF file to use would be something like this
+
+the_ROM_image:
+{
+	image {
+	      { type=bootimage, file=vpl_gen_fixed.pdi }
+	      { type=bootloader, file=plm.elf }
+	      { core=psm, file=psmfw.elf }
+	}
+
+	image {
+	      id = 0x1c000000, name=apu_subsystem
+	      { type=raw, load=0x00001000, file=versal-vck190-revA-x-ebm-01-revA.dtb }
+	      { type=raw, load=0x40000000, file=LedTest_Gpio.pdi }
+	      { core=a72-0, exception_level=el-3, trustzone, file=bl31.elf }
+ 	      { core=a72-0, exception_level=el-2, file=u-boot.elf }
+	      { core=a72-0, exception_level=el-1, trustzone,
+	            load=0x60000000, startup=0x60000000, file=tee-raw.bin }
+	}
+}
+
+Upstream-Status: Submitted [https://review.trustedfirmware.org/c/TF-A/trusted-firmware-a/+/16276]
+
+Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
+---
+ plat/xilinx/versal/bl31_versal_setup.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/plat/xilinx/versal/bl31_versal_setup.c b/plat/xilinx/versal/bl31_versal_setup.c
+index 9504c0407..2da58fb40 100644
+--- a/plat/xilinx/versal/bl31_versal_setup.c
++++ b/plat/xilinx/versal/bl31_versal_setup.c
+@@ -119,6 +119,12 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
+ 		INFO("BL31: fsbl-atf handover success %d.\n", ret);
+ 	}
+ 
++	if (!bl32_image_ep_info.pc) {
++		WARN("BL31: use built-in BL32 config data\n");
++		bl32_image_ep_info.pc = BL32_BASE;
++		bl32_image_ep_info.spsr = arm_get_spsr_for_bl32_entry();
++	}
++
+ 	NOTICE("BL31: Secure code at 0x%lx\n", bl32_image_ep_info.pc);
+ 	NOTICE("BL31: Non secure code at 0x%lx\n", bl33_image_ep_info.pc);
+ }
+-- 
+2.34.1

--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_2022.1.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_2022.1.bbappend
@@ -1,3 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:versal = " \
+	file://plat-versal-support-raw-bin.patch \
+"
+
 # Align provides with meta-arm
 PROVIDES += "virtual/trusted-firmware-a"
 


### PR DESCRIPTION
Add patch that adds adds support for BL32 TEE-RAW.BIN by
defaulting to built-time addresses when FSBL fails at providing
a valid jump address.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>