### PR TITLE
base: images: install dtc package

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-feature-debug.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-debug.inc
@@ -9,4 +9,5 @@ CORE_IMAGE_BASE_INSTALL += " \
     minicom \
     devmem2 \
     curl \
+    dtc \
 "


### PR DESCRIPTION
Install dtc package by default for all images, as this likely to be used on all platforms for exporting device tree during debugging.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>