### PR TITLE
Revert "base: gnu-efi: enable for riscv64"

### DIFF
--- a/meta-lmp-base/recipes-bsp/gnu-efi/gnu-efi_3.0.14.bbappend
+++ b/meta-lmp-base/recipes-bsp/gnu-efi/gnu-efi_3.0.14.bbappend
@@ -1,2 +1,0 @@
-# Enable support for riscv64
-COMPATIBLE_HOST = "(x86_64.*|i.86.*|aarch64.*|arm.*|riscv64.*)-linux"


### PR DESCRIPTION
This reverts commit 96d61736cdee86771930c5592531f96124d21ca6.

merged https://git.yoctoproject.org/poky/commit/?id=b02bdaa5a5b1dc051849919785d4687bec1bfaf8

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>