### PR TITLE
base: recipe-sota: aktualizr-lite: bump to 73a1bb7

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "e5bbb3aac72593cc1854857114e5388ef0a28311"
+SRCREV:lmp = "73a1bb7d0cc89efb079cb771d0604cce77c8d549"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
Relevant changes:
- 73a1bb7 ostree: Add a flag to turn ON/OFF update blocking
- 465b473 boot: Block update if boot fw update is in progress
- e83d38a aktualizr: Switch to libaktualizr 2022.11+fio
- b4ac6ef apps: Prune images only if pruning is enabled
- 94d72a4 docker: Do auth according to the spec

Signed-off-by: Mike <mike.sul@foundries.io>