### PR TITLE
base-files: use FILESEXTRAPATHS without machine overrides

### DIFF
--- a/meta-lmp-base/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-lmp-base/recipes-core/base-files/base-files_%.bbappend
@@ -1,1 +1,1 @@
-FILESEXTRAPATHS:prepend:lmp := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
This is the only place on the layer this is used.

```
grep 'FILESEXTRAPATHS.*lmp' -r
# meta-lmp-base/recipes-core/base-files/base-files_%.bbappend:FILESEXTRAPATHS:prepend:lmp := "${THISDIR}/${PN}:"
```

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>