### PR TITLE
base: lmp: bbmask meta-st-stm32mp make-mod-scripts bbappend

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -113,6 +113,7 @@ BBMASK += " \
 BBMASK += " \
     /meta-st-stm32mp/recipes-core/busybox/busybox_%.bbappend \
     /meta-st-stm32mp/recipes-graphics/drm/libdrm_2.4.110.bbappend \
+    /meta-st-stm32mp/recipes-kernel/make-mod-scripts/make-mod-scripts_%.bbappend \
 "
 
 # disable xsct tarball by default (xilinx)


### PR DESCRIPTION
Bbappend disables support for GCC plugins for stm32mpcommon, which is
not really needed.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>