### PR TITLE
base: lmp-base: include development debug tools

### DIFF
--- a/meta-lmp-base/conf/distro/lmp-base.conf
+++ b/meta-lmp-base/conf/distro/lmp-base.conf
@@ -15,4 +15,4 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS = ""
 DISTRO_FEATURES_DEFAULT:remove = "modsign"
 
 # Facilitate debugging
-DISTRO_FEATURES_DEFAULT:append = " debuginfod"
+DISTRO_FEATURES_DEFAULT:append = " debuginfod lmpdebug"

--- a/meta-lmp-base/recipes-samples/images/lmp-base-console-image.bb
+++ b/meta-lmp-base/recipes-samples/images/lmp-base-console-image.bb
@@ -17,6 +17,7 @@ require ${@bb.utils.contains('MACHINE_FEATURES', 'se05x', 'lmp-feature-se05x.inc
 require ${@bb.utils.contains('MACHINE_FEATURES', 'tpm2', 'lmp-feature-tpm2.inc', '', d)}
 require ${@bb.utils.contains('MACHINE_FEATURES', 'efi', 'lmp-feature-efi.inc', '', d)}
 require ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'lmp-feature-ima.inc', '', d)}
+require ${@bb.utils.contains('DISTRO_FEATURES', 'lmpdebug', 'lmp-feature-debug.inc', '', d)}
 
 IMAGE_FEATURES += "ssh-server-openssh"
 


### PR DESCRIPTION
The distro lmp-base is used usually for developing and debugging issues. Include a set of debug tools to this distro by default.

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>