### PR TITLE
base: support: add default btattach.conf to bluetooth-attach service

### DIFF
--- a/meta-lmp-base/recipes-support/bluetooth-attach/bluetooth-attach_0.1.bb
+++ b/meta-lmp-base/recipes-support/bluetooth-attach/bluetooth-attach_0.1.bb
@@ -7,7 +7,10 @@ inherit allarch systemd
 
 RDEPENDS:${PN} += "bluez5"
 
-SRC_URI = "file://btattach.service"
+SRC_URI = " \
+    file://btattach.service \
+    file://btattach.conf \
+"
 
 S = "${WORKDIR}"
 
@@ -16,6 +19,10 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 do_install () {
 	install -d ${D}${systemd_system_unitdir}
 	install -m 0644 ${S}/btattach.service ${D}${systemd_system_unitdir}
+	install -d ${D}${sysconfdir}/bluetooth/
+	install -m 0644 ${S}/btattach.conf ${D}${sysconfdir}/bluetooth/
 }
 
 SYSTEMD_SERVICE:${PN} = "btattach.service"
+
+FILES_${PN} += "${sysconfdir}/bluetooth/btattach.conf"


### PR DESCRIPTION
The default empty file can easily be overridden for special machines
by adding a .bbappend in the appropriate layer (meta-lmp-bsp or
meta-subscriber).

Signed-off-by: Michael Scott <mike@foundries.io>