### PR TITLE
base: layer.conf: exclude os-release in the siggen as it is abisafe

### DIFF
--- a/meta-lmp-base/conf/layer.conf
+++ b/meta-lmp-base/conf/layer.conf
@@ -31,3 +31,6 @@ BBFILES_DYNAMIC += " \
     tpm-layer:${LAYERDIR}/dynamic-layers/tpm-layer/*/*/*.bb \
     tpm-layer:${LAYERDIR}/dynamic-layers/tpm-layer/*/*/*.bbappend \
 "
+
+# A list of recipes that are completely stable and will never change.
+SIGGEN_EXCLUDERECIPES_ABISAFE += "os-release"


### PR DESCRIPTION
The recipe os-release only install a file on target so we cat exclude it from the siggen and avoid rebuild packages that releies on the files they provided by the os-release.

Currently one bigside effects of this issue is rebuilding systemd and consequently everything that depends on that.

A list of recipes that are completely stable and will never change. The ABI for the recipes in the list are presented by output from the tasks run to build the recipe. Use of this variable is one way to remove dependencies from one recipe on another that affect task signatures and thus force rebuilds when the recipe changes.
https://docs.yoctoproject.org/ref-manual/variables.html?highlight=siggen_exclude_safe_recipe_deps#term-SIGGEN_EXCLUDERECIPES_ABISAFE

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>