### PR TITLE
Revert "bsp: ti-img-rogue-umlibs: fix usrmerge"

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-graphics/libgles/ti-img-rogue-umlibs_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-graphics/libgles/ti-img-rogue-umlibs_%.bbappend
@@ -1,6 +1,0 @@
-do_install:append() {
-    if ${@bb.utils.contains('DISTRO_FEATURES', 'usrmerge', 'true', 'false', d)}; then
-        mv ${D}/lib/firmware ${D}${nonarch_base_libdir}
-        rmdir ${D}/lib
-    fi
-}


### PR DESCRIPTION
This reverts commit b2a7a2e3adeefef685bf8b28d8685b6b20bfc76a.

Upstream meta-ti reverted the graphics changes because the master branch is broken as bitbake fails parsing.
Once that meta-ti is exercised ao the autobilder it is a blocker on the yocto project.