### PR TITLE
base: fioconfig: Bump revision for foundriesio/go-ecies

### DIFF
--- a/meta-lmp-base/recipes-support/fioconfig/fioconfig_git.bb
+++ b/meta-lmp-base/recipes-support/fioconfig/fioconfig_git.bb
@@ -11,7 +11,7 @@ SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO};branch=main \
 	file://fioconfig.path \
 	file://fioconfig-extract.service \
 "
-SRCREV = "9fd137b5f3afa32a580c4f89e390dae9287a8196"
+SRCREV = "c7146409461c37a8e711b0ecadc5c0659e0a947e"
 
 UPSTREAM_CHECK_COMMITS = "1"
 


### PR DESCRIPTION
This bumps fioconfig to pull in the changes which
remove the go-ethereum dependency in favor of the foundriesio/go-ecies.

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>