### PR TITLE
base: ovmf: backport patches to fix nvm support with qemu

### DIFF
--- a/meta-lmp-base/recipes-core/ovmf/ovmf/0001-MdeModulePkg-NvmExpressDxe-fix-check-for-Cap.Css.patch
+++ b/meta-lmp-base/recipes-core/ovmf/ovmf/0001-MdeModulePkg-NvmExpressDxe-fix-check-for-Cap.Css.patch
@@ -1,0 +1,38 @@
+From da20ace9d582f61a0938cf53f10a4352400619a4 Mon Sep 17 00:00:00 2001
+From: "Mara Sophie Grosch via groups.io" <littlefox=lf-net.org@groups.io>
+Date: Wed, 23 Mar 2022 18:22:33 +0800
+Subject: [PATCH 1/2] MdeModulePkg/NvmExpressDxe: fix check for Cap.Css
+
+Fix the check for NVMe command set being supported by the controller.
+
+Was problematic with qemu (6.2.0, Debian 1:6.2+dfsg-3), which sets 0xC1
+in that register, making the OVMF think the NVMe controller does not
+support NVMe.
+
+Uncovered by commit 9dd14fc91c174eae87fd122c7ac70073a363527f, which
+changed the number of bits included in the Css register from 4 to 8.
+
+Upstream-Status: Backport [https://github.com/tianocore/edk2/pull/2682]
+
+Signed-off-by: Mara Sophie Grosch <littlefox@lf-net.org>
+Reviewed-by: Hao A Wu <hao.a.wu@intel.com>
+---
+ MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+index ac77afe113..6706996ad5 100644
+--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
++++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+@@ -785,7 +785,7 @@ NvmeControllerInit (
+     return Status;
+   }
+ 
+-  if (Private->Cap.Css != 0x01) {
++  if ((Private->Cap.Css & BIT0) == 0) {
+     DEBUG ((DEBUG_INFO, "NvmeControllerInit: the controller doesn't support NVMe command set\n"));
+     return EFI_UNSUPPORTED;
+   }
+-- 
+2.34.1
+

--- a/meta-lmp-base/recipes-core/ovmf/ovmf/0002-MdeModulePkg-NvmExpressPei-fix-check-for-NVM-command.patch
+++ b/meta-lmp-base/recipes-core/ovmf/ovmf/0002-MdeModulePkg-NvmExpressPei-fix-check-for-NVM-command.patch
@@ -1,0 +1,31 @@
+From f4f6188862b5557f96581ce2d0fb6084e3f355e4 Mon Sep 17 00:00:00 2001
+From: "Mara Sophie Grosch via groups.io" <littlefox=lf-net.org@groups.io>
+Date: Wed, 23 Mar 2022 18:22:34 +0800
+Subject: [PATCH 2/2] MdeModulePkg/NvmExpressPei: fix check for NVM command set
+
+Previous commit fixed that check in DXE, this one now for PEI.
+
+Upstream-Status: Backport [https://github.com/tianocore/edk2/pull/2682]
+
+Signed-off-by: Mara Sophie Grosch <littlefox@lf-net.org>
+Reviewed-by: Hao A Wu <hao.a.wu@intel.com>
+---
+ MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiHci.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiHci.c b/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiHci.c
+index ac956bdce4..bff5cfd0d5 100644
+--- a/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiHci.c
++++ b/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiHci.c
+@@ -571,7 +571,7 @@ NvmeControllerInit (
+   // Read the controller Capabilities register and verify that the NVM command set is supported
+   //
+   NVME_GET_CAP (Private, &Private->Cap);
+-  if (Private->Cap.Css != 0x01) {
++  if ((Private->Cap.Css & BIT0) == 0) {
+     DEBUG ((DEBUG_ERROR, "%a: The NVME controller doesn't support NVMe command set.\n", __FUNCTION__));
+     return EFI_UNSUPPORTED;
+   }
+-- 
+2.34.1
+

--- a/meta-lmp-base/recipes-core/ovmf/ovmf_git.bbappend
+++ b/meta-lmp-base/recipes-core/ovmf/ovmf_git.bbappend
@@ -1,2 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "\
+	file://0001-MdeModulePkg-NvmExpressDxe-fix-check-for-Cap.Css.patch \
+	file://0002-MdeModulePkg-NvmExpressPei-fix-check-for-NVM-command.patch \
+"
+
 PACKAGECONFIG += "${@bb.utils.contains('MACHINE_FEATURES', 'tpm2', 'tpm2', '', d)}"
 PACKAGECONFIG[tpm2] = "-D TPM2_ENABLE=TRUE,-D TPM2_ENABLE=FALSE,,"


### PR DESCRIPTION
Backport patches already applied in main and latest edk2 stable in order to fix NVME usage with recent QEMU versions, as described at https://github.com/tianocore/edk2/pull/2637.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>