### PR TITLE
lmp-staging: serialize do_compile of heavy tasks

### DIFF
--- a/meta-lmp-base/classes/lmp-staging.bbclass
+++ b/meta-lmp-base/classes/lmp-staging.bbclass
@@ -17,6 +17,9 @@ python __anonymous() {
 
     if bb.data.inherits_class('go-mod', d):
         d.appendVarFlag('do_compile', 'network', '1')
+
+    if pn in ["clang", "rust"]:
+        d.appendVarFlag('do_compile', 'lockfiles', " ${TMPDIR}/lmp-hack-avoid-oom-do_compile.lock")
 }
 
 inherit ${INHERIT_KERNEL_MODSIGN}

--- a/meta-lmp-base/classes/lmp-staging.bbclass
+++ b/meta-lmp-base/classes/lmp-staging.bbclass
@@ -8,6 +8,8 @@
 INHERIT_KERNEL_MODSIGN = ""
 
 python __anonymous() {
+    pn = d.getVar('PN')
+
     if bb.data.inherits_class('module', d):
         d.appendVar('DEPENDS', ' virtual/kernel')
         if 'modsign' in d.getVar('DISTRO_FEATURES'):


### PR DESCRIPTION
This is a work around to not compile rust and clang at same time as it is very huge tasks.

It uses the bitbake lockfiles to run the refered tasks one at a time. The bitbake UI can be misleading since it will inform you that the tasks are working at the same time, which is not true because only one is working and all the others are blocked.
I have a pending bitbake patch to improve this situation.

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>