### PR TITLE
base: lmp-passwd/group: add lpadmin group

### DIFF
--- a/meta-lmp-base/files/lmp-group-table
+++ b/meta-lmp-base/files/lmp-group-table
@@ -50,6 +50,7 @@ shutdown:x:70:
 nobody:*:99:
 users:x:100:
 pulse:x:171:
+lpadmin:x:970:
 ntp:x:971:
 parsec:x:972:
 pulse-access:x:973:


### PR DESCRIPTION
Required by the cups recipe.

| ERROR: Nothing PROVIDES 'cups' (but layers/meta-openembedded/meta-oe/recipes-support/freerdp/freerdp_2.8.0.bb DEPENDS on or otherwise requires it) | cups was skipped: cups - cups: system groupname lpadmin does not have a static ID defined. Add lpadmin to one of these files: layers/meta-lmp/meta-lmp-base/files/lmp-group-table

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>