### PR TITLE
base: lmp: non-clangable: add optee-os-fio-mfgtool

### DIFF
--- a/meta-lmp-base/conf/distro/include/non-clangable.inc
+++ b/meta-lmp-base/conf/distro/include/non-clangable.inc
@@ -82,6 +82,9 @@ TOOLCHAIN:pn-optee-test = "gcc"
 #  /srv/oe/build/conf/../../layers/meta-lmp/meta-lmp-base/recipes-security/optee/optee-fiovb_git.bb:do_compile
 TOOLCHAIN:pn-optee-fiovb = "gcc"
 
+# lmp-mfgtool distro
+TOOLCHAIN:pn-optee-os-fio-mfgtool = "gcc"
+
 # kv260
 # vck190-versal
 # uz3eg-iocc-ebbr-sec


### PR DESCRIPTION
Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>