### PR TITLE
AM6XXX: publish boot firmware files (no MC)

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -568,6 +568,7 @@ KERNEL_IMAGETYPE:sota:k3 = "fitImage"
 KERNEL_IMAGETYPES:sota:k3 = "${KERNEL_IMAGETYPE}"
 PREFERRED_PROVIDER_virtual/kernel:k3 ?= "linux-lmp-ti-staging"
 WKS_FILE_DEPENDS:append:k3 = " virtual/bootloader"
+OSTREE_DEPLOY_USR_OSTREE_BOOT:k3 = "1"
 # multiconfig with the same TMP fails in the rm_work.bbclass
 RM_WORK_EXCLUDE:append:k3 = " texinfo-dummy-native gettext-minimal-native gnu-config"
 

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -586,6 +586,8 @@ UBOOT_LOADADDRESS:am62xx-evm = "0x82000000"
 UBOOT_DTB_LOADADDRESS:am62xx-evm = "0x88000000"
 EFI_PROVIDER:am62xx-evm = ""
 KERNEL_DEVICETREE:append:am62xx-evm = " ${@bb.utils.contains('MACHINE_FEATURES', 'jailhouse', 'ti/k3-am625-base-board-jailhouse.dtbo', '', d)}"
+LMP_BOOT_FIRMWARE_FILES:am62xx-evm = "tispl.bin u-boot.img"
+LMP_BOOT_FIRMWARE_FILES:append:sota:am62xx-evm = " boot.itb"
 
 # TI AM64x
 MACHINE_FEATURES:append:am64xx-evm = " optee"
@@ -601,6 +603,8 @@ UBOOT_ENTRYPOINT:am64xx-evm = "0x82000000"
 UBOOT_LOADADDRESS:am64xx-evm = "0x82000000"
 UBOOT_DTB_LOADADDRESS:am64xx-evm = "0x88000000"
 EFI_PROVIDER:am64xx-evm = ""
+LMP_BOOT_FIRMWARE_FILES:am64xx-evm = "tispl.bin u-boot.img"
+LMP_BOOT_FIRMWARE_FILES:append:sota:am64xx-evm = " boot.itb"
 
 # Nvidia Tegra
 DISTRO_FEATURES:append:tegra = " opengl"

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -584,6 +584,7 @@ UBOOT_ENTRYPOINT:am62xx-evm = "0x82000000"
 UBOOT_LOADADDRESS:am62xx-evm = "0x82000000"
 UBOOT_DTB_LOADADDRESS:am62xx-evm = "0x88000000"
 EFI_PROVIDER:am62xx-evm = ""
+KERNEL_DEVICETREE:append:am62xx-evm = " ${@bb.utils.contains('MACHINE_FEATURES', 'jailhouse', 'ti/k3-am625-base-board-jailhouse.dtbo', '', d)}"
 
 # TI AM64x
 MACHINE_FEATURES:append:am64xx-evm = " optee"
@@ -599,7 +600,6 @@ UBOOT_ENTRYPOINT:am64xx-evm = "0x82000000"
 UBOOT_LOADADDRESS:am64xx-evm = "0x82000000"
 UBOOT_DTB_LOADADDRESS:am64xx-evm = "0x88000000"
 EFI_PROVIDER:am64xx-evm = ""
-KERNEL_DEVICETREE:append:am62xx-evm = " ${@bb.utils.contains('MACHINE_FEATURES', 'jailhouse', 'ti/k3-am625-base-board-jailhouse.dtbo', '', d)}"
 
 # Nvidia Tegra
 DISTRO_FEATURES:append:tegra = " opengl"

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -567,6 +567,7 @@ K3_IMAGE_GEN_SRCREV:ti-soc = "840b06f2624f7ea8a49ec1637cd8574165ad786f"
 KERNEL_IMAGETYPE:sota:k3 = "fitImage"
 KERNEL_IMAGETYPES:sota:k3 = "${KERNEL_IMAGETYPE}"
 PREFERRED_PROVIDER_virtual/kernel:k3 ?= "linux-lmp-ti-staging"
+WKS_FILE_DEPENDS:append:k3 = " virtual/bootloader"
 # multiconfig with the same TMP fails in the rm_work.bbclass
 RM_WORK_EXCLUDE:append:k3 = " texinfo-dummy-native gettext-minimal-native gnu-config"
 

--- a/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/lmp-boot-firmware/lmp-boot-firmware.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/lmp-boot-firmware/lmp-boot-firmware.bbappend
@@ -1,0 +1,4 @@
+# Depend on scr-fit as boot.itb is not yet part of the boot firmware
+TI_BOOT_SCRIPT_DEPLOY ?= ""
+TI_BOOT_SCRIPT_DEPLOY:sota:k3 = "u-boot-ostree-scr-fit:do_deploy"
+do_install[depends] += "${TI_BOOT_SCRIPT_DEPLOY}"


### PR DESCRIPTION
Similar to https://github.com/foundriesio/meta-lmp/pull/1020 but without deploying/installing the MC related files (k3-r5 firmware).