### PR TITLE
base: optee-os-fio: enable support for non-secure i2c buses

### DIFF
--- a/meta-lmp-bsp/recipes-security/optee/optee-os-fio-bsp.inc
+++ b/meta-lmp-bsp/recipes-security/optee/optee-os-fio-bsp.inc
@@ -91,7 +91,7 @@ EXTRA_OEMAKE:append:imx8mn-ddr4-evk = " \
     ${@bb.utils.contains('MACHINE_FEATURES', 'se05x', 'CFG_IMX_I2C=y CFG_CORE_SE05X_I2C_BUS=2', '', d)} \
 "
 EXTRA_OEMAKE:append:stm32mp15-disco = " \
-    ${@bb.utils.contains('MACHINE_FEATURES', 'se05x', 'CFG_STM32_CRYPTO_DRIVER=n CFG_STM32_CRYP=n CFG_STM32_I2C=y CFG_CORE_SE05X_I2C_BUS=5', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'se05x', 'CFG_STM32_CRYPTO_DRIVER=n CFG_STM32_CRYP=n CFG_STM32_I2C=y CFG_CORE_SE05X_I2C_BUS=5 CFG_WITH_NSEC_I2CS=y', '', d)} \
 "
 
 # Extra Settings for Secure Machines


### PR DESCRIPTION
Enable CFG_WITH_NSEC_I2CS=y, so OP-TEE can use non-secure i2c buses.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>