### PR TITLE
Setscene fixes

### DIFF
--- a/meta-lmp-base/recipes-core/images/core-image-minimal-initramfs.bbappend
+++ b/meta-lmp-base/recipes-core/images/core-image-minimal-initramfs.bbappend
@@ -1,2 +1,5 @@
 # Only initramfs-module-install-efi is supported
 INITRAMFS_SCRIPTS:remove = "initramfs-module-install"
+
+SSTATE_SKIP_CREATION:task-image-qa = "0"
+SSTATE_SKIP_CREATION:task-image-complete = "0"

--- a/meta-lmp-base/recipes-core/images/core-image-minimal-initramfs.bbappend
+++ b/meta-lmp-base/recipes-core/images/core-image-minimal-initramfs.bbappend
@@ -3,3 +3,5 @@ INITRAMFS_SCRIPTS:remove = "initramfs-module-install"
 
 SSTATE_SKIP_CREATION:task-image-qa = "0"
 SSTATE_SKIP_CREATION:task-image-complete = "0"
+
+inherit nopackages

--- a/meta-lmp-base/recipes-core/images/initramfs-ostree-lmp-image.bb
+++ b/meta-lmp-base/recipes-core/images/initramfs-ostree-lmp-image.bb
@@ -44,3 +44,6 @@ IMAGE_ROOTFS_EXTRA_SPACE = "0"
 IMAGE_OVERHEAD_FACTOR = "1.0"
 
 BAD_RECOMMENDATIONS += "busybox-syslog"
+
+SSTATE_SKIP_CREATION:task-image-qa = "0"
+SSTATE_SKIP_CREATION:task-image-complete = "0"

--- a/meta-lmp-base/recipes-core/os-release/os-release.bbappend
+++ b/meta-lmp-base/recipes-core/os-release/os-release.bbappend
@@ -16,6 +16,8 @@ LMP_FACTORY_TAG = "${LMP_DEVICE_REGISTER_TAG}"
 IMAGE_ID = "${LMP_FACTORY_IMAGE}"
 IMAGE_VERSION = "${H_BUILD}"
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 inherit deploy
 
 do_deploy () {


### PR DESCRIPTION
- base: core-image-minimal-initramfs: inherit nopackages
_This can be proposed upstream_
- base: initramfs-ostree-lmp-image: use a python anonimus to check IMAGE_FSTYPES
- base: core-image-minimal-initramfs: use the sstate for all task
_A better approach can be a new bbclass or inc with the bits used in initramfs_
- base: initramfs-ostree-lmp-image: use the sstate for all task
_A better approach can be a new bbclass or inc with the bits used in initramfs_
- base: lmp: remove image-buildinfo as we don't use it anymore

This PR improves the local build time a lot and building with more cache reduces the time to 25 minutes

`time bitbake lmp-base-console-image`
```
real    23m58.393s
user    0m25.023s
sys     0m17.533s
```
