### PR TITLE
recipes-support: update full_image for imx8qm-mek-sec

### DIFF
--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek-sec/full_image.uuu.in
@@ -1,11 +1,6 @@
 uuu_version 1.3.102
 
 SDPS: boot -f imx-boot-mfgtool.signed
-CFG: FB: -vid 0x0525 -pid 0x4000
-CFG: FB: -vid 0x0525 -pid 0x4025
-CFG: FB: -vid 0x0525 -pid 0x402F
-CFG: FB: -vid 0x0525 -pid 0x4030
-CFG: FB: -vid 0x0525 -pid 0x4031
 
 SDPU: delay 1000
 SDPU: write -f u-boot-mfgtool.itb
@@ -19,13 +14,21 @@ SDPV: write -f u-boot-mfgtool.itb
 SDPV: jump
 # }
 
+FB: delay 100
 FB: ucmd setenv fastboot_dev mmc
-FB: ucmd setenv emmc_dev 0
-FB: ucmd mmc dev ${emmc_dev} 1; mmc erase 0 0x3C00
+FB: ucmd setenv mmcdev 0
+FB: ucmd mmc dev ${mmcdev} 1; mmc erase 0 0x3C00
+FB: flash bootloader ../imx-boot-@@MACHINE@@.signed
+FB: flash bootloader_s ../imx-boot-@@MACHINE@@.signed
+FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
+FB: flash bootloader2_s ../u-boot-@@MACHINE@@.itb
+FB: ucmd mmc partconf 0 0 1 0
+
+FB: ucmd mmc dev ${mmcdev}
 
 # Clear fiovb vars
 FB: ucmd imx_is_closed || true
-FB: ucmd if fiovb init ${emmc_dev} && test -n "${board_is_closed}"; then setenv fiovb_rpmb 1; else true; fi
+FB: ucmd if fiovb init ${mmcdev} && test -n "${board_is_closed}"; then setenv fiovb_rpmb 1; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue bootcount 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue rollback 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue upgrade_available 0; else true; fi
@@ -35,9 +38,4 @@ FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue debug 0; 
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue is_secondary_boot 0; else true; fi
 
 FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
-FB: flash bootloader ../imx-boot-@@MACHINE@@.signed
-FB: flash bootloader_s ../imx-boot-@@MACHINE@@.signed
-FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
-FB: flash bootloader2_s ../u-boot-@@MACHINE@@.itb
-FB: ucmd mmc partconf 0 0 1 0
 FB: done

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek/bootloader.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek/bootloader.uuu.in
@@ -1,11 +1,6 @@
 uuu_version 1.3.102
 
 SDPS: boot -f imx-boot-mfgtool
-CFG: FB: -vid 0x0525 -pid 0x4000
-CFG: FB: -vid 0x0525 -pid 0x4025
-CFG: FB: -vid 0x0525 -pid 0x402F
-CFG: FB: -vid 0x0525 -pid 0x4030
-CFG: FB: -vid 0x0525 -pid 0x4031
 
 SDPU: delay 1000
 SDPU: write -f u-boot-mfgtool.itb


### PR DESCRIPTION
This was after trying and failing on real hardware.

This script successfully installs on a closed board provided that the dtb and u-boot config are correct.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>