### PR TITLE
Patch docker config for nerdctl

### DIFF
--- a/meta-lmp-base/recipes-containers/nerdctl/nerdctl/cli-config-support-default-system-config.patch
+++ b/meta-lmp-base/recipes-containers/nerdctl/nerdctl/cli-config-support-default-system-config.patch
@@ -1,0 +1,29 @@
+diff --git a/src/import/vendor.fetch/github.com/docker/cli/cli/config/config.go b/src/import/vendor.fetch/github.com/docker/cli/cli/config/config.go
+index 31ad117d41..eaf851e22c 100644
+--- a/src/import/vendor.fetch/github.com/docker/cli/cli/config/config.go
++++ b/src/import/vendor.fetch/github.com/docker/cli/cli/config/config.go
+@@ -21,6 +21,7 @@ const (
+ 	configFileDir  = ".docker"
+ 	oldConfigfile  = ".dockercfg"
+ 	contextsDir    = "contexts"
++	defaultSystemConfig = "/usr/lib/docker/config.json"
+ )
+ 
+ var (
+@@ -124,6 +125,16 @@ func load(configDir string) (*configfile.ConfigFile, bool, error) {
+ 	filename := filepath.Join(configDir, ConfigFileName)
+ 	configFile := configfile.New(filename)
+ 
++   // LmP: Load values from system config by default
++   if _, err := os.Stat(defaultSystemConfig); err == nil {
++       file, err := os.Open(defaultSystemConfig)
++       if err == nil {
++           configFile.LoadFromReader(file)
++           file.Close()
++       }
++   }
++
++
+ 	// Try happy path first - latest config file
+ 	if file, err := os.Open(filename); err == nil {
+ 		defer file.Close()

--- a/meta-lmp-base/recipes-containers/nerdctl/nerdctl_git.bbappend
+++ b/meta-lmp-base/recipes-containers/nerdctl/nerdctl_git.bbappend
@@ -1,3 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = "\
+	file://cli-config-support-default-system-config.patch \
+	"
+
 do_install() {
 	install -d ${D}${bindir}
 	install -m 755 ${S}/src/import/_output/nerdctl ${D}${bindir}


### PR DESCRIPTION
base: rc: nerdctl: Patch docker/cli to set a def conf path
    
- Patch docker/cli module before compiling nerdctl so it uses
  docker config file `/usr/lib/docker/config.json` for auth by default.
  A use may override it by setting DOCKER_CONFIG to refer to their
  config directory.
