### PR TITLE
base: ostree: fix the clang override

### DIFF
--- a/meta-lmp-base/recipes-extended/ostree/ostree_%.bbappend
+++ b/meta-lmp-base/recipes-extended/ostree/ostree_%.bbappend
@@ -24,7 +24,7 @@ SRC_URI:append = " \
 # | tmp-lmp/work/corei7-64-lmp-linux/ostree/2021.6-r0/recipe-sysroot-native/usr/bin/x86_64-lmp-linux/x86_64-lmp-linux-ld: /usr/src/debug/glibc/2.35-r0/git/stdio-common/../stdio-common/printf_fphex.c:206: undefined reference to `__unordtf2'
 # | tmp-lmp/work/corei7-64-lmp-linux/ostree/2021.6-r0/recipe-sysroot-native/usr/bin/x86_64-lmp-linux/x86_64-lmp-linux-ld: /usr/src/debug/glibc/2.35-r0/git/stdio-common/../stdio-common/printf_fphex.c:206: undefined reference to `__letf2'
 # | x86_64-lmp-linux-clang -target x86_64-lmp-linux  -m64 -march=nehalem -mtune=generic -mfpmath=sse -msse4.2 -mlittle-endian --dyld-prefix=/usr -Qunused-arguments -fstack-protector-strong  -O2 -D_F
-COMPILER_RT:pn-ostree:libc-glibc:toolchain-clang:x86 = " \
+COMPILER_RT:libc-glibc:toolchain-clang:x86 = " \
     ${@bb.utils.contains('PACKAGECONFIG', 'static', '-rtlib=libgcc --unwindlib=libgcc', '', d)}"
-COMPILER_RT:pn-ostree:libc-glibc:toolchain-clang:x86-64 = " \
+COMPILER_RT:libc-glibc:toolchain-clang:x86-64 = " \
     ${@bb.utils.contains('PACKAGECONFIG', 'static', '-rtlib=libgcc --unwindlib=libgcc', '', d)}"


### PR DESCRIPTION
fixup for https://github.com/foundriesio/meta-lmp/commit/0abb08c83aee7027711f538e29a5ff16dc334304 `pn-PACKAGE` override is usufull in global variables not in local

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>