### PR TITLE
lmp-staging: archiver multiconfig signature workaround

### DIFF
--- a/meta-lmp-base/classes/lmp-staging.bbclass
+++ b/meta-lmp-base/classes/lmp-staging.bbclass
@@ -20,6 +20,11 @@ python __anonymous() {
 
     if pn in ["clang", "rust"]:
         d.appendVarFlag('do_compile', 'lockfiles', " ${TMPDIR}/lmp-hack-avoid-oom-do_compile.lock")
+
+    if bb.data.inherits_class('archiver', d) and is_work_shared(d) and \
+        d.getVarFlag('ARCHIVER_MODE', 'src') == "original" and \
+        d.getVarFlag('ARCHIVER_MODE', 'diff') == '1':
+            d.setVarFlag('do_deploy_archives', 'vardepvalue', '%s:do_unpack_and_patch' % pn)
 }
 
 inherit ${INHERIT_KERNEL_MODSIGN}


### PR DESCRIPTION
The OE archiver bbclass do_deploy_archives task is broken with multiconfig for shared recipes, the tasks have diferent signatures for each machine used in the multiconfig and this can rise race conditions.

To eliminate this race conditions we will use the signature of the previous task do_unpack_and_patch that works with multiconfig, this will make the do_deploy_archives task machine agnostic.

Steps to reproduce:

```
bitbake mc:k3r5:gcc-source-12.2.0 gcc-source-12.2.0 -c do_deploy_archives -S none
```

And check the signatures:

```
grep do_deploy_archives locked-sigs.inc | sort | uniq
# gcc-source-12.2.0:do_deploy_archives:541a6951ee58276d9698f631a18ff47962131fb5a21d9b7d60e27bc84165ecb2 \
# gcc-source-12.2.0:do_deploy_archives:b3149f6c89dc250d02a978e2492126dcef43ffac974856d94e2be3d8038bc2fd \
```

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>