### PR TITLE
LmP: move INHERIT out of distro config

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -79,8 +79,6 @@ BUILD_OSTREE_TARBALL ?= "0"
 INHERIT += "lmp"
 INHERIT += "lmp-staging"
 
-## Create SPDX (SBOM) by default
-INHERIT += "create-spdx"
 INHERIT += "buildhistory"
 BUILDHISTORY_COMMIT = "1"
 

--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -79,9 +79,6 @@ BUILD_OSTREE_TARBALL ?= "0"
 INHERIT += "lmp"
 INHERIT += "lmp-staging"
 
-INHERIT += "buildhistory"
-BUILDHISTORY_COMMIT = "1"
-
 # Clang toolchain
 TOOLCHAIN ?= "clang"
 RUNTIME = "llvm"

--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -79,11 +79,6 @@ BUILD_OSTREE_TARBALL ?= "0"
 INHERIT += "lmp"
 INHERIT += "lmp-staging"
 
-# Archive sources (for license compliance)
-INHERIT += "archiver"
-ARCHIVER_MODE[src] ?= "original"
-ARCHIVER_MODE[diff] ?= "1"
-
 ## Create SPDX (SBOM) by default
 INHERIT += "create-spdx"
 INHERIT += "buildhistory"

--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -83,8 +83,6 @@ INHERIT += "lmp-staging"
 INHERIT += "archiver"
 ARCHIVER_MODE[src] ?= "original"
 ARCHIVER_MODE[diff] ?= "1"
-# disable archiver for all recipes
-COPYLEFT_RECIPE_TYPES ?= ""
 
 ## Create SPDX (SBOM) by default
 INHERIT += "create-spdx"


### PR DESCRIPTION
**Archiver**
A fix to don't re-run the rm_work is merged upstream
https://git.yoctoproject.org/poky/commit/?id=6cd9a85d2b9f6272c0b0e9d68c6dbd5e8c0c336b
https://git.yoctoproject.org/poky/commit/?id=0f9773ee717d54ce1ed5001bc5ef4ec470f13476

**Create-spdx**
The create-spdx is been moved to only runs on CI as local builds can run in the majority of time without this
that reduces the build time.

**Buildhistory**
Moves the buildhistory to bitbake conf as this is not a distro
configuration and is more related to a build configuration.