### PR TITLE
Add support for htpdate

### DIFF
--- a/meta-lmp-base/recipes-support/htpdate/htpdate/default.conf
+++ b/meta-lmp-base/recipes-support/htpdate/htpdate/default.conf
@@ -1,0 +1,1 @@
+HTPDATE_ARGS="-st www.example.com"

--- a/meta-lmp-base/recipes-support/htpdate/htpdate_1.3.6.bb
+++ b/meta-lmp-base/recipes-support/htpdate/htpdate_1.3.6.bb
@@ -1,0 +1,31 @@
+SUMMARY = "HTTP based time synchronization tool"
+DESCRIPTION = "The  HTTP Time Protocol (HTP) is used to synchronize a computer's time with\
+ web servers as reference time source. This program can be used instead\
+ ntpdate or similar, in networks that has a firewall blocking the NTP port.\
+ Htpdate will synchronize the computer time to Greenwich Mean Time (GMT),\
+ using the timestamps from HTTP headers found in web servers response (the\
+ HEAD method will be used to get the information).\
+ Htpdate works through proxy servers. Accuracy of htpdate will be usually\
+ within 0.5 seconds (better with multiple servers).\
+"
+HOMEPAGE = "https://github.com/twekkel/htpdate"
+BUGTRACKER = "https://github.com/twekkel/htpdate/issues"
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://htpdate.c;beginline=26;endline=30;md5=2b6cdb94bd5349646d7e33f9f501eef7"
+
+SRC_URI = "http://www.vervest.org/htp/archive/c/htpdate-${PV}.tar.gz"
+SRC_URI[sha256sum] = "3cdc558ec8e53ef374a42490b2f28c0b23981fa8754a6d7182044707828ad1e9"
+
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+do_configure () {
+	:
+}
+
+do_compile () {
+	oe_runmake
+}
+
+do_install () {
+	oe_runmake install 'INSTALL=install' 'STRIP=echo' 'DESTDIR=${D}'
+}

--- a/meta-lmp-base/recipes-support/htpdate/htpdate_1.3.6.bb
+++ b/meta-lmp-base/recipes-support/htpdate/htpdate_1.3.6.bb
@@ -16,7 +16,11 @@ LIC_FILES_CHKSUM = "file://htpdate.c;beginline=26;endline=30;md5=2b6cdb94bd53496
 SRC_URI = "http://www.vervest.org/htp/archive/c/htpdate-${PV}.tar.gz"
 SRC_URI[sha256sum] = "3cdc558ec8e53ef374a42490b2f28c0b23981fa8754a6d7182044707828ad1e9"
 
+inherit systemd
+
 TARGET_CC_ARCH += "${LDFLAGS}"
+
+SYSTEMD_SERVICE:${PN} = "htpdate.service"
 
 do_configure () {
 	:
@@ -28,4 +32,8 @@ do_compile () {
 
 do_install () {
 	oe_runmake install 'INSTALL=install' 'STRIP=echo' 'DESTDIR=${D}'
+	if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+		install -d ${D}${systemd_system_unitdir}
+		install -m 644 ${S}/scripts/htpdate.service ${D}${systemd_system_unitdir}
+	fi
 }

--- a/meta-lmp-base/recipes-support/htpdate/htpdate_1.3.6.bb
+++ b/meta-lmp-base/recipes-support/htpdate/htpdate_1.3.6.bb
@@ -13,7 +13,9 @@ BUGTRACKER = "https://github.com/twekkel/htpdate/issues"
 LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://htpdate.c;beginline=26;endline=30;md5=2b6cdb94bd5349646d7e33f9f501eef7"
 
-SRC_URI = "http://www.vervest.org/htp/archive/c/htpdate-${PV}.tar.gz"
+SRC_URI = "http://www.vervest.org/htp/archive/c/htpdate-${PV}.tar.gz \
+	   file://default.conf \
+"
 SRC_URI[sha256sum] = "3cdc558ec8e53ef374a42490b2f28c0b23981fa8754a6d7182044707828ad1e9"
 
 inherit systemd
@@ -33,6 +35,8 @@ do_compile () {
 do_install () {
 	oe_runmake install 'INSTALL=install' 'STRIP=echo' 'DESTDIR=${D}'
 	if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+		install -d ${D}${sysconfdir}/default
+		install -m 644 ${WORKDIR}/default.conf ${D}${sysconfdir}/default/htpdate
 		install -d ${D}${systemd_system_unitdir}
 		install -m 644 ${S}/scripts/htpdate.service ${D}${systemd_system_unitdir}
 	fi


### PR DESCRIPTION
Taking latest from meta-oe/master (due required changes), enable support for systemd and also provide a default config.

Systemd support should be sent upstream as well, will do that after finalizing this pr.