### PR TITLE
base: vulkan-loader: mx8mm-nxp-bsp doesn't support vulkan

### DIFF
--- a/meta-lmp-base/recipes-graphics/vulkan/vulkan-loader_1.3.204.1.bbappend
+++ b/meta-lmp-base/recipes-graphics/vulkan/vulkan-loader_1.3.204.1.bbappend
@@ -1,0 +1,1 @@
+RRECOMMENDS:${PN}:remove:imxgpu:mx8mm-nxp-bsp = "libvulkan-imx"


### PR DESCRIPTION
Vulkan is disabled on meta-freescale for 8M Mini since ee92b5a,
so add the same logic to not recommends libvulkan-imx on this machines.
https://github.com/Freescale/meta-freescale/commit/ee92b5a8b2cad45de267d3cf6dae9251f5ed11fd

This append is version specific because it's a workaround until
upstream found and merge a solution then we can drop this patch.
https://github.com/Freescale/meta-freescale/pull/1249

This also fix:
```
ERROR: Nothing RPROVIDES 'libvulkan-imx' (but /srv/oe/build/conf/../../layers/openembedded-core/meta/recipes-graphics/vulkan/vulkan-loader_1.3.216.0.bb RDEPENDS on or otherwise requires it)
ERROR: Required build target 'lmp-base-console-image' has no buildable providers.
Missing or unbuildable dependency chain was: ['lmp-base-console-image', 'weston', 'virtual/libgles2', 'mesa', 'vulkan-loader', 'libvulkan-imx']
```

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>