### PR TITLE
bsp: u-boot-ostree-scr-fit: explicitly specify that offsets are in hex

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/apalis-imx6/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/apalis-imx6/boot.cmd
@@ -15,10 +15,13 @@ setenv optee_ovl_addr 0x16000000
 setenv fit_addr ${loadaddr}
 
 # Boot firmware updates
-setenv bootloader 2
-setenv bootloader2 100
-setenv bootloader_s 802
-setenv bootloader2_s 900
+
+# Offsets are in blocks (512 bytes each)
+setenv bootloader 0x2
+setenv bootloader2 0x100
+setenv bootloader_s 0x802
+setenv bootloader2_s 0x900
+
 setenv bootloader_image "SPL"
 setenv bootloader_s_image ${bootloader_image}
 setenv bootloader2_image "u-boot.itb"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/apalis-imx8/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/apalis-imx8/boot.cmd
@@ -25,8 +25,10 @@ setenv bootcmd_load_m4_1 'if imxtract ${ramdisk_addr_r}#conf@@FIT_NODE_SEPARATOR
 setenv bootcmd_load_fw 'run bootcmd_load_hdmi; run bootcmd_load_m4_0; run bootcmd_load_m4_1;'
 
 # Boot firmware updates
-setenv bootloader 0
-setenv bootloader2 400
+
+# Offsets are in blocks (512 bytes each)
+setenv bootloader 0x0
+setenv bootloader2 0x400
 setenv bootloader_s ${bootloader}
 setenv bootloader2_s ${bootloader2}
 setenv bootloader_image "imx-boot"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx6ulevk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx6ulevk/boot.cmd
@@ -16,10 +16,13 @@ setenv optee_ovl_addr 0x86000000
 setenv fit_addr ${loadaddr}
 
 # Boot firmware updates
-setenv bootloader 2
-setenv bootloader2 8a
-setenv bootloader_s 1002
-setenv bootloader2_s 108a
+
+# Offsets are in blocks (512 bytes each)
+setenv bootloader 0x2
+setenv bootloader2 0x8a
+setenv bootloader_s 0x1002
+setenv bootloader2_s 0x108a
+
 setenv bootloader_image "SPL"
 setenv bootloader_s_image ${bootloader_image}
 setenv bootloader2_image "u-boot.itb"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx6ullevk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx6ullevk/boot.cmd
@@ -16,10 +16,13 @@ setenv optee_ovl_addr 0x86000000
 setenv fit_addr ${loadaddr}
 
 # Boot firmware updates
-setenv bootloader 2
-setenv bootloader2 8a
-setenv bootloader_s 1002
-setenv bootloader2_s 108a
+
+# Offsets are in blocks (512 bytes each)
+setenv bootloader 0x2
+setenv bootloader2 0x8a
+setenv bootloader_s 0x1002
+setenv bootloader2_s 0x108a
+
 setenv bootloader_image "SPL"
 setenv bootloader_s_image ${bootloader_image}
 setenv bootloader2_image "u-boot.itb"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx7ulpea-ucom/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx7ulpea-ucom/boot.cmd
@@ -16,10 +16,13 @@ setenv fit_addr ${initrd_addr}
 setenv loadaddr ${fit_addr}
 
 # Boot firmware updates
-setenv bootloader 2
-setenv bootloader2 180
-setenv bootloader_s 1002
-setenv bootloader2_s 1180
+
+# Offsets are in blocks (512 bytes each)
+setenv bootloader 0x2
+setenv bootloader2 0x180
+setenv bootloader_s 0x1002
+setenv bootloader2_s 0x1180
+
 setenv bootloader_image "SPL"
 setenv bootloader_s_image ${bootloader_image}
 setenv bootloader2_image "u-boot.itb"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mm-lpddr4-evk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mm-lpddr4-evk/boot.cmd
@@ -12,10 +12,13 @@ setenv fdt_file_final freescale_${fdt_file}
 setenv fit_addr ${initrd_addr}
 
 # Boot firmware updates
