### PR TITLE
base: non-clangable: optee-sks: force gcc

### DIFF
--- a/meta-lmp-base/conf/distro/include/non-clangable.inc
+++ b/meta-lmp-base/conf/distro/include/non-clangable.inc
@@ -81,6 +81,7 @@ OBJCOPY:pn-mcumgr:toolchain-clang = "${HOST_PREFIX}objcopy"
 TOOLCHAIN:pn-optee-os-fio = "gcc"
 TOOLCHAIN:pn-optee-os-tadevkit = "gcc"
 TOOLCHAIN:pn-optee-test = "gcc"
+TOOLCHAIN:pn-optee-sks = "gcc"
 
 # apalis-imx6-sec
 # imx8mm-lpddr4-evk-sec


### PR DESCRIPTION
Align toolchain with the same one used by optee-os to avoid similar build failures.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>