### PR TITLE
Remove meta-ti-extras layer dependencies

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/ti-sci-fw/ti-sci-fw_git.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/ti-sci-fw/ti-sci-fw_git.bbappend
@@ -1,0 +1,2 @@
+# set a default value for TI_K3_SECDEV_INSTALL_DIR
+export TI_K3_SECDEV_INSTALL_DIR = "${STAGING_DIR_NATIVE}${datadir}/ti/ti-k3-secdev"

--- a/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-ti/secdev/ti-k3-secdev_git.bb
+++ b/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-ti/secdev/ti-k3-secdev_git.bb
@@ -1,0 +1,38 @@
+DESCRIPTION = "Security development tools for High-Security(HS) TI K3 processors."
+HOMEPAGE = "https://git.ti.com/cgit/security-development-tools/core-secdev-k3"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://manifest/k3-secdev-0.2-manifest.html;md5=f632a78870cc64550078d7b3cbac0892"
+
+require recipes-ti/includes/ti-paths.inc
+
+# Native host tool only
+COMPATIBLE_MACHINE = "null"
+COMPATIBLE_MACHINE:class-native = "(.*)"
+COMPATIBLE_MACHINE:class-nativesdk = "(.*)"
+
+GIT_URI = "git://git.ti.com/git/security-development-tools/core-secdev-k3.git"
+GIT_PROTOCOL = "https"
+GIT_BRANCH = "master"
+GIT_SRCREV = "eb2c4d734487e5095b94cef3fd7213ee71d9e016"
+
+SRC_URI = "${GIT_URI};protocol=${GIT_PROTOCOL};branch=${GIT_BRANCH}"
+SRCREV = "${GIT_SRCREV}"
+
+S = "${WORKDIR}/git"
+
+do_install() {
+    CP_ARGS="-Prf --preserve=mode,links,timestamps --no-preserve=ownership"
+    install -d ${D}${TI_K3_SECDEV_INSTALL_DIR_RECIPE}
+    cp ${CP_ARGS} ${S}/* ${D}${TI_K3_SECDEV_INSTALL_DIR_RECIPE}
+}
+
+FILES:${PN} += "${TI_K3_SECDEV_INSTALL_DIR_RECIPE}"
+
+INSANE_SKIP:${PN} = "arch ldflags file-rdeps"
+
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-ti/secdev/ti-k3-secdev_git.bb
+++ b/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-ti/secdev/ti-k3-secdev_git.bb
@@ -4,7 +4,9 @@ SECTION = "devel"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://manifest/k3-secdev-0.2-manifest.html;md5=f632a78870cc64550078d7b3cbac0892"
 
-require recipes-ti/includes/ti-paths.inc
+# set a default value for TI_K3_SECDEV_INSTALL_DIR_RECIPE
+export TI_K3_SECDEV_INSTALL_DIR_RECIPE = "${datadir}/ti/ti-k3-secdev"
+include recipes-ti/includes/ti-paths.inc
 
 # Native host tool only
 COMPATIBLE_MACHINE = "null"


### PR DESCRIPTION
**This is a temporary workaround to remove the dependencie in
meta-ti-extras until the patch is merged upstream.
https://lists.yoctoproject.org/g/meta-ti/message/15567
https://lists.yoctoproject.org/g/meta-ti/message/15568
https://lists.yoctoproject.org/g/meta-ti/message/15569**

The meta-ti-bsp layer is still broken for K3 HS platforms.

The patch [1] makes the check-layer happy again as it does not
fail any more during bitbake parsing but it will be difficult
for the end user to discover this dependency on meta-ti-extras.
On the other side, meta-ti-extras depends on meta-ti-bsp so
this is a circular dependency.

Currently the layer is broken for am62xx-evm/am64xx-evm machines:

```
ERROR: Nothing PROVIDES 'ti-k3-secdev-native' (but mc:k3r5:/srv/oe/build/conf/../../layers/meta-ti/meta-ti-bsp/recipes-bsp/ti-sci-fw/ti-sci-fw_git.bb DEPENDS on or otherwise requires it). Close matches:
  libtspi-dev-native
  makedevs-native
```

[1] - 8e43835c ti-sci-fw: make dependency on meta-ti-extras soft