### PR TITLE
base: u-boot-fio: imx-2022.04: fix commit hash

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
@@ -1,5 +1,5 @@
 require u-boot-fio-common.inc
 
-SRCREV = "edc7a363c9fcfa9b20c0dbbdf4d902fef595947b"
+SRCREV = "cede8a4f1449260eaac4128dd9d2e023b2d0a346"
 SRCBRANCH = "2022.04+lf-5.15.32-2.0.0-fio"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"


### PR DESCRIPTION
Fix the hash of HEAD commit cede8a4f144 ("[FIO internal] ARM: mach-imx: spl: add support of imx8mn_evk in spl_mmc_get_uboot_raw_sector()").

Fixes: a02692f3 ("base: u-boot-fio: add recipe for imx-2022.04")
Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>