### PR TITLE
mcumgr: fix build with clang and bump

### DIFF
--- a/meta-lmp-base/conf/distro/include/non-clangable.inc
+++ b/meta-lmp-base/conf/distro/include/non-clangable.inc
@@ -66,6 +66,13 @@ OBJCOPY:pn-docker-ce:toolchain-clang = "${HOST_PREFIX}objcopy"
 STRIP:pn-docker-compose:toolchain-clang = "${HOST_PREFIX}strip"
 OBJCOPY:pn-docker-compose:toolchain-clang = "${HOST_PREFIX}objcopy"
 
+# ERROR: mcumgr-v0.0.1+git-r0 do_package: Fatal errors occurred in subprocesses:
+# Command '['x86_64-lmp-linux-llvm-strip', '--remove-section=.comment', '--remove-section=.note', '/srv/oe/build/tmp-lmp/work/corei7-64-lmp-linux/mcumgr/v0.0.1+git-r0/package/usr/bin/mcumgr']' returned non-zero exit status 1.
+# Subprocess output:x86_64-lmp-linux-llvm-strip: error: SHT_STRTAB string table section [index 9] is non-null terminated
+# ERROR: Task (/srv/oe/build/conf/../../layers/meta-lmp/meta-lmp-base/recipes-devtools/mcumgr/mcumgr_git.bb:do_package) failed with exit code '1'
+STRIP:pn-mcumgr:toolchain-clang = "${HOST_PREFIX}strip"
+OBJCOPY:pn-mcumgr:toolchain-clang = "${HOST_PREFIX}objcopy"
+
 # qemuarm64-secureboot
 # | ld.lld: error: cannot open /usr/lib/clang/14.0.3/lib/linux/libclang_rt.builtins-aarch64.a: No such file or directory
 #  /srv/oe/build/conf/../../layers/meta-lmp/meta-lmp-base/recipes-security/optee/optee-os-fio_3.17.0.bb:do_compile

--- a/meta-lmp-base/recipes-devtools/mcumgr/mcumgr_git.bb
+++ b/meta-lmp-base/recipes-devtools/mcumgr/mcumgr_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 
 GO_IMPORT = "github.com/apache/mynewt-mcumgr-cli/mcumgr"
 SRC_URI = "git://github.com/apache/mynewt-mcumgr-cli;protocol=https;branch=master"
-SRCREV = "0ba791a8d336bc751598be36099998439184b033"
+SRCREV = "5c56bd24066c780aad5836429bfa2ecc4f9a944c"
 
 UPSTREAM_CHECK_COMMITS = "1"
 PV = "v0.0.1+git"

--- a/meta-lmp-base/recipes-devtools/mcumgr/mcumgr_git.bb
+++ b/meta-lmp-base/recipes-devtools/mcumgr/mcumgr_git.bb
@@ -11,7 +11,7 @@ SRCREV = "0ba791a8d336bc751598be36099998439184b033"
 UPSTREAM_CHECK_COMMITS = "1"
 PV = "v0.0.1+git"
 
-inherit go goarch
+inherit go
 
 # OE build default do_compile recipe is creating oddly broken binary
 # To fix this, let's use the same as manual build steps


### PR DESCRIPTION
- base: mcumgr: bump 5c56bd
```
Changelog:
- chore: upgrade deps
- Merge pull request #26 from AudioStreamingPlatform/master
- Added LICENSE file
```
- base: mcumgr: relay only on go that uses goarch underline
```
grep -rn goarch openembedded-core/meta/classes/go.bbclass
openembedded-core/meta/classes/go.bbclass:1:inherit goarch
```
- base: non-clangable: add mcumgr
```
llvm-strip fails with:

ERROR: mcumgr-v0.0.1+git-r0 do_package: Fatal errors occurred in subprocesses:
Command '['x86_64-lmp-linux-llvm-strip', '--remove-section=.comment', '--remove-section=.note', '/srv/oe/build/tmp-lmp/work/corei7-64-lmp-linux/mcumgr/v0.0.1+git-r0/package/usr/bin/mcumgr']' returned non-zero exit status 1.
Subprocess output:x86_64-lmp-linux-llvm-strip: error: SHT_STRTAB string table section [index 9] is non-null terminated
ERROR: Task (/srv/oe/build/conf/../../layers/meta-lmp/meta-lmp-base/recipes-devtools/mcumgr/mcumgr_git.bb:do_package) failed with exit code '1'
```
Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>