### PR TITLE
base: lmp: remove image-buildinfo as we don't use it anymore

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -82,7 +82,6 @@ INHERIT += "lmp-staging"
 ## Create SPDX (SBOM) by default
 INHERIT += "create-spdx"
 INHERIT += "buildhistory"
-INHERIT += "image-buildinfo"
 BUILDHISTORY_COMMIT = "1"
 
 # Clang toolchain


### PR DESCRIPTION
This also adds a dependencie BBLAYERS that rebuild many recipes from scracth when we cange the build dir.

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>