### PR TITLE
base: lmp: non-clangable: add imx-atf

### DIFF
--- a/meta-lmp-base/conf/distro/include/non-clangable.inc
+++ b/meta-lmp-base/conf/distro/include/non-clangable.inc
@@ -85,6 +85,9 @@ TOOLCHAIN:pn-optee-fiovb = "gcc"
 # lmp-mfgtool distro
 TOOLCHAIN:pn-optee-os-fio-mfgtool = "gcc"
 
+# imx targets (not reproducible)
+TOOLCHAIN:pn-imx-atf = "gcc"
+
 # kv260
 # vck190-versal
 # uz3eg-iocc-ebbr-sec


### PR DESCRIPTION
Build is not reproducible, causing the binary hash to change at every clean build (and causing unexpected boot firmware updates).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>