### PR TITLE
provision.sh.in: accept STM32_Programmer -otp displ failure

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files/provision.sh.in
+++ b/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files/provision.sh.in
@@ -94,7 +94,7 @@ function usage {
 # [...]
 
 stm32prog_otp_refresh_values () {
-	otp_displ=$(STM32_Programmer_CLI -c port=USB1 -otp displ)
+	otp_displ=$(STM32_Programmer_CLI -c port=USB1 -otp displ || echo "STM32_Programmer_CLI -otp displ returned an error")
 	# Make some validity tests on the "STM32_Programmer_CLI"
 	# output. Match the version after "STM32CubeProgrammer v":
 	stm32prog_vers=$(echo "$otp_displ" | sed -n -e '/.*[[:blank:]]*STM32CubeProgrammer v\([0-9][0-9]*\.[0-9][0-9\.]*\)[[:blank:]]*$/s//\1/p')


### PR DESCRIPTION
The "`provision.sh`" script was made more robust by commit a9b949cf7d59 [1] that introduced a "`set -e`" command in the Bash script [2], which:
```
  set -e Exit immediately if a pipeline (...), exits with a
         non-zero status.
```
The script is more robust in the sense that it will exit immediately in case a subcommand fails. The purpose is to avoid to close an STM32MP15x from which the OTP is not fully burned.

When testing commit a9b949cf7d59 [1] on a closed STM32MP15x device, "`provision.sh`" stopped with an error message:
```
  Flashing service completed successfully
  + stm32prog_otp_refresh_values ++ STM32_Programmer_CLI -c port=USB1 -otp displ
  + otp_displ='      -------------------------------------------------------------------
                          STM32CubeProgrammer v2.12.0
        -------------------------------------------------------------------
  [...]
  Uploading OTP data:
  Error: Read OTP Partition failed

  Error: Uploading the OTP structure failed
  Error: Initializing the OTP structure failed
  '
```
The diagnostic is easy: on a closed STM32MP15x, the `"STM32_Programmer_CLI -c port=USB1 -otp displ`" command embedded in line 105:
```  otp_displ=$(STM32_Programmer_CLI -c port=USB1 -otp displ)```
fails and return an error code 1, because the OTP is not accessible on closed STM32MP15x. With "`set -e`", this failure aborts the script.

Fixed: accept an error on that particular command, by appending a "`|| echo ...`" to the command.

References:
- [1]       commit a9b949cf7d59 (recipes-support: provision.sh.in: add
            error exit handling) from Tim Anderson
            <tim.anderson@foundries.io>, 2023-02-09 10:26:32 -0700
- [2]       "bash(1) — Linux manual page"
            <https://www.man7.org/linux/man-pages/man1/bash.1.html>