### PR TITLE
lmp-boot-firmware: limit bootfirmware_version length

### DIFF
--- a/meta-lmp-base/recipes-bsp/lmp-boot-firmware/lmp-boot-firmware.bb
+++ b/meta-lmp-base/recipes-bsp/lmp-boot-firmware/lmp-boot-firmware.bb
@@ -53,6 +53,9 @@ do_install() {
             for file in `ls ${D}${nonarch_base_libdir}/${FIRMWARE_DEPLOY_DIR}/`; do
                 version="${version}-`md5sum ${D}${nonarch_base_libdir}/${FIRMWARE_DEPLOY_DIR}/${file} | cut -d' ' -f1`"
             done
+
+	    # limit the length of version
+	    version="`echo ${version} | md5sum | cut -d' ' -f1`"
         fi
         echo "bootfirmware_version=${version#-}" > version.txt
 


### PR DESCRIPTION
When the bootfirmware_version is not fixed by PV, the length of bootfirmware_version depends on the number of files passed in LMP_BOOT_FIRMWARE_FILES

Having a variable length is no problem for u-boot env. With backend such as fiovb it is a problem because the storage size of the variable is fixed - 128b in the current boot-common.cmd.in.

Make a single md5sum out of the current bootfirmware_version content so keeps on changing if any of the files in LMP_BOOT_FIRMWARE_FILES changes and length does not exceed 128b.