### PR TITLE
base: python3-plug-and-trust-ssscli: bump to 6c67941

### DIFF
--- a/meta-lmp-base/recipes-devtools/python/python3-plug-and-trust-ssscli_3.3.0.bb
+++ b/meta-lmp-base/recipes-devtools/python/python3-plug-and-trust-ssscli_3.3.0.bb
@@ -4,7 +4,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRC_URI = "git://github.com/foundriesio/plug-and-trust-ssscli;branch=main;protocol=https"
-SRCREV = "f77c65d5b3de649d7db1c023ee41d871f77cd224"
+SRCREV = "6c679410e15fb2ae1123bc74ef54f7173278abcc"
 
 S = "${WORKDIR}/git/src"
 
@@ -12,7 +12,6 @@ inherit setuptools3
 
 RDEPENDS:${PN} += "plug-and-trust-seteec \
     ${PYTHON_PN}-click \
-    ${PYTHON_PN}-func-timeout \
     ${PYTHON_PN}-logging \
     ${PYTHON_PN}-cryptography \
 "


### PR DESCRIPTION
Relevant changes:
- 6c67941 cli: drop external dependency for func_timeout

Also drop rdepends on func_timeout as it is not required anymore.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>