### PR TITLE
base: lmp: kmod-native: add openssl to PACKAGECONFIG

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -50,6 +50,7 @@ PACKAGECONFIG:append:pn-qemu-native = " libusb"
 PACKAGECONFIG:append:pn-networkmanager = " libedit"
 PACKAGECONFIG:remove:pn-networkmanager = " readline"
 PACKAGECONFIG:append:pn-kmod = " openssl"
+PACKAGECONFIG:append:pn-kmod-native = " openssl"
 PACKAGECONFIG:append:pn-cryptsetup = " luks2"
 PACKAGECONFIG:append:pn-cryptsetup-native = " luks2"
 


### PR DESCRIPTION
We use signed kernel modules by default, so enable openssl support in
kmod-native to facilitate debugging with devshell

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>