### PR TITLE
base: u-boot-fio: imx-2022.04: bump to 727d16723a6

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
@@ -1,6 +1,6 @@
 require u-boot-fio-common.inc
 
-SRCREV = "cede8a4f1449260eaac4128dd9d2e023b2d0a346"
+SRCREV = "727d16723a6ed9eb49229f293a775bfdc9f36399"
 SRCBRANCH = "2022.04+lf-5.15.32-2.0.0-fio"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 


### PR DESCRIPTION
Relevant changes:
- 727d16723a6 [FIO toimx] usb: imx: mx6: fix building ehci-mx6 driver
- 113d21b4408 [FIO toup] mmc: spl: select SPL_BLK for SPL_DM_MMC
- e03d63fe4cb [FIO toup] spl: crypto: fix including object files of SHA* in SPL
- ab9772994bf [FIO squash] image-sig: fix disabling SHA1 with FIT_SIGNATURE_STRICT
- 22478f6591a [FIO toup] imx: mx6: spl: reduce BSS size
- 6f174fd7e5f [FIO toup] ARM: mach-imx: imx8ulp: Fix SPL_CRYPTO name
- f025258336c [FIO toup] usb: dwc3: Fix renaming SPL_USB_HOST_SUPPORT to SPL_USB_HOST
- ef3ed1ae6fd [FIO fromtree] net: nfs: Fix CVE-2022-30767 (old CVE-2019-14196)
- 099bb6d19c8 [FIO fromtree] zlib: Port fix for CVE-2018-25032 to U-Boot
- a4430a0515a [FIO fromtree] fs/squashfs: Use kcalloc when relevant
- f33505d8d43 [FIO fromtree] net: Check for the minimum IP fragmented datagram size
- 2e4c58bc871 [FIO fromtree] fs/squashfs: sqfs_read: Prevent arbitrary code execution
- 1bb60dac7ff [FIO fromtree] i2c: fix stack buffer overflow vulnerability in i2c md command

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>