### PR TITLE
bsp: initramfs-ostree-lmp-image: tegra: install tegra-firmware-xusb

### DIFF
--- a/meta-lmp-bsp/recipes-core/images/initramfs-ostree-lmp-image.bbappend
+++ b/meta-lmp-bsp/recipes-core/images/initramfs-ostree-lmp-image.bbappend
@@ -1,0 +1,2 @@
+# USB support requires firmware to be available in the initrd
+PACKAGE_INSTALL:append:tegra = " tegra-firmware-xusb"


### PR DESCRIPTION
USB support requires firmware to be available in the initrd.