### PR TITLE
bsp: u-boot-ti-staging: deploy u-boot config

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
@@ -1,5 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
+include recipes-bsp/u-boot/u-boot-lmp-common.inc
+
 # From the cicd.dunfell.202301120721 dunfell tag
 SRCREV = "bd53c102458cc39a8b2ab68e19996a2280a4d509"
 


### PR DESCRIPTION
Also include u-boot-lmp-common.inc in order for the final u-boot config to be deployed as part of the build process (facilitates debugging).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>