### PR TITLE
base: u-boot-fio: imx-2022.04: bump to 7bd9d0a8fc

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
@@ -1,6 +1,6 @@
 require u-boot-fio-common.inc
 
-SRCREV = "57a29d901c11df089364f38ccc21b41117cfb9f3"
+SRCREV = "7bd9d0a8fcc854d969d2420c29114fed1a2693e5"
 SRCBRANCH = "2022.04+lf-5.15.52-2.1.0-fio"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 


### PR DESCRIPTION
Relevant changes:
- 7bd9d0a8fc [FIO tosquash] imx8: adjust address for FIT buffer

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>