### PR TITLE
base: u-boot-ostree-scr-fit: print fiovb.is_secondary_boot

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common-alternative.cmd.in
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common-alternative.cmd.in
@@ -76,6 +76,7 @@ fi
 if test "${fiovb.debug}" = "1"; then
 	echo "${fio_msg} ################ Debug info ###############"
 	echo "${fio_msg} State machine variables:"
+	echo "${fio_msg} fiovb.is_secondary_boot = ${fiovb.is_secondary_boot}"
 	echo "${fio_msg} fiovb.bootcount = ${fiovb.bootcount}"
 	echo "${fio_msg} fiovb.rollback = ${fiovb.rollback}"
 	echo "${fio_msg} fiovb.upgrade_available = ${fiovb.upgrade_available}"


### PR DESCRIPTION
Print fiovb.is_secondary_boot when debug prints are enabled.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>