### PR TITLE
base: u-boot-fio: imx-2022.04: bump to b4d62dc03a1

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
@@ -1,6 +1,6 @@
 require u-boot-fio-common.inc
 
-SRCREV = "9d8a0ac2e51ab8b3250e1443a2fd7a872561ebe3"
+SRCREV = "57a29d901c11df089364f38ccc21b41117cfb9f3"
 SRCBRANCH = "2022.04+lf-5.15.52-2.1.0-fio"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 


### PR DESCRIPTION
Relevant changes:
- b4d62dc03a1 [FIO tosquash] imx8qm_mek: fix build issues for CONFIG_MMCROOT

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>