### PR TITLE
Use the lmp mirrors in PREMIRRORS and keep it in sync with MIRRORS

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -87,7 +87,7 @@ BUILDHISTORY_COMMIT = "1"
 TOOLCHAIN ?= "clang"
 RUNTIME = "llvm"
 
-PREMIRRORS ??= "\
+PREMIRRORS += "\
      git://.*/.* https://storage.googleapis.com/lmp-cache/downloads/ \n \
      ftp://.*/.* https://storage.googleapis.com/lmp-cache/downloads/ \n \
      http://.*/.* https://storage.googleapis.com/lmp-cache/downloads/ \n \

--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -95,6 +95,7 @@ PREMIRRORS += "\
 "
 
 MIRRORS =+ "\
+     git://.*/.* https://storage.googleapis.com/lmp-cache/downloads/ \n \
      ftp://.*/.* https://storage.googleapis.com/lmp-cache/downloads/ \n \
      http://.*/.* https://storage.googleapis.com/lmp-cache/downloads/ \n \
      https://.*/.* https://storage.googleapis.com/lmp-cache/downloads/ \n \


### PR DESCRIPTION
- base: lmp: adds lmp mirrors to PREMIRRORS

As we have the PREMIRRORS assigned with ??= the Yocto mirrors takes precedence so ours is disabled, change that and adds our mirrors.

- base: lmp: keep lmp PREMIRRORS in sync with MIRRORS