### PR TITLE
base: optee-os-fio: 3.18: bump to bc34b5d9b

### DIFF
--- a/meta-lmp-base/recipes-security/optee/files/se050_applet_version.patch
+++ b/meta-lmp-base/recipes-security/optee/files/se050_applet_version.patch
@@ -5,10 +5,10 @@ the ones from the se051 series.
 diff -Naur a/core/drivers/crypto/se050/crypto.mk b/core/drivers/crypto/se050/crypto.mk
 --- a/core/drivers/crypto/se050/crypto.mk	2022-05-03 00:00:21.634533730 -0300
 +++ b/core/drivers/crypto/se050/crypto.mk	2022-05-03 00:02:32.820359683 -0300
-@@ -13,6 +13,8 @@
- CFG_CORE_SE05X_SCP03_EARLY ?= y
- # Deletes all persistent storage from the SE050 at boot
- CFG_CORE_SE05X_INIT_NVM ?= n
+@@ -17,6 +17,8 @@ CFG_CORE_SE05X_INIT_NVM ?= n
+ # Secure Element (SE) Non Volatile Memory object unless there is explicit
+ # confirmation from the SE that the NVM object has been removed.
+ CFG_CORE_SE05X_BLOCK_OBJ_DEL_ON_ERROR ?= n
 +# Select the SE05X applet version for aligning the built-in features
 +CFG_CORE_SE05X_VER ?= 03_XX
  

--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.18.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.18.0.bb
@@ -1,5 +1,5 @@
 require optee-os-fio.inc
 
 PV = "3.18.0+git"
-SRCREV = "939fb9c74117873193143f3eb3e76b385ba87cc0"
+SRCREV = "bc34b5d9b8894371a68c40fd5c230645e697b332"
 SRCBRANCH = "3.18+fio"


### PR DESCRIPTION
Relevant changes:
- bc34b5d9b [FIO fromlist] crypto: se050: updates to the crypto object deletion interface
- ca186acc5 [FIO fromtree] core: mmu: Fix wrong input argument of tee_mm_init()
- 87b59f2e1 [FIO fromtree] plat-stm32mp1: conf: fix tzdram default size when w/o rsv-shm
- d676cf4ca [FIO fromtree] drivers: imx-i2c: add support for imx8mn
- 3ca5eebd1 [FIO squash] arm: boot: fix adding new sub-nodes
- 143053347 [FIO internal] dts: stm32mp1: add i2c5 alias
- 67ddb833b [FIO internal] dts: stm32mp1: provide config properties for i2c5
- 2b03050a8 [FIO toup] stm32mp1: add support for i2c5 bus
- ec6d52e16 [FIO toup] plat-imx: fix subnodes for imx6ull

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>