### PR TITLE
non clangable: add new bsp packages

### DIFF
--- a/meta-lmp-base/conf/distro/include/non-clangable.inc
+++ b/meta-lmp-base/conf/distro/include/non-clangable.inc
@@ -94,8 +94,9 @@ TOOLCHAIN:pn-trusted-firmware-a = "gcc"
 # jetson-agx-xavier-devkit
 TOOLCHAIN:pn-cboot-t19x = "gcc"
 
-# stm32mp1-disco
+# stm32mp1
 TOOLCHAIN:pn-tf-a-stm32mp = "gcc"
+TOOLCHAIN:pn-tf-a-fio = "gcc"
 
 # qemuriscv64
 TOOLCHAIN:pn-opensbi = "gcc"

--- a/meta-lmp-base/conf/distro/include/non-clangable.inc
+++ b/meta-lmp-base/conf/distro/include/non-clangable.inc
@@ -89,6 +89,7 @@ TOOLCHAIN:pn-arm-trusted-firmware = "gcc"
 
 # am64xx-evm
 TOOLCHAIN:pn-ti-sci-fw = "gcc"
+TOOLCHAIN:pn-trusted-firmware-a = "gcc"
 
 # jetson-agx-xavier-devkit
 TOOLCHAIN:pn-cboot-t19x = "gcc"


### PR DESCRIPTION
- base: lmp: non-clangable: add trusted-firmware-a used in am6xxx
- base: lmp: non-clangable: add tf-a-fio used in stm32mp1