### PR TITLE
base: u-boot: u-boot-fio_imx-2022.04 decrease preference

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
@@ -3,3 +3,5 @@ require u-boot-fio-common.inc
 SRCREV = "cede8a4f1449260eaac4128dd9d2e023b2d0a346"
 SRCBRANCH = "2022.04+lf-5.15.32-2.0.0-fio"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
+
+DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
Add DEFAULT_PREFERENCE = -1, so recipe is not built by default.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>