### PR TITLE
base: mcumgr: enable network in compile step

### DIFF
--- a/meta-lmp-base/recipes-devtools/mcumgr/mcumgr_git.bb
+++ b/meta-lmp-base/recipes-devtools/mcumgr/mcumgr_git.bb
@@ -13,6 +13,9 @@ PV = "v0.0.1+git"
 
 inherit go goarch
 
+# Go modules are currently downloaded during build step
+do_compile[network] = "1"
+
 # OE build default do_compile recipe is creating oddly broken binary
 # To fix this, let's use the same as manual build steps
 # NOTE: The binary is much larger than default recipe


### PR DESCRIPTION
This fixes build error:
| go: github.com/go-ble/ble@v0.0.0-20181002102605-e78417b510a3: Get "https://proxy.golang.org/github.com/go-ble/ble/@v/v0.0.0-20181002102605- e78417b510a3.mod": dial tcp: lookup proxy.golang.org: no such host

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>