### PR TITLE
bsp: u-boot: beaglebone-yocto: replace addr_fit with rdaddr

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/beaglebone-yocto/lmp.cfg
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/beaglebone-yocto/lmp.cfg
@@ -3,7 +3,7 @@ CONFIG_FIT_VERBOSE=y
 CONFIG_FIT_SIGNATURE=y
 # CONFIG_ANDROID_BOOT_IMAGE is not set
 CONFIG_USE_BOOTCOMMAND=y
-CONFIG_BOOTCOMMAND="run findfdt; if test ${devtype}1 = 1; then setenv devtype mmc; fi; if test ${devnum}x = x; then setenv devnum 0; fi; fatload ${devtype} ${devnum}:1 ${addr_fit} /boot.itb; setenv verify 1; source ${addr_fit}; reset"
+CONFIG_BOOTCOMMAND="run findfdt; if test ${devtype}1 = 1; then setenv devtype mmc; fi; if test ${devnum}x = x; then setenv devnum 0; fi; fatload ${devtype} ${devnum}:1 ${rdaddr} /boot.itb; setenv verify 1; source ${rdaddr}; reset"
 CONFIG_BOOTCOUNT_LIMIT=y
 CONFIG_BOOTCOUNT_ENV=y
 CONFIG_BOOTCOUNT_BOOTLIMIT=3

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/beaglebone-yocto/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/beaglebone-yocto/boot.cmd
@@ -3,8 +3,8 @@ setenv bootlimit 3
 
 setenv bootcmd_resetvars 'setenv kernel_image; setenv bootargs; setenv kernel_image2; setenv bootargs2'
 setenv bootcmd_otenv 'run bootcmd_resetvars; ext4load ${devtype} ${devnum}:2 ${loadaddr} /boot/loader/uEnv.txt; env import -t ${loadaddr} ${filesize} kernel_image bootargs kernel_image2 bootargs2'
-setenv bootcmd_load_f 'ext4load ${devtype} ${devnum}:2 ${addr_fit} "/boot"${kernel_image}'
-setenv bootcmd_run 'bootm ${addr_fit}#conf@@FIT_NODE_SEPARATOR@@${fdtfile}'
+setenv bootcmd_load_f 'ext4load ${devtype} ${devnum}:2 ${rdaddr} "/boot"${kernel_image}'
+setenv bootcmd_run 'bootm ${rdaddr}#conf@@FIT_NODE_SEPARATOR@@${fdtfile}'
 setenv bootcmd_rollbackenv 'setenv kernel_image ${kernel_image2}; setenv bootargs ${bootargs2}'
 setenv bootcmd_set_rollback 'if test ! "${rollback}" = "1"; then setenv rollback 1; setenv upgrade_available 0; saveenv; fi'
 setenv bootostree 'run bootcmd_load_f; run bootcmd_run'


### PR DESCRIPTION
addr_fit was removed from the default environment since u-boot ff8f277e9121c6636e21bb7d7381c4dcac2a596b, so replace with rdaddr instead as that is high and large enough for loading the fit image.

This fixes a boot issue with u-boot 2022.04 on a clean flash (default environment).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>