### PR TITLE
base/bsp: openssh: drop rng-tools removal

### DIFF
--- a/meta-lmp-base/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-lmp-base/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,5 +1,0 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-
-# OE-Core sets to rng-tools by default, which is not wanted by meta-lmp,
-# unless the BSP has a kernel < 5.6 (which can be added in meta-lmp-bsp).
-PACKAGECONFIG ?= ""

--- a/meta-lmp-bsp/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-lmp-bsp/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,2 +1,0 @@
-# BSPs with kernel older than 5.6 (blocking /dev/random reads)
-PACKAGECONFIG:apalis-imx8 ?= "rng-tools"


### PR DESCRIPTION
OE-Core 2ed579aa28 removes rng-tools pkg-config and rrecommends logic from the openssh recipe, so drop our local overrides as they are not required anymore.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>