### PR TITLE
aktualizr: add default pkcs11 label to aktualizr config

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr-pkcs11-label.bb
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr-pkcs11-label.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Aktualizr configuration snippet to make sure pkcs#11 token is labeled properly"
+HOMEPAGE = "https://github.com/advancedtelematic/aktualizr"
+SECTION = "base"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
+
+inherit allarch
+
+SRC_URI = "file://pkcs11-label.toml"
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+PV = "1.0"
+
+S = "${WORKDIR}"
+
+do_install() {
+    install -m 0700 -d ${D}${libdir}/sota/conf.d
+    install -m 0644 ${WORKDIR}/pkcs11-label.toml ${D}${libdir}/sota/conf.d/46-pkcs11-label.toml
+}
+
+FILES:${PN} = " \
+    ${libdir}/sota/conf.d/46-pkcs11-label.toml \
+"

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr-pkcs11-label/pkcs11-label.toml
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr-pkcs11-label/pkcs11-label.toml
@@ -1,0 +1,2 @@
+[p11]
+label = "aktualizr"

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -16,6 +16,7 @@ PACKAGECONFIG[ubootenv] = ",,u-boot-fw-utils,u-boot-fw-utils u-boot-default-env 
 PACKAGECONFIG[libfyaml] = ",,,libfyaml"
 PACKAGECONFIG[aklite-offline] = "-DBUILD_AKLITE_OFFLINE=ON,-DBUILD_AKLITE_OFFLINE=OFF,"
 PACKAGECONFIG[nerdctl] = "-DBUILD_AKLITE_WITH_NERDCTL=ON,-DBUILD_AKLITE_WITH_NERDCTL=OFF,,nerdctl"
+PACKAGECONFIG[hsm] = "-DBUILD_P11=ON -DPKCS11_ENGINE_PATH=${PKCS11_ENGINE_PATH},-DBUILD_P11=OFF,libp11,aktualizr-pkcs11-label"
 
 SYSTEMD_PACKAGES += "${PN}-lite"
 SYSTEMD_SERVICE:${PN}-lite = "aktualizr-lite.service"


### PR DESCRIPTION
This patch will ensure backward compatibility for aktualizr deployments working with HSM modules. Currently aktualizr uses 1st available initialized token. With changes coming aktualizr will use the token with proper label.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>