### PR TITLE
base: dbus: specify runstatedir to use /run

### DIFF
--- a/meta-lmp-base/recipes-core/dbus/dbus_%.bbappend
+++ b/meta-lmp-base/recipes-core/dbus/dbus_%.bbappend
@@ -1,0 +1,2 @@
+# Avoid warnings with systemd
+EXTRA_OECONF += "--runstatedir=/run"


### PR DESCRIPTION
From oe-core master (4df1a16e5c38d0fb724f63d37cc032aa37fa122f), specify runstatedir to use /run directly (instead of the default /var/run), to fix the following runtime warning from systemd:

systemd-tmpfiles[350]: /usr/lib/tmpfiles.d/dbus.conf:13: Line references path below legacy directory /var/run/, updating /var/run/dbus/containers → /run/dbus/containers; please update the tmpfiles.d/ drop-in file accordingly.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>