### PR TITLE
base: optee-os-fio: 3.18: bump to 6467bb295

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.18.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.18.0.bb
@@ -1,5 +1,5 @@
 require optee-os-fio.inc
 
 PV = "3.18.0+git"
-SRCREV = "081d4817011305c05cc13d57c009b7aadbd13655"
+SRCREV = "6467bb2956f99c61e18910325087d64873f5579b"
 SRCBRANCH = "3.18+fio"


### PR DESCRIPTION
Relevant changes:
- 6467bb295 [FIO toup] versal: authenc: fix PLM DMA timeout

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>