### PR TITLE
recipes-support: Correct apalis-imx8-sec full_image.uuu script

### DIFF
--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx8-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/apalis-imx8-sec/full_image.uuu.in
@@ -19,13 +19,21 @@ SDPV: write -f u-boot-mfgtool.itb
 SDPV: jump
 # }
 
+FB: delay 100
 FB: ucmd setenv fastboot_dev mmc
-FB: ucmd setenv emmc_dev 0
-FB: ucmd mmc dev ${emmc_dev} 1; mmc erase 0 0x3C00
+FB: ucmd setenv mmcdev 0
+FB: ucmd mmc dev ${mmcdev} 1; mmc erase 0 0x3C00
+FB: flash bootloader ../imx-boot-@@MACHINE@@.signed
+FB: flash bootloader_s ../imx-boot-@@MACHINE@@.signed
+FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
+FB: flash bootloader2_s ../u-boot-@@MACHINE@@.itb
+FB: ucmd mmc partconf 0 0 1 0
+
+FB: ucmd mmc dev ${mmcdev}
 
 # Clear fiovb vars
 FB: ucmd imx_is_closed || true
-FB: ucmd if fiovb init ${emmc_dev} && test -n "${board_is_closed}"; then setenv fiovb_rpmb 1; else true; fi
+FB: ucmd if fiovb init ${mmcdev} && test -n "${board_is_closed}"; then setenv fiovb_rpmb 1; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue bootcount 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue rollback 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue upgrade_available 0; else true; fi
@@ -35,9 +43,4 @@ FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue debug 0; 
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue is_secondary_boot 0; else true; fi
 
 FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
-FB: flash bootloader ../imx-boot-@@MACHINE@@.signed
-FB: flash bootloader_s ../imx-boot-@@MACHINE@@.signed
-FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
-FB: flash bootloader2_s ../u-boot-@@MACHINE@@.itb
-FB: ucmd mmc partconf 0 0 1 0
 FB: done


### PR DESCRIPTION
This suffers from the same order issue as the MEK. this should be almost the same as the MEK at this point.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>