### PR TITLE
base: containers: log container name instead of container id

### DIFF
--- a/meta-lmp-base/recipes-containers/docker/files/daemon.json.in
+++ b/meta-lmp-base/recipes-containers/docker/files/daemon.json.in
@@ -1,5 +1,8 @@
 {
   "log-driver": "journald",
+  "log-opts": {
+    "tag": "{{.Name}}"
+  },
   "max-concurrent-downloads": @@MAX_CONCURRENT_DOWNLOADS@@,
   "max-download-attempts": @@MAX_DOWNLOAD_ATTEMPTS@@
 }


### PR DESCRIPTION
This shows logging information with the container name as in: Nov 09 17:15:03 intel-corei7-64 shellhttpd-httpd-1[407]: Starting

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>