### PR TITLE
Provision robustness

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files/provision.sh.in
+++ b/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files/provision.sh.in
@@ -25,14 +25,103 @@ function usage {
 }
 
 # NOTE: use v1 of the STM32_Programmer_CLI OTP disp command which doesn't correctly use word= param
+# Typical output of "STM32_Programmer_CLI -c port=USB1 -otp displ":
+# For v2.12:
+#       -------------------------------------------------------------------
+#                         STM32CubeProgrammer v2.12.0                  
+#       -------------------------------------------------------------------
+# [...]
+# OTP Partition read successfully
+#
+# OTP DATA WORDS : 
+#
+# STRUCT VERSION           :
+#                          | version    : 0x00000002
+# GLOBAL STATE             :
+#                          | Status     : 0x00000000
+#                          |_ State            : Secure Open
+#                          |_ Hardware Key Set : N
+#                          |_ Encrypted data   : N
+#
+# OTP REGISTERS:
+#
+# ---------------------------------------------------------------------------
+#     ID      |        value    |     status
+# ---------------------------------------------------------------------------
+#     000     |     0x00000017  |  0x30000000
+#                                  |_[28] Shadow write sticky lock
+#                                  |_[29] Shadow read sticky lock
+#             |                 |          
+#     001     |     0x00008024  |  0x50000000
+#                                  |_[28] Shadow write sticky lock
+#                                  |_[30] Permanent write lock
+#             |                 |          
+#
+# For v2.11 and before, the "ID" contains 2 digits:
+#       -------------------------------------------------------------------
+#                         STM32CubeProgrammer v2.11.0                  
+#       -------------------------------------------------------------------
+# [...]
+# OTP Partition read successfully
+#
+# OTP DATA WORDS : 
+#
+# Struct_version           :
+#                          | none       : 0x00000002
+# BSEC_OTP_CONFIG          :
+#                          |_ State            : Secure Open
+#                          |_ Hardware Key Set : N
+#                          |_ Encrypted data   : N
+#
+# OTP REGISTERS:
+# 
+# ---------------------------------------------------------------------------
+#     ID     |        value    |     status
+# ---------------------------------------------------------------------------
+#     00     |     0x00000017  |  0x30000000
+#                                  |_[28] Shadow write sticky lock
+#                                  |_[29] Shadow read sticky lock
+#            |                 |          
+#     01     |     0x00008024  |  0x50000000
+#                                  |_[28] Shadow write sticky lock
+#                                  |_[30] Permanent write lock
+#            |                 |          
+# [...]
+
 stm32prog_otp_refresh_values () {
-	otp_list=$(STM32_Programmer_CLI -c port=USB1 -otp displ)
+	otp_displ=$(STM32_Programmer_CLI -c port=USB1 -otp displ)
+	# Make some validity tests on the "STM32_Programmer_CLI"
+	# output. Match the version after "STM32CubeProgrammer v":
+	stm32prog_vers=$(echo "$otp_displ" | sed -n -e '/.*[[:blank:]]*STM32CubeProgrammer v\([0-9][0-9]*\.[0-9][0-9\.]*\)[[:blank:]]*$/s//\1/p')
+	# If not a version 2, print an error and stop.
+	if [ "${stm32prog_vers%%\.*}" != "2" ] ; then
+		error_exit "detected STM32CubeProgrammer version ${stm32prog_vers}, we support only v2.x.y"
+	fi
+	# If not a version 2.11 or 2.12, exit with an error.
+	case "${stm32prog_vers}" in
+	2.11.*)
+	  ;;
+	2.12.*)
+	  ;;
+	*)
+		echo "Detected STM32CubeProgrammer version ${stm32prog_vers}"
+		error_exit "We support only STM32CubeProgrammer v2.11 and v2.12."
+	  ;;
+	esac
+	# Make sure we match the "OTP Partition read successfully" line.
+	# Keep that line and the rest:
+	otp_list=$(echo "${otp_displ}" | sed -ne "/OTP Partition read successfully/,$ p")
+	if [ -z "${otp_list}" ] ; then
+		echo "Warning: failed to read the OTP partition"
+	fi
 }
 
 stm32prog_state_is_open () {
 	echo "${otp_list}" | grep "State *: Secure Open"
 }
 
+# "stm32prog_otp_get_value()"'s argument should contain 2 digits, to
+# be compatible with the STM32CubeProgrammer v2.11 and v2.12.
 stm32prog_otp_get_value () {
 	echo "${otp_list}" | sed -n "/^  *0\?${1}  *| *\(0x[[:xdigit:]]\{8\}\)  *|.*$/s//\1/p"
 }

