### PR TITLE
base: kmeta-linux-lmp-5.10.y: bump to 2b0fbe83

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.10.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.10.y"
-KERNEL_META_COMMIT ?= "53683670469246ddde215214ca605164319d7ef0"
+KERNEL_META_COMMIT ?= "2b0fbe838d7d6f8363f70a80ba33849f6bd0b838"


### PR DESCRIPTION
Relevant changes:
- 2b0fbe83 bsp: ti-arm64-common: add CONFIG_OF_OVERLAY

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>