### PR TITLE
aktualizr: start service after time is synced

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
@@ -1,7 +1,8 @@
 [Unit]
 Description=Aktualizr Lite SOTA Client
-After=network.target boot-complete.target
+After=network.target boot-complete.target time-sync.target
 Requires=boot-complete.target
+Wants=time-sync.target
 ConditionPathExists=|/var/sota/sota.toml
 ConditionPathExists=|/usr/lib/sota/conf.d/10-lite-public-stream.toml
 ConditionPathExists=!/usr/bin/mbedCloudClient


### PR DESCRIPTION
On boot, the start of aktualizr-lite tends to be deplayed by 5min. The time might not be synced yet causing the certificate validation to fail. Such issue is probably only seen on system witout an RTC, which may wake up with extravagant time.

Making aktualizr-lite.service wait for time-sync.target solves the problem.

Here is an example of log without the fix:
```
Apr 28 17:42:35 kikou-lol-2001221002003915 systemd[1]: Starting Aktualizr Lite SOTA Client...
Apr 28 17:42:35 kikou-lol-2001221002003915 systemd[1]: Started Aktualizr Lite SOTA Client.
Apr 28 17:42:35 kikou-lol-2001221002003915 aktualizr-lite[682]: Reading config: "/usr/lib/sota/conf.d/30-rollback.toml"
Apr 28 17:42:35 kikou-lol-2001221002003915 aktualizr-lite[682]: Reading config: "/usr/lib/sota/conf.d/40-hardware-id.toml"
Apr 28 17:42:35 kikou-lol-2001221002003915 aktualizr-lite[682]: Reading config: "/var/sota/sota.toml"
Apr 28 17:42:35 kikou-lol-2001221002003915 aktualizr-lite[682]: Bootstrap empty SQL storage
Apr 28 17:42:35 kikou-lol-2001221002003915 aktualizr-lite[682]: Bootstraping DB to version 25
Apr 28 17:42:35 kikou-lol-2001221002003915 aktualizr-lite[682]: Could not find Primary ECU serial, set to lazy init mode
Apr 28 17:42:36 kikou-lol-2001221002003915 aktualizr-lite[682]: Importing root metadata from a local file system...
Apr 28 17:42:36 kikou-lol-2001221002003915 aktualizr-lite[682]: KeyId 043a994f2c6eb25a0035f0e7fd2ed3088460a052afd5903a84e06fbf7d8758ce is not valid to sign for this role (root).
Apr 28 17:42:36 kikou-lol-2001221002003915 aktualizr-lite[682]: KeyId 65f772f214c0dbfa74aee05fa310f7389eb288d9b1f408faa525bc9a28175b5a is not valid to sign for this role (root).
Apr 28 17:42:36 kikou-lol-2001221002003915 aktualizr-lite[682]: Successfully imported CI root role metadata from "/usr/lib/sota/tuf/ci"
Apr 28 17:42:36 kikou-lol-2001221002003915 aktualizr-lite[682]: No Pending Installs
Apr 28 17:42:37 kikou-lol-2001221002003915 aktualizr-lite[682]: curl error 60 (http code 0): SSL peer certificate or SSH remote key was not OK
Apr 28 17:42:38 kikou-lol-2001221002003915 aktualizr-lite[682]: curl error 60 (http code 0): SSL peer certificate or SSH remote key was not OK
Apr 28 17:42:39 kikou-lol-2001221002003915 aktualizr-lite[682]: curl error 60 (http code 0): SSL peer certificate or SSH remote key was not OK
Apr 28 17:42:39 kikou-lol-2001221002003915 aktualizr-lite[682]: Active Target: kikou-lol-lmp-355, sha256: 5bdea85941e832186d710eda13345d3e639f9bdf5581cfae978763caa649c8e1
Apr 28 17:42:39 kikou-lol-2001221002003915 aktualizr-lite[682]: Checking for a new Target...
Apr 28 17:42:39 kikou-lol-2001221002003915 aktualizr-lite[682]: curl error 60 (http code 0): SSL peer certificate or SSH remote key was not OK
Apr 28 17:42:41 kikou-lol-2001221002003915 aktualizr-lite[682]: curl error 60 (http code 0): SSL peer certificate or SSH remote key was not OK
Apr 28 17:42:42 kikou-lol-2001221002003915 aktualizr-lite[682]: curl error 60 (http code 0): SSL peer certificate or SSH remote key was not OK
Apr 28 17:42:42 kikou-lol-2001221002003915 aktualizr-lite[682]: Failed to send App states to Device Gateway: 60 SSL peer certificate or SSH remote key was not OK HTTP 0
Apr 28 17:42:42 kikou-lol-2001221002003915 aktualizr-lite[682]: curl error 60 (http code 0): SSL peer certificate or SSH remote key was not OK
Apr 28 17:42:43 kikou-lol-2001221002003915 aktualizr-lite[682]: curl error 60 (http code 0): SSL peer certificate or SSH remote key was not OK
Apr 28 17:42:45 kikou-lol-2001221002003915 aktualizr-lite[682]: curl error 60 (http code 0): SSL peer certificate or SSH remote key was not OK
Apr 28 17:42:45 kikou-lol-2001221002003915 aktualizr-lite[682]: curl error 60 (http code 0): SSL peer certificate or SSH remote key was not OK
Apr 28 17:42:46 kikou-lol-2001221002003915 aktualizr-lite[682]: curl error 60 (http code 0): SSL peer certificate or SSH remote key was not OK
Apr 28 17:42:47 kikou-lol-2001221002003915 aktualizr-lite[682]: curl error 60 (http code 0): SSL peer certificate or SSH remote key was not OK
Apr 28 17:42:47 kikou-lol-2001221002003915 aktualizr-lite[682]: Failed to update Image repo metadata: Failed to fetch role timestamp in image repository.
Apr 28 17:42:47 kikou-lol-2001221002003915 aktualizr-lite[682]: Unable to update latest metadata, going to sleep for 300 seconds before starting a new update cycle
[5 min later ...]
Sep 26 12:38:03 kikou-lol-2001221002003915 aktualizr-lite[687]: Active Target: kikou-lol-lmp-355, sha256: 5bdea85941e832186d710eda13345d3e639f9bdf5581cfae978763caa649c8e1
```