-setenv bootloader 42
-setenv bootloader2 300
-setenv bootloader_s 1042
-setenv bootloader2_s 1300
+
+# Offsets are in blocks (512KB each)
+setenv bootloader 0x42
+setenv bootloader2 0x300
+setenv bootloader_s 0x1042
+setenv bootloader2_s 0x1300
+
 setenv bootloader_image "imx-boot"
 setenv bootloader_s_image ${bootloader_image}
 setenv bootloader2_image "u-boot.itb"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mn-ddr4-evk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mn-ddr4-evk/boot.cmd
@@ -12,10 +12,13 @@ setenv fdt_file_final freescale_${fdtfile}
 setenv fit_addr 0x43800000
 
 # Boot firmware updates
-setenv bootloader 0
-setenv bootloader2 300
-setenv bootloader_s 1000
-setenv bootloader2_s 1300
+
+# Offsets are in blocks (512 bytes each)
+setenv bootloader 0x0
+setenv bootloader2 0x300
+setenv bootloader_s 0x1000
+setenv bootloader2_s 0x1300
+
 setenv bootloader_image "imx-boot"
 setenv bootloader_s_image ${bootloader_image}
 setenv bootloader2_image "u-boot.itb"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mp-lpddr4-evk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mp-lpddr4-evk/boot.cmd
@@ -12,10 +12,13 @@ setenv fdt_file_final freescale_${fdtfile}
 setenv fit_addr 0x43800000
 
 # Boot firmware updates
-setenv bootloader 0
-setenv bootloader2 300
-setenv bootloader_s 1000
-setenv bootloader2_s 1300
+
+# Offsets are in blocks (512 bytes each)
+setenv bootloader 0x0
+setenv bootloader2 0x300
+setenv bootloader_s 0x1000
+setenv bootloader2_s 0x1300
+
 setenv bootloader_image "imx-boot"
 setenv bootloader_s_image ${bootloader_image}
 setenv bootloader2_image "u-boot.itb"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mq-evk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mq-evk/boot.cmd
@@ -11,10 +11,13 @@ setenv rootpart 2
 setenv fit_addr 0x43800000
 
 # Boot firmware updates
-setenv bootloader 42
-setenv bootloader2 300
-setenv bootloader_s 1042
-setenv bootloader2_s 1300
+
+# Offsets are in blocks (512 bytes each)
+setenv bootloader 0x42
+setenv bootloader2 0x300
+setenv bootloader_s 0x1042
+setenv bootloader2_s 0x1300
+
 setenv bootloader_image "imx-boot"
 setenv bootloader_s_image "imx-boot-nohdmi"
 setenv bootloader2_image "u-boot.itb"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8qm-mek/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8qm-mek/boot.cmd
@@ -27,8 +27,10 @@ setenv bootcmd_load_m4_1 'if imxtract ${ramdisk_addr_r}#conf@@FIT_NODE_SEPARATOR
 setenv bootcmd_load_fw 'run bootcmd_load_hdmi; run bootcmd_load_m4_0; run bootcmd_load_m4_1;'
 
 # Boot firmware updates
-setenv bootloader 0
-setenv bootloader2 400
+
+# Offsets are in blocks (512 bytes each)
+setenv bootloader 0x0
+setenv bootloader2 0x400
 setenv bootloader_s ${bootloader}
 setenv bootloader2_s ${bootloader2}
 setenv bootloader_image "imx-boot"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/stm32mp15-eval/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/stm32mp15-eval/boot.cmd
@@ -15,8 +15,8 @@ setenv check_board_closed 'if test "${boot_auth}" = "2"; then setenv board_is_cl
 setenv check_secondary_boot 'if test "${boot_part}" = "2"; then setenv fiovb.is_secondary_boot 1; else setenv fiovb.is_secondary_boot 0; fi;'
 
 # All values are provided in blocks (512 bytes each)
-setenv bootloader 0
-setenv bootloader2 200
+setenv bootloader 0x0
+setenv bootloader2 0x200
 setenv bootloader_size 0x1000
 setenv bootloader_s ${bootloader}
 setenv bootloader2_s ${bootloader2}


### PR DESCRIPTION
Explicitly specify that all offset values are in hex and in blocks (512 bytes each).

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>