### PR TITLE
base: optee-os-fio: 3.18: bump to 3a1ec4c9d

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.18.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.18.0.bb
@@ -1,5 +1,5 @@
 require optee-os-fio.inc
 
 PV = "3.18.0+git"
-SRCREV = "382fb9d8445abde10429cfae636a68413fc51640"
+SRCREV = "3a1ec4c9d596e388d2a6d1251ba1029e29f7552b"
 SRCBRANCH = "3.18+fio"


### PR DESCRIPTION
Relevant changes:
- 3a1ec4c9d [FIO toup] drivers: se050: fix regression

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>