### PR TITLE
Revert "base: kern-tools-native: bump to 6a4752ebb"

### DIFF
--- a/meta-lmp-base/recipes-kernel/kern-tools/kern-tools-native_git.bbappend
+++ b/meta-lmp-base/recipes-kernel/kern-tools/kern-tools-native_git.bbappend
@@ -1,2 +1,0 @@
-# Needed until oe-core 533720a17 is available in kirkstone
-SRCREV = "6a4752ebbe7d242c02b3c74a5772926edd243626"


### PR DESCRIPTION
```
This reverts commit 9f0837380755461262efc58cb1c4e14dbd47ae59.

It is already merged on master/kirkstone

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
```

Merged Upstream:

- master: https://git.yoctoproject.org/poky/commit/?id=4c9b5da26bf56c80f2dfdbcb8b35ee36baa8ad7c

- kirstone: not yet