### PR TITLE
base: optee-os-fio: deploy build configuration

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio.inc
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio.inc
@@ -71,6 +71,11 @@ do_deploy() {
 
     # Link tee.bin so it can be consumed by recipes such as imx-boot
     ln -sf optee/tee-pager_v2.bin ${DEPLOYDIR}/tee.bin
+
+    # Deploy optee_os config used during build
+    install -D -m 644 ${B}/conf.mk ${DEPLOYDIR}/${PN}-config-${MACHINE}-${PV}-${PR}
+    ln -sf ${PN}-config-${MACHINE}-${PV}-${PR} ${DEPLOYDIR}/${PN}-config-${MACHINE}
+    ln -sf ${PN}-config-${MACHINE}-${PV}-${PR} ${DEPLOYDIR}/${PN}-config
 }
 
 addtask deploy before do_build after do_install


### PR DESCRIPTION
Publish the final configuration used as part of the recipe build into the LmP deploy folder.

Having the conf.mk file published is quite useful when debugging configuration issues without having to build it locally.

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>