Here is the same system, with the added systemd constraint:
```
Sep 26 12:48:16 kikou-lol-2001221002003915 systemd[1]: Starting Aktualizr Lite SOTA Client...
Sep 26 12:48:16 kikou-lol-2001221002003915 systemd[1]: Started Aktualizr Lite SOTA Client.
Sep 26 12:48:16 kikou-lol-2001221002003915 aktualizr-lite[1062]: Reading config: "/usr/lib/sota/conf.d/30-rollback.toml"
Sep 26 12:48:16 kikou-lol-2001221002003915 aktualizr-lite[1062]: Reading config: "/usr/lib/sota/conf.d/40-hardware-id.toml"
Sep 26 12:48:16 kikou-lol-2001221002003915 aktualizr-lite[1062]: Reading config: "/var/sota/sota.toml"
Sep 26 12:48:16 kikou-lol-2001221002003915 aktualizr-lite[1062]: Bootstrap empty SQL storage
Sep 26 12:48:16 kikou-lol-2001221002003915 aktualizr-lite[1062]: Bootstraping DB to version 25
Sep 26 12:48:16 kikou-lol-2001221002003915 aktualizr-lite[1062]: Could not find Primary ECU serial, set to lazy init mode
Sep 26 12:48:16 kikou-lol-2001221002003915 aktualizr-lite[1072]: Cannot read environment, using default
Sep 26 12:48:17 kikou-lol-2001221002003915 aktualizr-lite[1062]: Importing root metadata from a local file system...
Sep 26 12:48:17 kikou-lol-2001221002003915 aktualizr-lite[1062]: KeyId 043a994f2c6eb25a0035f0e7fd2ed3088460a052afd5903a84e06fbf7d8758ce is not valid to sign for this role (root).
Sep 26 12:48:17 kikou-lol-2001221002003915 aktualizr-lite[1062]: KeyId 65f772f214c0dbfa74aee05fa310f7389eb288d9b1f408faa525bc9a28175b5a is not valid to sign for this role (root).
Sep 26 12:48:17 kikou-lol-2001221002003915 aktualizr-lite[1062]: Successfully imported CI root role metadata from "/usr/lib/sota/tuf/ci"
Sep 26 12:48:17 kikou-lol-2001221002003915 aktualizr-lite[1062]: No Pending Installs
Sep 26 12:48:17 kikou-lol-2001221002003915 aktualizr-lite[1062]: Active Target: kikou-lol-lmp-357, sha256: 08942c25d3fec402a64d7631230117d28533c9efa6199d674126360f792e9f97
```