### PR TITLE
bsp: u-boot-ti-staging: am62xx-evm: use vfat for env

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging/am62xx-evm/lmp.cfg
+++ b/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging/am62xx-evm/lmp.cfg
@@ -1,6 +1,8 @@
 CONFIG_BOOTCOMMAND="mmc dev ${mmcdev}; mmc rescan; fatload mmc ${mmcdev}:1 ${loadaddr} /boot.itb; source ${loadaddr}; env default -a; saveenv; reset"
-CONFIG_SYS_MMC_ENV_DEV=1
-CONFIG_SYS_MMC_ENV_PART=1
+# CONFIG_ENV_IS_IN_MMC is not set
+CONFIG_ENV_IS_IN_FAT=y
+CONFIG_ENV_FAT_INTERFACE="mmc"
+CONFIG_ENV_FAT_DEVICE_AND_PART="1:1"
 CONFIG_BOOTCOUNT_LIMIT=y
 CONFIG_BOOTCOUNT_BOOTLIMIT=3
 CONFIG_BOOTCOUNT_ENV=y


### PR DESCRIPTION
Move the default environment from an emmc offset to the first vfat partition (sdcard) as a way to facilitate the environment management process on clean flash.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>