### PR TITLE
base: lmp-device-register: bump to 2bb3a61

### DIFF
--- a/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl glib-2.0"
 
-SRCREV = "ccd449989b8e97b5c401fba993d306e28514d443"
+SRCREV = "2bb3a61bfc908e95b56eb2d4cd38ea09abb9846b"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https;branch=master"
 


### PR DESCRIPTION
Relevant changes:
- 2bb3a61 Extend the check whether a device is registered

Signed-off-by: Mike <mike.sul@foundries.io>