### PR TITLE
Additional fixes for the NXP BSP

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -327,6 +327,7 @@ WKS_FILE:sota:imx8mq-evk-ebbr ?= "efidisk-sota.wks.in"
 # iMX8MM
 UBOOT_SIGN_ENABLE:sota:mx8mm-generic-bsp = "1"
 IMX_DEFAULT_BOOTLOADER:mx8mm-generic-bsp ?= "u-boot-fio"
+UBOOT_ENTRYPOINT:mx8mm-generic-bsp = "0x40400000"
 UBOOT_DTB_LOADADDRESS:mx8mm-generic-bsp = "0x43000000"
 PREFERRED_PROVIDER_virtual/trusted-firmware-a:mx8mm-nxp-bsp ?= "imx-atf"
 EXTRA_IMAGEDEPENDS:append:mx8mm-nxp-bsp = "virtual/trusted-firmware-a"

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -354,6 +354,7 @@ OSTREE_SPLIT_BOOT:mx8mm-nxp-bsp = "${@bb.utils.contains('DISTRO_FEATURES', 'luks
 OSTREE_DEPLOY_USR_OSTREE_BOOT:mx8mm-nxp-bsp = "${@bb.utils.contains('DISTRO_FEATURES', 'luks', '1', '0', d)}"
 WKS_FILE:sota:mx8mm-nxp-bsp = "${@bb.utils.contains('DISTRO_FEATURES', 'luks', 'sdimage-imx8-spl-split-boot-sota.wks.in', 'sdimage-imx8-spl-sota.wks.in', d)}"
 ## iMX8MM EVK
+MACHINE_FIRMWARE:append:imx8mm-lpddr4-evk = " linux-firmware-qca"
 KERNEL_DEVICETREE:append:imx8mm-lpddr4-evk = " freescale/imx8mm-evkb.dtb"
 KMACHINE:imx8mm-lpddr4-evk = "imx8mmevk"
 OSTREE_KERNEL_ARGS:imx8mm-lpddr4-evk ?= "console=tty1 console=ttymxc1,115200 earlycon=ec_imx6q,0x30890000,115200 root=/dev/mmcblk2p2 rootfstype=ext4"

--- a/meta-lmp-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-lmp-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -17,11 +17,11 @@ SRC_URI:append = "\
 "
 SRCREV_TIInit_11.8.32 ?= "31a43dc1248a6c19bb886006f8c167e2fd21cb78"
 
-IMX_FIRMWARE_BRANCH ?= "lf-5.10.52_2.1.0"
+IMX_FIRMWARE_BRANCH ?= "lf-5.15.52_2.1.0"
 SRC_URI:append:imx-nxp-bsp = "\
     git://github.com/NXP/imx-firmware.git;protocol=https;branch=${IMX_FIRMWARE_BRANCH};destsuffix=imx-firmware;name=imx-firmware; \
 "
-SRCREV_imx-firmware ?= "6d7f77b83164b08334806c4aa2034bc1f7da7b7d"
+SRCREV_imx-firmware ?= "b6f070e3d4cab23932d9e6bc29e3d884a7fd68f4"
 
 SRC_URI:append:beaglebone-yocto = "\
     https://github.com/beagleboard/beaglebone-black-wireless/raw/d9135000a223228158d92fd2e3f00e495f642fee/firmware/wl18xx-conf.bin;name=wl18xx-conf \

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/imx8mm-lpddr4-evk/0001-FIO-toup-arm64-dts-imx8mm-evk-qca-wifi-enable-suppor.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/imx8mm-lpddr4-evk/0001-FIO-toup-arm64-dts-imx8mm-evk-qca-wifi-enable-suppor.patch
@@ -1,0 +1,48 @@
+From a48aba8ed188ec94bbdf6f37bea3d94b4d9904fe Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo@foundries.io>
+Date: Wed, 2 Nov 2022 20:08:21 -0300
+Subject: [PATCH] [FIO toup] arm64: dts: imx8mm-evk-qca-wifi: enable support
+ for bluetooth
+
+Add required changes to enable the qca bluetooth device.
+
+Upstream-Status: Pending
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+---
+ .../dts/freescale/imx8mm-evk-qca-wifi.dts     | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts
+index aa1a25f00f550..8749a92237dd4 100755
+--- a/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts
+@@ -13,6 +13,25 @@ / {
+ 
+ /delete-node/&pmic_nxp;
+ 
++&uart1 { /* BT */
++	bluetooth {
++		compatible = "qcom,qca9377-bt";
++		enable-gpios = <&gpio2 6 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&iomuxc {
++	pinctrl_uart1: uart1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_UART1_RXD_UART1_DCE_RX     0x140
++			MX8MM_IOMUXC_UART1_TXD_UART1_DCE_TX     0x140
++			MX8MM_IOMUXC_UART3_RXD_UART1_DCE_CTS_B  0x140
++			MX8MM_IOMUXC_UART3_TXD_UART1_DCE_RTS_B  0x140
++			MX8MM_IOMUXC_SD1_DATA4_GPIO2_IO6        0x19
++		>;
++	};
++};
++
+ &i2c1 {
+ 	pmic_rohm: pmic@4b {
+ 		compatible = "rohm,bd71847";
+-- 
+2.38.1
+

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_5.15_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_5.15_git.bb
@@ -25,6 +25,10 @@ SRC_URI:append:imx8mp-lpddr4-evk = " \
     ${@bb.utils.contains('MACHINE_FEATURES', 'se05x', 'file://0001-FIO-internal-arch-arm64-dts-imx8mp-enable-I2C5-bus.patch', '', d)} \
 "
 
+# Add bluetooth support for QCA9377
+SRC_URI:append:imx8mm-lpddr4-evk = " \
+    file://0001-FIO-toup-arm64-dts-imx8mm-evk-qca-wifi-enable-suppor.patch \
+"
 # Fix bluetooth reset for Murata 1MW
 SRC_URI:append:imx8mn-ddr4-evk = " \
     file://0001-FIO-internal-arm64-dts-imx8mn-evk.dtsi-re-add-blueto.patch \


### PR DESCRIPTION
* Bump linux-firmware imx to be aligned with current BSP release
* Fix kernel entrypoint for mx8mm
* Add bluetooth support for imx8mmevka
* Add qca firmware on imx8mm devices (for evka)