### PR TITLE
base: optee-os-fio: 3.18: bump to fcf11c1f0

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.18.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.18.0.bb
@@ -1,5 +1,5 @@
 require optee-os-fio.inc
 
 PV = "3.18.0+git"
-SRCREV = "6d30e480fe42a4597d261b5b010937e52a4e3fa7"
+SRCREV = "fcf11c1f03e8a249e745d2bfe437c863aedfba45"
 SRCBRANCH = "3.18+fio"


### PR DESCRIPTION
Relevant changes:
- fcf11c1f0 [FIO squash] core: arm: boot: set PSCI API for cpus in a DT overlay
- 210667f26 [FIO toup] core: arm: boot: fix walking thru cpu nodes in DT
- aefa85603 [FIO fromtree] crypto: se050: provision SCP03 keys back factory keys
- ee594bff8 [FIO fromtree] crypto: se050: output the SCP03 security level to the console
- 64505a6ae [FIO toup] drivers: clk: stm32mp15: force secure rcc if board is closed
- 59096f4e5 [FIO fromtree] crypto: se050: SCP03 enabled only session.
- 1f5cb9e87 [FIO fromtree] crypto: se050: add support for the SE050F
- 0b2957bff [FIO fromtree] crypto: se050: fix SE050F2 identifier

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>