### PR TITLE
base: lmp-feature-se05x: include fio-se05x-cli

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-feature-se05x.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-se05x.inc
@@ -1,5 +1,6 @@
 # SE05X packages
 CORE_IMAGE_BASE_INSTALL += " \
+    fio-se05x-cli \
     plug-and-trust-seteec \
     python3-plug-and-trust-ssscli \
 "


### PR DESCRIPTION
Include fio-se05x-cli as part of lmp-feature-se050x as that is the tool we're now maintaining.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>