### PR TITLE
nvidia: enable optee-os from source (instead of pre-built)

### DIFF
--- a/meta-lmp-base/conf/distro/include/non-clangable.inc
+++ b/meta-lmp-base/conf/distro/include/non-clangable.inc
@@ -82,6 +82,10 @@ TOOLCHAIN:pn-optee-test = "gcc"
 #  /srv/oe/build/conf/../../layers/meta-lmp/meta-lmp-base/recipes-security/optee/optee-fiovb_git.bb:do_compile
 TOOLCHAIN:pn-optee-fiovb = "gcc"
 
+# tegra (xavier and orin)
+TOOLCHAIN:pn-optee-os = "gcc"
+TOOLCHAIN:pn-optee-nvsamples = "gcc"
+
 # lmp-mfgtool distro
 TOOLCHAIN:pn-optee-os-fio-mfgtool = "gcc"
 

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -598,6 +598,7 @@ OSTREE_LOADER_LINK:tegra = "0"
 OSTREE_BOOTLOADER:tegra ?= "syslinux"
 CORE_IMAGE_BASE_INSTALL:remove:tegra = "resize-helper"
 OSTREE_DEPLOY_DEVICETREE:tegra = "1"
+PREFERRED_PROVIDER_virtual/optee-os:tegra = "optee-os"
 ## jetson-agx-xavier-devkit (tegra194)
 OSTREE_KERNEL_ARGS:tegra194 ?= "\${cbootargs} root=/dev/mmcblk0p1 rootwait rootfstype=ext4 mminit_loglevel=4 console=tty0 console=ttyTCU0,115200 fbcon=map:0 sdhci_tegra.en_boot_part_access=1"
 ## jetson-agx-orin-devkit (tegra234)

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -599,6 +599,7 @@ OSTREE_BOOTLOADER:tegra ?= "syslinux"
 CORE_IMAGE_BASE_INSTALL:remove:tegra = "resize-helper"
 OSTREE_DEPLOY_DEVICETREE:tegra = "1"
 PREFERRED_PROVIDER_virtual/optee-os:tegra = "optee-os"
+MACHINE_FEATURES:append:tegra = " optee"
 ## jetson-agx-xavier-devkit (tegra194)
 OSTREE_KERNEL_ARGS:tegra194 ?= "\${cbootargs} root=/dev/mmcblk0p1 rootwait rootfstype=ext4 mminit_loglevel=4 console=tty0 console=ttyTCU0,115200 fbcon=map:0 sdhci_tegra.en_boot_part_access=1"
 ## jetson-agx-orin-devkit (tegra234)

--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-security/optee/optee-os_3.16.0-l4t-r35.1.0.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-security/optee/optee-os_3.16.0-l4t-r35.1.0.bbappend
@@ -1,0 +1,6 @@
+# Separate TAs into a different package, follow optee-os-fio
+PACKAGES += "${PN}-ta"
+RPROVIDES:${PN}-ta = "virtual-optee-os-ta"
+
+FILES:${PN} = "${nonarch_base_libdir}/firmware/"
+FILES:${PN}-ta = "${nonarch_base_libdir}/optee_armtz"

--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-security/optee/optee-test_3.16.0-l4t-r35.1.0.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-security/optee/optee-test_3.16.0-l4t-r35.1.0.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS:${PN} = "optee-os-ta optee-client"


### PR DESCRIPTION
This also allows us to be compatible with latest meta-tegra changes.