### PR TITLE
-rt for imx6ul*

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.15.y"
-KERNEL_META_COMMIT ?= "c29ac0b1adc6bf432e2ed46b987835f7cc10666c"
+KERNEL_META_COMMIT ?= "9ad1611bf62064c268b3e95709292350b3c9d6f3"


### PR DESCRIPTION
Relevant changes:
- 9ad1611 bsp: imx6ulevk: add preempt-rt definition
- b719fd2 bsp: imx6ullevk: add preempt-rt definition

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>