### PR TITLE
base: lmp: drop BBMASK for meta-st-stm32mp make-mod-scripts

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -127,7 +127,6 @@ BBMASK += " \
     /meta-st-stm32mp/recipes-core/busybox/busybox_%.bbappend \
     /meta-st-stm32mp/recipes-graphics/drm/libdrm_2.4.110.bbappend \
     /meta-st-stm32mp/recipes-bsp/trusted-firmware-a/tf-a-stm32mp_2.6.bb \
-    /meta-st-stm32mp/recipes-kernel/make-mod-scripts/make-mod-scripts_%.bbappend \
 "
 
 # disable xsct tarball by default (xilinx)


### PR DESCRIPTION
bbappend removed in latest meta-st-stm32mp update (a033970).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>