### PR TITLE
os-release: bypass the allarch_package_arch_handler

### DIFF
--- a/meta-lmp-base/recipes-core/os-release/os-release.bbappend
+++ b/meta-lmp-base/recipes-core/os-release/os-release.bbappend
@@ -17,6 +17,11 @@ IMAGE_ID = "${LMP_FACTORY_IMAGE}"
 IMAGE_VERSION = "${H_BUILD}"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+# to set the PACKAGE_ARCH we need to bypass
+# the allarch_package_arch_handler from allarch.bbclass
+python allarch_package_arch_handler () {
+    pass
+}
 
 inherit deploy
 


### PR DESCRIPTION
This is a fixup for 96bc0769 os-release: set PACKAGE_ARCH machine dependent

To set the PACKAGE_ARCH we need to bypass the allarch_package_arch_handler from allarch.bbclass otherwise they will set the PACKAGE_ARCH=all regardless of what is defined elsewhere.

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>