### PR TITLE
base: rc: nerdctl: Add patch to extend `ps` output

### DIFF
--- a/meta-lmp-base/recipes-containers/nerdctl/nerdctl/0001-extend-ps-output.patch
+++ b/meta-lmp-base/recipes-containers/nerdctl/nerdctl/0001-extend-ps-output.patch
@@ -1,0 +1,137 @@
+diff --git a/src/import/cmd/nerdctl/compose_ps.go b/src/import/cmd/nerdctl/compose_ps.go
+index 5d12cd5..f58307b 100644
+--- a/src/import/cmd/nerdctl/compose_ps.go
++++ b/src/import/cmd/nerdctl/compose_ps.go
+@@ -80,7 +80,7 @@ func composePsAction(cmd *cobra.Command, args []string) error {
+ 		if err != nil {
+ 			return err
+ 		}
+-		status := formatter.ContainerStatus(ctx, container)
++		status, _ := formatter.ContainerStatus(ctx, container)
+ 		if status == "Up" {
+ 			status = "running" // corresponds to Docker Compose v2.0.1
+ 		}
+diff --git a/src/import/cmd/nerdctl/ps.go b/src/import/cmd/nerdctl/ps.go
+index 70fc9f6..c85c0e2 100644
+--- a/src/import/cmd/nerdctl/ps.go
++++ b/src/import/cmd/nerdctl/ps.go
+@@ -108,8 +108,10 @@ type containerPrintable struct {
+ 	Platform  string // nerdctl extension
+ 	Names     string
+ 	Ports     string
++	State     containerd.Status
+ 	Status    string
+ 	Runtime   string // nerdctl extension
++	Labels    map[string]string
+ 	// TODO: "Labels", "LocalVolumes", "Mounts", "Networks", "RunningFor", "Size", "State"
+ }
+ 
+@@ -182,11 +184,13 @@ func printContainers(ctx context.Context, cmd *cobra.Command, containers []conta
+ 			id = id[:12]
+ 		}
+ 
+-		cStatus := formatter.ContainerStatus(ctx, c)
++		cStatus, cState := formatter.ContainerStatus(ctx, c)
+ 		if !strings.HasPrefix(cStatus, "Up") && !all {
+ 			continue
+ 		}
+-
++		if cState == nil {
++			cState = &containerd.Status{Status: containerd.Unknown}
++		}
+ 		p := containerPrintable{
+ 			Command:   formatter.InspectContainerCommand(spec, trunc),
+ 			CreatedAt: info.CreatedAt.Round(time.Second).Local().String(), // format like "2021-08-07 02:19:45 +0900 JST"
+@@ -195,8 +199,10 @@ func printContainers(ctx context.Context, cmd *cobra.Command, containers []conta
+ 			Platform:  info.Labels[labels.Platform],
+ 			Names:     getPrintableContainerName(info.Labels),
+ 			Ports:     formatter.FormatPorts(info.Labels),
++			State:     *cState,
+ 			Status:    cStatus,
+ 			Runtime:   info.Runtime.Name,
++			Labels:    info.Labels,
+ 		}
+ 
+ 		if tmpl != nil {
+diff --git a/src/import/cmd/nerdctl/start.go b/src/import/cmd/nerdctl/start.go
+index 7d2bfe7..3e8cfb8 100644
+--- a/src/import/cmd/nerdctl/start.go
++++ b/src/import/cmd/nerdctl/start.go
+@@ -85,7 +85,7 @@ func startContainer(ctx context.Context, container containerd.Container) error {
+ 		}
+ 		taskCIO = cio.LogURI(logURI)
+ 	}
+-	cStatus := formatter.ContainerStatus(ctx, container)
++	cStatus, _ := formatter.ContainerStatus(ctx, container)
+ 	if cStatus == "Up" {
+ 		logrus.Warnf("container %s is already running", container.ID())
+ 		return nil
+diff --git a/src/import/cmd/nerdctl/stats.go b/src/import/cmd/nerdctl/stats.go
+index 4e38420..86ca042 100644
+--- a/src/import/cmd/nerdctl/stats.go
++++ b/src/import/cmd/nerdctl/stats.go
+@@ -169,7 +169,7 @@ func statsAction(cmd *cobra.Command, args []string) error {
+ 		}
+ 
+ 		for _, c := range containers {
+-			cStatus := formatter.ContainerStatus(ctx, c)
++			cStatus, _ := formatter.ContainerStatus(ctx, c)
+ 			if !all {
+ 				if !strings.HasPrefix(cStatus, "Up") {
+ 					continue
+diff --git a/src/import/cmd/nerdctl/update.go b/src/import/cmd/nerdctl/update.go
+index a587671..e30aceb 100644
+--- a/src/import/cmd/nerdctl/update.go
++++ b/src/import/cmd/nerdctl/update.go
+@@ -170,7 +170,7 @@ func updateContainer(ctx context.Context, client *containerd.Client, id string,
+ 	if err != nil {
+ 		return err
+ 	}
+-	cStatus := formatter.ContainerStatus(ctx, container)
++	cStatus, _ := formatter.ContainerStatus(ctx, container)
+ 	if cStatus == "pausing" {
+ 		return fmt.Errorf("container %q is in pausing state", id)
+ 	}
+diff --git a/src/import/pkg/formatter/formatter.go b/src/import/pkg/formatter/formatter.go
+index 7efb0fb..4a21794 100644
+--- a/src/import/pkg/formatter/formatter.go
++++ b/src/import/pkg/formatter/formatter.go
+@@ -33,7 +33,7 @@ import (
+ 	"github.com/sirupsen/logrus"
+ )
+ 
+-func ContainerStatus(ctx context.Context, c containerd.Container) string {
++func ContainerStatus(ctx context.Context, c containerd.Container) (string, *containerd.Status) {
+ 	// Just in case, there is something wrong in server.
+ 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+ 	defer cancel()
+@@ -45,23 +45,23 @@ func ContainerStatus(ctx context.Context, c containerd.Container) string {
+ 		// when it exits. So, the status will be "created" for this
+ 		// case.
+ 		if errdefs.IsNotFound(err) {
+-			return strings.Title(string(containerd.Created))
++			return strings.Title(string(containerd.Created)), nil
+ 		}
+-		return strings.Title(string(containerd.Unknown))
++		return strings.Title(string(containerd.Unknown)), nil
+ 	}
+ 
+ 	status, err := task.Status(ctx)
+ 	if err != nil {
+-		return strings.Title(string(containerd.Unknown))
++		return strings.Title(string(containerd.Unknown)), nil
+ 	}
+ 
+ 	switch s := status.Status; s {
+ 	case containerd.Stopped:
+-		return fmt.Sprintf("Exited (%v) %s", status.ExitStatus, TimeSinceInHuman(status.ExitTime))
++		return fmt.Sprintf("Exited (%v) %s", status.ExitStatus, TimeSinceInHuman(status.ExitTime)), &status
+ 	case containerd.Running:
+-		return "Up" // TODO: print "status.UpTime" (inexistent yet)
++		return "Up", &status // TODO: print "status.UpTime" (inexistent yet)
+ 	default:
+-		return strings.Title(string(s))
++		return strings.Title(string(s)), &status
+ 	}
+ }
+ 

--- a/meta-lmp-base/recipes-containers/nerdctl/nerdctl_git.bbappend
+++ b/meta-lmp-base/recipes-containers/nerdctl/nerdctl_git.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append = "\
 	file://cli-config-support-default-system-config.patch \
+	file://0001-extend-ps-output.patch \
 	"
 
 do_install() {


### PR DESCRIPTION
We need to patch `nerdctl` to get the same info about containers as we get from `docker` CLI command.

Signed-off-by: Mike <mike.sul@foundries.io>