### PR TITLE
base: images: move i2c-tools to feature-debug

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-feature-debug.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-debug.inc
@@ -10,4 +10,5 @@ CORE_IMAGE_BASE_INSTALL += " \
     devmem2 \
     curl \
     dtc \
+    i2c-tools \
 "

--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -35,7 +35,6 @@ CORE_IMAGE_BASE_INSTALL += " \
     mtd-utils \
     sudo \
     zram \
-    i2c-tools \
 "
 
 # Additional packages when sota is available


### PR DESCRIPTION
Move i2c-tools package to lmp-feature-debug, as it's mainly used for SE05x communication debugging.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>