### PR TITLE
base: recipe-sota: aktualizr-lite: bump to 4ab5400

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "70b90a9c7403bb0bbd02fa96af56c954f76f9154"
+SRCREV:lmp = "4ab5400ce05e8dc591a4ff5b787082a7dce6f3ea"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
Relevant changes:
- 2c9db75 reportqueue: Catch exceptions while loading events from DB
- b847a9f aklite-offline: Add param to tune a docker client
- 4ab5400 rootfstreemanager: make sure to call updateNotify and installNotify

Signed-off-by: Mike <mike.sul@foundries.io>