### PR TITLE
base: lmp-image-common: install tzdata by default

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -34,6 +34,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     resize-helper \
     mtd-utils \
     sudo \
+    tzdata \
     zram \
 "
 


### PR DESCRIPTION
Adds ~3MB to the image size, but useful for users wanting to set timezone to a valid value other than UTC.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>