### PR TITLE
base: lmp-base: define INITRD_IMAGE_LIVE

### DIFF
--- a/meta-lmp-base/conf/distro/lmp-base.conf
+++ b/meta-lmp-base/conf/distro/lmp-base.conf
@@ -16,3 +16,5 @@ DISTRO_FEATURES_DEFAULT:remove = "modsign"
 
 # Facilitate debugging
 DISTRO_FEATURES_DEFAULT:append = " debuginfod lmpdebug"
+
+INITRD_IMAGE_LIVE ?= ""


### PR DESCRIPTION
Otherwise is not possible to build lmp-base distro using intel-corei7-64 target machine.

```
ERROR: Nothing PROVIDES '${@'' (but /lmp/build/conf/../../layers/meta-lmp/meta-lmp-base/recipes-samples/images/lmp-base-console-image.bb DEPENDS on or otherwise requires it)
ERROR: Required build target 'lmp-base-console-image' has no buildable providers.
Missing or unbuildable dependency chain was: ['lmp-base-console-image', "${@'"]
```

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>