### PR TITLE
base: u-boot-fio: 2022.04: bump to 3b47abb216

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2022.04.bb
@@ -1,5 +1,5 @@
 require u-boot-fio-common.inc
 
-SRCREV = "ab2a05b9108c0df9963c7bf3630dcb4fa7871e69"
+SRCREV = "3b47abb2169204408ed93924e117dc0b6f0a619f"
 SRCBRANCH = "2022.04+fio"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"


### PR DESCRIPTION
Relevant changes:
- 3b47abb216 [FIO internal] ARM: dts: stm32mp157c-ev1: add optee node
- 2fa8f7459f [FIO internal] ARM: dts: stm32mp157c-dk2: dm-pre-reloc for optee
- 9bb61a8858 [FIO squash] drivers: tee: i2c: fix format arguments size
- 6c259e2e23 [FIO internal] ARM: dts: stm32mp157c-dk2-u-boot: add optee node with rpmb dev
- 4c157f1b94 [FIO internal] fastboot: add oem ucmd for remote u-boot commands

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>