### PR TITLE
base: optee-os-fio: 3.18: bump to 06944aba5

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.18.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.18.0.bb
@@ -1,5 +1,5 @@
 require optee-os-fio.inc
 
 PV = "3.18.0+git"
-SRCREV = "f2159b5a0bac1bd4ff0887f91d56543d1b91e8af"
+SRCREV = "06944aba585de4119e9d5f7b83beab03eed5b8e9"
 SRCBRANCH = "3.18+fio"


### PR DESCRIPTION
Relevant changes:
- 06944aba5 [FIO fromlist] crypto: drivers: se050-f: rsa: can fallback to software operations
- b4b1ea1ff [FIO fromlist] crypto: drivers: se050-f: ecc: can fallback to software operations
- 692276b28 [FIO fromlist] crypto: drivers: se050: ecc: fallback to software operations
- ef0248b38 [FIO fromlist] crypto: drivers: se050: rsa: fallback to software operations
- 9bc763021 [FIO fromlist] crypto: drivers: se050-f: rsa: fix support
- 873334ea2 [FIO fromlist] crypto: drivers: se050: adaptor: provide the oefid interface
- 16ab116b7 [FIO fromtree] core: crypto-api: rsa: pass algorithm to implementation
- d729f2aa9 [FIO internal]: se050: scp03: prohibit derived keys without RPMB ready.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>