### PR TITLE
base: lmp-device-register: bump to ccd4499

### DIFF
--- a/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl glib-2.0"
 
-SRCREV = "959126ae2350851eee33b140b17eb056e77046ac"
+SRCREV = "ccd449989b8e97b5c401fba993d306e28514d443"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https;branch=master"
 


### PR DESCRIPTION
Relevant changes:
- ccd4499 Print log message of each error

Signed-off-by: Mike <mike.sul@foundries.io>