### PR TITLE
base: lmp-device-register: bump version

### DIFF
--- a/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,17 +4,13 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl glib-2.0"
 
-SRCREV = "2bb3a61bfc908e95b56eb2d4cd38ea09abb9846b"
+SRCREV = "848bcbbba886320b13b11ac04826be0361288619"
 
-SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https;branch=main"
 
-# Defaults to the public factory
-LMP_DEVICE_REGISTER_TAG ?= "master"
-LMP_DEVICE_FACTORY ?= "lmp"
 LMP_DEVICE_API ?= "https://api.foundries.io/ota/devices/"
 
-PACKAGECONFIG ?= "aklitetags composeapp"
-PACKAGECONFIG[aklitetags] = "-DAKLITE_TAGS=ON -DDEFAULT_TAG=${LMP_DEVICE_REGISTER_TAG},-DAKLITE_TAGS=OFF,"
+PACKAGECONFIG ?= "composeapp"
 PACKAGECONFIG[composeapp] = "-DDOCKER_COMPOSE_APP=ON,-DDOCKER_COMPOSE_APP=OFF,"
 PACKAGECONFIG[production] = "-DPRODUCTION=ON,-DPRODUCTION=OFF,"
 
@@ -27,7 +23,6 @@ RDEPENDS:${PN} += "openssl-bin ${SOTA_CLIENT}"
 EXTRA_OECMAKE += "\
     -DGIT_COMMIT=${SRCREV} \
     -DHARDWARE_ID=${MACHINE} \
-    -DDEVICE_FACTORY=${LMP_DEVICE_FACTORY} \
     -DDEVICE_API=${LMP_DEVICE_API} \
     -DSOTA_CLIENT=${SOTA_CLIENT} \
 "


### PR DESCRIPTION
Move to:

 * use new "main" branch
 * drop all the ifdef content and use /etc/os-release