### PR TITLE
Archiver: fix setscene locally 

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -83,6 +83,8 @@ INHERIT += "lmp-staging"
 INHERIT += "archiver"
 ARCHIVER_MODE[src] ?= "original"
 ARCHIVER_MODE[diff] ?= "1"
+# disable archiver for all recipes
+COPYLEFT_RECIPE_TYPES ?= ""
 
 ## Create SPDX (SBOM) by default
 INHERIT += "create-spdx"

--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -79,6 +79,11 @@ BUILD_OSTREE_TARBALL ?= "0"
 INHERIT += "lmp"
 INHERIT += "lmp-staging"
 
+# Archive sources (for license compliance)
+INHERIT += "archiver"
+ARCHIVER_MODE[src] ?= "original"
+ARCHIVER_MODE[diff] ?= "1"
+
 ## Create SPDX (SBOM) by default
 INHERIT += "create-spdx"
 INHERIT += "buildhistory"


### PR DESCRIPTION
Enable the archiver for every build to fix the SSTATETASKS chain.
The archiver is always enabled on the CI but locally not and this breaks the sstate-cache reuse.

This also fixes many rm_works issue where one of them is the following:
    
```
Task cpio:do_rm_work couldn't be used from the cache because:
  We need hash a11151ed05614d9577893318e8b401bb5450cbdce002199fd3fc4128f21d273e, closest matching task was 8186adc8138c84e4d21eaeef053db0a0bea1c12e6fea2487d59833559ea76f57
  basehash changed from 47a321369469543dff15da565f7460bf32bff0e724f063a39cf4e89745fdda5d to 5406e5d6dfd20699e09815b796e1172f952d695cd7697dcec8ae4059e81551a5
  Variable SSTATETASKS value changed:
"do_create_runtime_spdx do_create_spdx [-do_deploy_archives-] do_deploy_source_date_epoch do_package do_package_qa do_package_write_ipk do_packagedata do_populate_lic do_populate_sysroot"
  runtaskdeps changed:
['cpio/cpio_2.13.bb:do_create_runtime_spdx cpio/cpio_2.13.bb:do_create_spdx', -cpio/cpio_2.13.bb:do_deploy_archives, 'cpio/cpio_2.13.bb:do_package_qa cpio/cpio_2.13.bb:do_package_write_ipk cpio/cpio_2.13.bb:do_packagedata cpio/cpio_2.13.bb:do_populate_lic cpio/cpio_2.13.bb:do_populate_sysroot']
  Number of task dependencies changed
  Dependency on task cpio/cpio_2.13.bb:do_deploy_archives was removed with hash 5c99260adc1101b877058bb216ffee861780736ac61ff6dfff2de13e8410abfc
```

_Note that this enable the archiver locally but they don't run._