### PR TITLE
bsp: linux-lmp: apalis-imx6: fix HDMI interface

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp/apalis-imx6/0001-FIO-extra-arch-arm-dts-imx6q-apalis-disable-lcdif-pa.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp/apalis-imx6/0001-FIO-extra-arch-arm-dts-imx6q-apalis-disable-lcdif-pa.patch
@@ -1,0 +1,59 @@
+From a5f5c57ecb1a646d379a1613a21328de82767dbc Mon Sep 17 00:00:00 2001
+From: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
+Date: Tue, 27 Dec 2022 17:51:12 +0200
+Subject: [PATCH] [FIO extra] arch: arm: dts: imx6q-apalis: disable lcdif panel
+
+If a lcdif panel is disconnected, it's probing always returns
+-EPROBE_DEFER. This prevents "imx-drm display-subsystem" from having
+bound to all sub-devices, including imx-ipuv3-crtc and dwhdmi-imx.
+The display-subsystem ends up unbound and noone display interface
+turns up.
+Disable LCDIF panel to unblock using al other display interfaces.
+
+Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
+---
+
+ arch/arm/boot/dts/imx6q-apalis-eval.dts       | 1 +
+ arch/arm/boot/dts/imx6q-apalis-ixora-v1.1.dts | 1 +
+ arch/arm/boot/dts/imx6q-apalis-ixora.dts      | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/arch/arm/boot/dts/imx6q-apalis-eval.dts b/arch/arm/boot/dts/imx6q-apalis-eval.dts
+index a0683b4aeca1..b967c25c90e7 100644
+--- a/arch/arm/boot/dts/imx6q-apalis-eval.dts
++++ b/arch/arm/boot/dts/imx6q-apalis-eval.dts
+@@ -78,6 +78,7 @@ panel: panel {
+ 		compatible = "edt,et057090dhu";
+ 		backlight = <&backlight>;
+ 		power-supply = <&reg_3v3_sw>;
++		status = "disabled";
+ 
+ 		port {
+ 			lcd_panel_in: endpoint {
+diff --git a/arch/arm/boot/dts/imx6q-apalis-ixora-v1.1.dts b/arch/arm/boot/dts/imx6q-apalis-ixora-v1.1.dts
+index 86e84781cf5d..31e43f93f0d2 100644
+--- a/arch/arm/boot/dts/imx6q-apalis-ixora-v1.1.dts
++++ b/arch/arm/boot/dts/imx6q-apalis-ixora-v1.1.dts
+@@ -78,6 +78,7 @@ panel: panel {
+ 		 */
+ 		compatible = "edt,et057090dhu";
+ 		backlight = <&backlight>;
++		status = "disabled";
+ 
+ 		port {
+ 			lcd_panel_in: endpoint {
+diff --git a/arch/arm/boot/dts/imx6q-apalis-ixora.dts b/arch/arm/boot/dts/imx6q-apalis-ixora.dts
+index 62e72773e53b..c147a42c2e5a 100644
+--- a/arch/arm/boot/dts/imx6q-apalis-ixora.dts
++++ b/arch/arm/boot/dts/imx6q-apalis-ixora.dts
+@@ -77,6 +77,7 @@ panel: panel {
+ 		 */
+ 		compatible = "edt,et057090dhu";
+ 		backlight = <&backlight>;
++		status = "disabled";
+ 
+ 		port {
+ 			lcd_panel_in: endpoint {
+-- 
+2.38.1
+

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp_git.bbappend
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp_git.bbappend
@@ -1,6 +1,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 # fix OP-TEE performance regression for Cortex-A9 i.MX6QDL
+# fix HDMI for Apalis-iMX6
 SRC_URI:append:apalis-imx6 = " \
     file://0001-MLK-16912-PL310-unlock-ways-during-initialization.patch \
+    file://0001-FIO-extra-arch-arm-dts-imx6q-apalis-disable-lcdif-pa.patch \
 "


### PR DESCRIPTION
Add a patch to make HDMI interface work.

Note, this patch disables a lcdif panel. If the panel is connected to a board, it is safe to enable it back - in this case, it won't break other interfaces.

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>