### PR TITLE
base: remove 10-lite-public-stream.toml.in

### DIFF
--- a/meta-lmp-base/recipes-sota/config/files/10-lite-public-stream.toml.in
+++ b/meta-lmp-base/recipes-sota/config/files/10-lite-public-stream.toml.in
@@ -1,9 +1,0 @@
-[uptane]
-polling_sec = 3600
-repo_server = "https://api.foundries.io/ota/repo/lmp/api/v1/user_repo/"
-
-[pacman]
-type = "ostree+compose_apps"
-compose_apps_root = "/var/sota/compose-apps"
-ostree_server = "https://api.foundries.io/ota/treehub/lmp/api/v2/"
-tags = @@AKLITE_TAG@@


### PR DESCRIPTION
Not used by anyone anymore since aktualizr-lite-public-stream.bb was removed in 360f02224d.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>