### PR TITLE
base: optee-os-fio: 3.18: bump to 382fb9d84

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.18.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.18.0.bb
@@ -1,5 +1,5 @@
 require optee-os-fio.inc
 
 PV = "3.18.0+git"
-SRCREV = "06944aba585de4119e9d5f7b83beab03eed5b8e9"
+SRCREV = "382fb9d8445abde10429cfae636a68413fc51640"
 SRCBRANCH = "3.18+fio"


### PR DESCRIPTION
Relevant changes:
- 382fb9d84 [FIO fromlist] crypto: se050: fix unused function warning when loglevel < 2
- ad8d5279e [FIO fromlist] crypto: drivers: se050-f: rsa: can fallback to softw-ops
- ebebbf4f2 [FIO fromlist] crypto: drivers: se050: rsa: fallback to softw-ops
- e942dd714 Revert "[FIO fromlist] crypto: drivers: se050: rsa: fallback to software operations"
- 443eb7f85 Revert "[FIO fromlist] crypto: drivers: se050-f: rsa: can fallback to software operations"

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>