### PR TITLE
base: lmp: mask meta-st-stm32mp libdrm_2.4.113.bbappend

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -126,6 +126,7 @@ BBMASK += " \
 BBMASK += " \
     /meta-st-stm32mp/recipes-core/busybox/busybox_%.bbappend \
     /meta-st-stm32mp/recipes-graphics/drm/libdrm_2.4.110.bbappend \
+    /meta-st-stm32mp/recipes-graphics/drm/libdrm_2.4.113.bbappend \
     /meta-st-stm32mp/recipes-bsp/trusted-firmware-a/tf-a-stm32mp_2.6.bb \
 "
 


### PR DESCRIPTION
This make possible to build meta-st-stm32mp layer
with oe-core master branch.

https://github.com/STMicroelectronics/meta-st-stm32mp/pull/45

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>