### PR TITLE
base: recipes-samples: add fio to audio group

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -98,5 +98,5 @@ python () {
 EXTRA_USERS_PARAMS = "\
 groupadd ${LMP_USER}; \
 useradd -p '${LMP_PASSWORD}' ${LMP_USER}; \
-usermod -a -G sudo,users,plugdev ${LMP_USER}; \
+usermod -a -G sudo,users,audio,plugdev ${LMP_USER}; \
 "


### PR DESCRIPTION
for some audio apps to work the default user needs to be added to the audio group.