### PR TITLE
luks2: support encryption in CI and online re-encryption on first boot

### DIFF
--- a/meta-lmp-base/recipes-support/luks-reencryption/luks-reencryption/luks-reencryption
+++ b/meta-lmp-base/recipes-support/luks-reencryption/luks-reencryption/luks-reencryption
@@ -7,7 +7,7 @@ set -e
 
 [ $(whoami) = "root" ] || { echo "E: You must be root" && exit 1; }
 
-DEVICE=$(lsblk -f | awk '/crypto_LUKS/ {print $1}' | awk '{sub(/^[^a-zA-Z]*/, ""); print}')
+DEVICE=$(lsblk -f | awk '/crypto_LUKS/ {print $1; exit}' | awk '{sub(/^[^a-zA-Z]*/, ""); print}')
 DEVICE="/dev/${DEVICE}"
 
 # Avoid using the PIN for OP-TEE supported PKCS#11 user authentication


### PR DESCRIPTION
Still not fully functional due https://gitlab.com/cryptsetup/cryptsetup/-/issues/780.

After that is fixed upstream, the only other piece missing would be the systemd job responsible for calling reencrypt --resume-only.