--- a/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files/provision.sh.in
+++ b/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files/provision.sh.in
@@ -34,7 +34,7 @@ stm32prog_state_is_open () {
 }
 
 stm32prog_otp_get_value () {
-	echo "${otp_list}" | sed -n "/^    ${1}     | *\(0x[[:xdigit:]]\{8\}\)  |.*$/s//\1/p"
+	echo "${otp_list}" | sed -n "/^  *0\?${1}  *| *\(0x[[:xdigit:]]\{8\}\)  *|.*$/s//\1/p"
 }
 
 stm32prog_otp_set_value () {

--- a/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files/provision.sh.in
+++ b/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files/provision.sh.in
@@ -5,6 +5,7 @@
 #
 # SPDX-License-Identifier: MIT
 #
+set -e
 
 # Name of the script
 scriptName="$(basename "$0")"
@@ -13,7 +14,11 @@ scriptName="$(basename "$0")"
 # Functions
 #######################
 function error_exit {
-	echo "ERROR:  ${1}"
+	if [ -n "${1}" ] ; then
+		echo "ERROR:  ${1}"
+	else
+		echo "ERROR: Command execution failure"
+	fi
 	exit 1
 }
 
@@ -134,6 +139,8 @@ stm32prog_otp_lock () {
 	STM32_Programmer_CLI -y -c port=USB1 -otp lock word=${1}
 }
 
+trap error_exit ERR
+
 #######################
 # Validate required commands are available
 #######################
@@ -155,16 +162,20 @@ fi
 # Parse Args
 #######################
 # NOTE: This requires GNU getopt.
-PARSED_ARGS=$(getopt --longoptions "pub-key-hash:" \
-		--options "" --name "${scriptName}" -- "$@")
-VALID_ARGS=$?
-if [ "${VALID_ARGS}" != "0" ] ; then
+if ! PARSED_ARGS=$(getopt --longoptions "pub-key-hash:" \
+		--options "" --name "${scriptName}" -- "$@") ; then
 	usage
 	error_exit "Unable to parse arguments"
 fi
 
 # Note the quotes around '${PARSED_ARGS}' are essential
 eval set -- "${PARSED_ARGS}"
+
+# Make sure required option is defined
+if [ $# = 1 ]; then
+	usage
+	error_exit "Required option missing"
+fi
 
 # Sec Boot Public Key SHA256 Hash Binary
 pubKeyFile=
@@ -264,7 +275,10 @@ fi # if not closed device
 STM32_Programmer_CLI -c port=USB1 -detach
 
 # Only close the device if not already closed
-if ! fastboot oem ucmd:"test \"\${boot_auth}\" = \"2\"">/dev/null 2>&1; then
+if stm32prog_state_is_open; then
+	if fastboot oem ucmd:"test \"\${boot_auth}\" = \"2\"">/dev/null 2>&1; then
+		error_exit "Device in inconsistent state"
+	fi
 	####
 	# Programming STM32 Sec Boot Pub Key Hash
 	#
@@ -272,9 +286,8 @@ if ! fastboot oem ucmd:"test \"\${boot_auth}\" = \"2\"">/dev/null 2>&1; then
 	####
 	echo "## Checking STM32 key"
 	for i in 24 25 26 27 28 29 30 31; do
-		fastboot oem ucmd:"fuse cmp 0 ${i} 00000000" > /dev/null 2>&1
-		check=$?
-		if [ "${check}" -ne "0" ]; then
+		if ! fastboot oem ucmd:"fuse cmp 0 ${i} 00000000" > /dev/null 2>&1 ; then
+			check=1
 			break
 		fi
 	done
@@ -295,12 +308,10 @@ if ! fastboot oem ucmd:"test \"\${boot_auth}\" = \"2\"">/dev/null 2>&1; then
 			# Must compare in little endian
 			word_le="0x${word:6:2}${word:4:2}${word:2:2}${word:0:2}"
 			fastboot oem ucmd:"fuse sense 0 ${i}"
-			fastboot oem ucmd:"fuse cmp 0 ${i} ${word_le}" > /dev/null 2>&1
-			check=$?
-			if [ "${check}" -ne "0" ]; then
+			if ! fastboot oem ucmd:"fuse cmp 0 ${i} ${word_le}" > /dev/null 2>&1 ; then
 				error_exit "STM32 Pub Key Hash was not programmed successfully. OTP ${i} is not correct"
 			fi
-			i=$(printf "%d" $((i + 1)))
+			i=$((i + 1))
 		done
 
 		####


### PR DESCRIPTION
Changing from STM32CubeProgrammer_CLI version 2.11.0 to version 2.12.0 caused the provision.sh script to not work.

This PR makes it work correctly for these 2 versions of the tools and only those as well as making sure that any command that fails in running this script will not allow the script to continue but exit with an appropriate error.