### PR TITLE
base: linux-lmp/-rt: add recipes for kernel 6.1

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
@@ -1,0 +1,4 @@
+KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
+KERNEL_META_REPO_PROTOCOL ?= "https"
+KERNEL_META_BRANCH ?= "linux-v6.1.y"
+KERNEL_META_COMMIT ?= "7cb2b18109bf03df3fc12757f511ba770eb34f92"

--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp-rt_6.1.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp-rt_6.1.bb
@@ -1,0 +1,20 @@
+include kmeta-linux-lmp-6.1.y.inc
+
+LINUX_VERSION ?= "6.1.12"
+KBRANCH = "linux-v6.1.y-rt"
+SRCREV_machine = "e43f6d4edd63c24694468425ea9572e35225f270"
+SRCREV_meta = "${KERNEL_META_COMMIT}"
+LINUX_KERNEL_TYPE = "preempt-rt"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+SRC_URI = "git://github.com/foundriesio/linux.git;protocol=https;branch=${KBRANCH};name=machine; \
+    ${KERNEL_META_REPO};protocol=${KERNEL_META_REPO_PROTOCOL};type=kmeta;name=meta;branch=${KERNEL_META_BRANCH};destsuffix=${KMETA} \
+"
+
+KMETA = "kernel-meta"
+
+require linux-lmp.inc
+include recipes-kernel/linux/linux-lmp-machine-custom.inc
+
+DEFAULT_PREFERENCE = "-1"

--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp_6.1.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp_6.1.bb
@@ -1,0 +1,19 @@
+include kmeta-linux-lmp-6.1.y.inc
+
+LINUX_VERSION ?= "6.1.14"
+KBRANCH = "linux-v6.1.y"
+SRCREV_machine = "419d0065241ad2df8620a64a3628811ed8e910fc"
+SRCREV_meta = "${KERNEL_META_COMMIT}"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+SRC_URI = "git://github.com/foundriesio/linux.git;protocol=https;branch=${KBRANCH};name=machine; \
+    ${KERNEL_META_REPO};protocol=${KERNEL_META_REPO_PROTOCOL};type=kmeta;name=meta;branch=${KERNEL_META_BRANCH};destsuffix=${KMETA} \
+"
+
+KMETA = "kernel-meta"
+
+require linux-lmp.inc
+include recipes-kernel/linux/linux-lmp-machine-custom.inc
+
+DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
Not yet default as STM32 still requires work.