### PR TITLE
base: kmeta-linux-lmp-5.15.y: bump to 9ec0e7d2

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.15.y"
-KERNEL_META_COMMIT ?= "852f54a8c5ae45534a7e2d5ac56010ab5b79e4e1"
+KERNEL_META_COMMIT ?= "9ec0e7d280e236257b65b045f78aa20dcabd8083"


### PR DESCRIPTION
Relevant changes:
- 9ec0e7d2 bsp: stm32: remove features that don't exist on this chip
- e6acc158 bsp: stm32: merge disco and eval fragments
- 928422ae bsp: stm32: remove features that don't exist on this chip

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>