### PR TITLE
TI: move to unshared TMPDIR in multiconfig machines

### DIFF
--- a/meta-lmp-base/classes/lmp-staging.bbclass
+++ b/meta-lmp-base/classes/lmp-staging.bbclass
@@ -22,6 +22,12 @@ python __anonymous() {
 
     if pn in d.getVar('LMPSTAGING_LOCK_TO_AVOID_OOM').split():
         d.appendVarFlag('do_compile', 'lockfiles', " ${TMPDIR}/lmp-hack-avoid-oom-do_compile.lock")
+
+    if bb.data.inherits_class('image_types_wic', d) and \
+        'k3' in d.getVar('MACHINEOVERRIDES').split(':') and \
+        all(bbmc.startswith('lmp-k3r5') for bbmc in d.getVar('BBMULTICONFIG').split()):
+            mcdepends = d.getVarFlag('do_image_wic', 'mcdepends')
+            d.setVarFlag('do_image_wic', 'mcdepends', mcdepends.replace(':k3r5', ':lmp-k3r5'))
 }
 
 inherit ${LMPSTAGING_INHERIT_KERNEL_MODSIGN}

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -581,6 +581,8 @@ SSTATE_ALLOW_OVERLAP_FILES:append:k3r5 = "${SSTATE_ALLOW_OVERLAP_FILES_K3R5}"
 RM_WORK_EXCLUDE:append:k3 = " texinfo-dummy-native gettext-minimal-native gnu-config"
 
 # TI AM62x
+BBMULTICONFIG:remove:am62xx-evm = "k3r5"
+BBMULTICONFIG:append:am62xx-evm = " lmp-k3r5"
 MACHINE_FEATURES:append:am62xx-evm = " optee"
 SOTA_CLIENT_FEATURES:append:am62xx-evm = " ubootenv"
 PREFERRED_PROVIDER_u-boot-fw-utils:am62xx-evm = "libubootenv"
@@ -599,6 +601,8 @@ LMP_BOOT_FIRMWARE_FILES:am62xx-evm = "tispl.bin u-boot.img"
 LMP_BOOT_FIRMWARE_FILES:append:sota:am62xx-evm = " boot.itb"
 
 # TI AM64x
+BBMULTICONFIG:remove:am64xx-evm = "k3r5-sr2-hs-fs k3r5-gp k3r5-sr2-hs-se"
+BBMULTICONFIG:append:am64xx-evm = " lmp-k3r5-sr2-hs-fs lmp-k3r5-gp lmp-k3r5-sr2-hs-se"
 MACHINE_FEATURES:append:am64xx-evm = " optee"
 SOTA_CLIENT_FEATURES:append:am64xx-evm = " ubootenv"
 PREFERRED_PROVIDER_u-boot-fw-utils:am64xx-evm = "libubootenv"

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -574,6 +574,9 @@ KERNEL_IMAGETYPES:sota:k3 = "${KERNEL_IMAGETYPE}"
 PREFERRED_PROVIDER_virtual/kernel:k3 ?= "linux-lmp-ti-staging"
 WKS_FILE_DEPENDS:append:k3 = " virtual/bootloader"
 OSTREE_DEPLOY_USR_OSTREE_BOOT:k3 = "1"
+SSTATE_ALLOW_OVERLAP_FILES_K3R5 = " ${DEPLOY_DIR_IPK}/armv7at2hf-vfp"
+SSTATE_ALLOW_OVERLAP_FILES_K3R5:am62xx-evm-k3r5 = ""
+SSTATE_ALLOW_OVERLAP_FILES:append:k3r5 = "${SSTATE_ALLOW_OVERLAP_FILES_K3R5}"
 # multiconfig with the same TMP fails in the rm_work.bbclass
 RM_WORK_EXCLUDE:append:k3 = " texinfo-dummy-native gettext-minimal-native gnu-config"
 

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -577,8 +577,6 @@ OSTREE_DEPLOY_USR_OSTREE_BOOT:k3 = "1"
 SSTATE_ALLOW_OVERLAP_FILES_K3R5 = " ${DEPLOY_DIR_IPK}/armv7at2hf-vfp"
 SSTATE_ALLOW_OVERLAP_FILES_K3R5:am62xx-evm-k3r5 = ""
 SSTATE_ALLOW_OVERLAP_FILES:append:k3r5 = "${SSTATE_ALLOW_OVERLAP_FILES_K3R5}"
-# multiconfig with the same TMP fails in the rm_work.bbclass
-RM_WORK_EXCLUDE:append:k3 = " texinfo-dummy-native gettext-minimal-native gnu-config"
 
 # TI AM62x
 BBMULTICONFIG:remove:am62xx-evm = "k3r5"

--- a/meta-lmp-bsp/conf/multiconfig/lmp-k3r5-gp.conf
+++ b/meta-lmp-bsp/conf/multiconfig/lmp-k3r5-gp.conf
@@ -1,0 +1,3 @@
+require conf/multiconfig/k3r5-gp.conf
+
+TMPDIR .= "-${BB_CURRENT_MC}"

--- a/meta-lmp-bsp/conf/multiconfig/lmp-k3r5-sr2-hs-fs.conf
+++ b/meta-lmp-bsp/conf/multiconfig/lmp-k3r5-sr2-hs-fs.conf
@@ -1,0 +1,3 @@
+require conf/multiconfig/k3r5-sr2-hs-fs.conf
+
+TMPDIR .= "-${BB_CURRENT_MC}"

--- a/meta-lmp-bsp/conf/multiconfig/lmp-k3r5-sr2-hs-se.conf
+++ b/meta-lmp-bsp/conf/multiconfig/lmp-k3r5-sr2-hs-se.conf
@@ -1,0 +1,3 @@
+require conf/multiconfig/k3r5-sr2-hs-se.conf
+
+TMPDIR .= "-${BB_CURRENT_MC}"

--- a/meta-lmp-bsp/conf/multiconfig/lmp-k3r5.conf
+++ b/meta-lmp-bsp/conf/multiconfig/lmp-k3r5.conf
@@ -1,0 +1,3 @@
+require conf/multiconfig/k3r5.conf
+
+TMPDIR .= "-${BB_CURRENT_MC}"


### PR DESCRIPTION
Using the same TMPDIR it is very sensitive and prone to several errors
when used in more complex situations.

This configuration forces that all native packages have to be the same between all
machines and this requirement is very easy to break.
Suppose you use a macinhe override and this requirement is no longer met.

Many of these anomalies can be verified with the use of the rm-work and
create-spdx bitbake classes.
