### PR TITLE
base: kmeta-linux-lmp-5.15.y: bump to d7be55c1

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.15.y"
-KERNEL_META_COMMIT ?= "1b0ca2f70f38a0d86a9c6e1b79db4c3125441d8f"
+KERNEL_META_COMMIT ?= "d7be55c1906434fac57ec86648dbbf3d80fde8ab"


### PR DESCRIPTION
Relevant changes:
- d7be55c1 bsp: imx8mn-evk: add options for jailhouse
- adee325b bsp: imx8mqevk: move UIO_IVSHMEM to module
- a2e337cb bsp: imx8mmevk: add options for jailhouse

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>