### PR TITLE
bsp: mfgtool-files: imx8qm-mek-sec: drop custom vendor id

### DIFF
--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek-sec/close.uuu
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek-sec/close.uuu
@@ -1,11 +1,6 @@
 uuu_version 1.3.102
 
 SDPS: boot -f imx-boot-mfgtool.signed
-CFG: FB: -vid 0x0525 -pid 0x4000
-CFG: FB: -vid 0x0525 -pid 0x4025
-CFG: FB: -vid 0x0525 -pid 0x402F
-CFG: FB: -vid 0x0525 -pid 0x4030
-CFG: FB: -vid 0x0525 -pid 0x4031
 
 SDPU: delay 1000
 SDPU: write -f u-boot-mfgtool.itb

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek-sec/fuse.uuu
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek-sec/fuse.uuu
@@ -1,11 +1,6 @@
 uuu_version 1.3.102
 
 SDPS: boot -f imx-boot-mfgtool.signed
-CFG: FB: -vid 0x0525 -pid 0x4000
-CFG: FB: -vid 0x0525 -pid 0x4025
-CFG: FB: -vid 0x0525 -pid 0x402F
-CFG: FB: -vid 0x0525 -pid 0x4030
-CFG: FB: -vid 0x0525 -pid 0x4031
 
 SDPU: delay 1000
 SDPU: write -f u-boot-mfgtool.itb


### PR DESCRIPTION
These values were taken from apalis-imx8 (toradex) and are not required for NXP-based boards.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>