### PR TITLE
base/bsp: openssh: drop rng-tools from default PACKAGECONFIG

### DIFF
--- a/meta-lmp-base/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-lmp-base/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,0 +1,3 @@
+# OE-Core sets to rng-tools by default, which is not wanted by meta-lmp,
+# unless the BSP has a kernel < 5.6 (which can be added in meta-lmp-bsp).
+PACKAGECONFIG ?= ""

--- a/meta-lmp-bsp/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-lmp-bsp/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,0 +1,3 @@
+# BSPs with kernel older than 5.6 (blocking /dev/random reads)
+PACKAGECONFIG:apalis-imx8 ?= "rng-tools"
+PACKAGECONFIG:tegra ?= "rng-tools"


### PR DESCRIPTION
Since kernel 5.6 reading /dev/random does not block anymore, and CRNG
(initialized by the kernel during boot) is considered to be good enough
for userspace, so no need for having rng-tools seeding entropy.

This is not done with a remove override as we still want to allow BSP
layers (or via meta-lmp-bsp) to be able to add rng-tools when needed
(e.g. kernel older than 5.6, as done with tegra and apalis-imx8).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>