### PR TITLE
base: optee-os-fio: 3.18: bump to 939fb9c74

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.18.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.18.0.bb
@@ -1,5 +1,5 @@
 require optee-os-fio.inc
 
 PV = "3.18.0+git"
-SRCREV = "6467bb2956f99c61e18910325087d64873f5579b"
+SRCREV = "939fb9c74117873193143f3eb3e76b385ba87cc0"
 SRCBRANCH = "3.18+fio"


### PR DESCRIPTION
Relevant changes:
- 939fb9c74 [FIO toup] crypto: versal: fix memory access after free

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>