### PR TITLE
base: ovmf: fix patches line endings

### DIFF
--- a/meta-lmp-base/recipes-core/ovmf/ovmf/0001-MdeModulePkg-NvmExpressDxe-fix-check-for-Cap.Css.patch
+++ b/meta-lmp-base/recipes-core/ovmf/ovmf/0001-MdeModulePkg-NvmExpressDxe-fix-check-for-Cap.Css.patch
@@ -1,4 +1,4 @@
-From da20ace9d582f61a0938cf53f10a4352400619a4 Mon Sep 17 00:00:00 2001
+From 9bea09034026f411531d103d422ca18f115f0df6 Mon Sep 17 00:00:00 2001
 From: "Mara Sophie Grosch via groups.io" <littlefox=lf-net.org@groups.io>
 Date: Wed, 23 Mar 2022 18:22:33 +0800
 Subject: [PATCH 1/2] MdeModulePkg/NvmExpressDxe: fix check for Cap.Css

--- a/meta-lmp-base/recipes-core/ovmf/ovmf/0002-MdeModulePkg-NvmExpressPei-fix-check-for-NVM-command.patch
+++ b/meta-lmp-base/recipes-core/ovmf/ovmf/0002-MdeModulePkg-NvmExpressPei-fix-check-for-NVM-command.patch
@@ -1,4 +1,4 @@
-From f4f6188862b5557f96581ce2d0fb6084e3f355e4 Mon Sep 17 00:00:00 2001
+From a9d844a413e04a36ca4cdf415a3d4aa7552ab37e Mon Sep 17 00:00:00 2001
 From: "Mara Sophie Grosch via groups.io" <littlefox=lf-net.org@groups.io>
 Date: Wed, 23 Mar 2022 18:22:34 +0800
 Subject: [PATCH 2/2] MdeModulePkg/NvmExpressPei: fix check for NVM command set


### PR DESCRIPTION
Correct the patches with the expected line endings, otherwise bitbake fails to apply the changes.

Converted incorrectly when exporting the patches at the previous commit.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>