### PR TITLE
base: kmeta-linux-lmp-5.15.y: bump to 1b0ca2f

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.15.y"
-KERNEL_META_COMMIT ?= "9ad1611bf62064c268b3e95709292350b3c9d6f3"
+KERNEL_META_COMMIT ?= "1b0ca2f70f38a0d86a9c6e1b79db4c3125441d8f"


### PR DESCRIPTION
This fixes a wired ethernet on imx8mp.

Relevant changes:
- 1b0ca2f bsp: imx8mp-lpddr4-evk: enable REALTEK_PHY
- 5f314c5 bsp: imx: apalis-imx6 enable DRM and HDMI

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>