### PR TITLE
base: recipes-sota: aktualizr-lite: bump to e5bbb3a

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "4ab5400ce05e8dc591a4ff5b787082a7dce6f3ea"
+SRCREV:lmp = "e5bbb3aac72593cc1854857114e5388ef0a28311"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
Relevant changes:

- e5bbb3a offline: Support update on dockerless systems
- 95f08e1 aktualizr: require pkcs11 token label
- 4679a05 appengine: Move pruning to an engine client impl
- e8b302f bootloader: Search bootloader version file in sysroot
- 13124a0 bootloader: Ignore failure of getting firmware ver

Signed-off-by: Mike <mike.sul@foundries.io>