### PR TITLE
Improve auto hostname

### DIFF
--- a/meta-lmp-base/recipes-support/lmp-auto-hostname/lmp-auto-hostname/lmp-auto-hostname.service.in
+++ b/meta-lmp-base/recipes-support/lmp-auto-hostname/lmp-auto-hostname/lmp-auto-hostname.service.in
@@ -7,6 +7,7 @@ After=local-fs.target dbus.service
 [Service]
 Environment=MACHINE=@@LMP_HOSTNAME_MACHINE@@ MODE=@@LMP_HOSTNAME_MODE@@ NETDEVICE=@@LMP_HOSTNAME_NETDEVICE@@
 ExecStart=/usr/bin/lmp-update-hostname
+ExecStartPost=/usr/bin/systemctl disable lmp-auto-hostname.service
 Type=oneshot
 RemainAfterExit=yes
 

--- a/meta-lmp-base/recipes-support/lmp-auto-hostname/lmp-auto-hostname/lmp-auto-hostname.service.in
+++ b/meta-lmp-base/recipes-support/lmp-auto-hostname/lmp-auto-hostname/lmp-auto-hostname.service.in
@@ -5,7 +5,7 @@ Before=network-pre.target avahi-daemon.service
 After=local-fs.target dbus.service
 
 [Service]
-Environment=MACHINE=@@LMP_HOSTNAME_MACHINE@@ MODE=@@LMP_HOSTNAME_MODE@@ NETDEVICE=@@LMP_HOSTNAME_NETDEVICE@@
+Environment=MACHINE=@@LMP_HOSTNAME_MACHINE@@ MODE=@@LMP_HOSTNAME_MODE@@ NETDEVICE=@@LMP_HOSTNAME_NETDEVICE@@ FIOVB_VAR=@@LMP_HOSTNAME_FIOVB_VAR@@
 ExecStart=/usr/bin/lmp-update-hostname
 ExecStartPost=/usr/bin/systemctl disable lmp-auto-hostname.service
 Type=oneshot

--- a/meta-lmp-base/recipes-support/lmp-auto-hostname/lmp-auto-hostname/lmp-update-hostname.sh
+++ b/meta-lmp-base/recipes-support/lmp-auto-hostname/lmp-auto-hostname/lmp-update-hostname.sh
@@ -56,7 +56,12 @@ else
 fi
 
 echo "Updating system hostname to ${NEW_HOSTNAME}"
-/usr/bin/hostnamectl --static --transient set-hostname ${NEW_HOSTNAME}
+if [ -x /usr/bin/hostnamectl ]; then
+    /usr/bin/hostnamectl --static --transient set-hostname ${NEW_HOSTNAME}
+else
+    echo ${NEW_HOSTNAME} > /etc/hostname
+    /usr/bin/hostname -F /etc/hostname
+fi
 
 echo "Updating /etc/hosts with hostname ${NEW_HOSTNAME}"
 if grep -q "^127.0.1.1" /etc/hosts; then

--- a/meta-lmp-base/recipes-support/lmp-auto-hostname/lmp-auto-hostname/lmp-update-hostname.sh
+++ b/meta-lmp-base/recipes-support/lmp-auto-hostname/lmp-auto-hostname/lmp-update-hostname.sh
@@ -33,6 +33,12 @@ if [ -f ${MODEL_SOURCE} ]; then
 	# Lowercase and no spaces (can generate bad values with special chars)
 	MODEL=$(sed -e 's/ /-/g' -e 's/+/plus/g' ${MODEL_SOURCE} | tr '[:upper:]' '[:lower:]' | tr -d '\0')
 fi
+if [ -x /usr/bin/fiovb_printenv ] && [ -n "${FIOVB_VAR}" ]; then
+	# Fetch the serial number in the fiovb variable named "${FIOVB_VAR}".
+	SERIAL_TMP=$(mktemp /tmp/lmp-update-hostname-fiovb.XXXXXXXXXX)
+	trap 'rm -f ${SERIAL_TMP}' EXIT
+	fiovb_printenv "${FIOVB_VAR}" > ${SERIAL_TMP} && SERIAL_SOURCE="${SERIAL_TMP}"
+fi
 if [ -f ${SERIAL_SOURCE} ]; then
 	# Lowercase and no leading zeros
 	SERIAL=$(sed -e 's/^0*//' ${SERIAL_SOURCE} | tr '[:upper:]' '[:lower:]' | tr -d '\0')

--- a/meta-lmp-base/recipes-support/lmp-auto-hostname/lmp-auto-hostname_0.1.bb
+++ b/meta-lmp-base/recipes-support/lmp-auto-hostname/lmp-auto-hostname_0.1.bb
@@ -16,6 +16,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 LMP_HOSTNAME_MACHINE ?= "${MACHINE}"
 LMP_HOSTNAME_MODE ?= "serial"
 LMP_HOSTNAME_NETDEVICE ?= ""
+LMP_HOSTNAME_FIOVB_VAR ?= ""
 
 SYSTEMD_SERVICE:${PN} = "lmp-auto-hostname.service"
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
@@ -24,6 +25,7 @@ do_compile() {
 	sed -e 's/@@LMP_HOSTNAME_MACHINE@@/${LMP_HOSTNAME_MACHINE}/' \
 		-e 's/@@LMP_HOSTNAME_MODE@@/${LMP_HOSTNAME_MODE}/' \
 		-e 's/@@LMP_HOSTNAME_NETDEVICE@@/${LMP_HOSTNAME_NETDEVICE}/' \
+		-e 's/@@LMP_HOSTNAME_FIOVB_VAR@@/${LMP_HOSTNAME_FIOVB_VAR}/' \
 		${WORKDIR}/lmp-auto-hostname.service.in > lmp-auto-hostname.service
 
 	# Force job to wait for the network interface to show up if used


### PR DESCRIPTION
3 commits that improves the "lmp-auto-hostname" feature [1]:
1. Support changing the hostname even if "`hostnamectl`" is not available, with a fall-back to "`/usr/bin/hostname`".
2. Avoid to run the script at every boot, to boot faster, because it is not needed.
3. Add an option to fetch the serial number from the secure environment with "`fiovb`", instead of using the CPU serial number.

References:
- [1]      "_Auto Hostname_"
           <https://docs.foundries.io/latest/user-guide/lmp-auto-hostname/lmp-auto-hostname.html>
- [2]      "_systemd-hostnamed.service, systemd-hostnamed — Daemon to control system hostname from programs_"
           <https://docs.foundries.io/latest/user-guide/lmp-auto-hostname/lmp-auto-hostname.html>