### PR TITLE
Add support for linux-tegra-rt

### DIFF
--- a/meta-lmp-base/conf/distro/include/non-clangable.inc
+++ b/meta-lmp-base/conf/distro/include/non-clangable.inc
@@ -103,6 +103,8 @@ OBJCOPY:pn-linux-lmp-ti-staging:toolchain-clang = "${HOST_PREFIX}objcopy"
 STRIP:pn-linux-lmp-ti-staging:toolchain-clang = "${HOST_PREFIX}strip"
 OBJCOPY:pn-linux-tegra:toolchain-clang = "${HOST_PREFIX}objcopy"
 STRIP:pn-linux-tegra:toolchain-clang = "${HOST_PREFIX}strip"
+OBJCOPY:pn-linux-tegra-rt:toolchain-clang = "${HOST_PREFIX}objcopy"
+STRIP:pn-linux-tegra-rt:toolchain-clang = "${HOST_PREFIX}strip"
 
 # jailhouse (includes kernel module)
 # | warning: the compiler differs from the one used to build the kernel

--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-kernel/linux/linux-tegra%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-kernel/linux/linux-tegra%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/linux-tegra:"
+
+SRC_URI:append = " file://lmp.cfg"

--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-kernel/linux/linux-tegra-rt_5.10.bb
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-kernel/linux/linux-tegra-rt_5.10.bb
@@ -1,0 +1,6 @@
+require recipes-kernel/linux/linux-tegra_5.10.bb
+
+# Use BSP with rt-patches applied
+SRC_REPO = "github.com/foundriesio/linux.git;protocol=https"
+SRCBRANCH = "oe4t-patches${LINUX_VERSION_EXTENSION}-rt"
+SRCREV = "c757f64a928b5eefd47c99b398b9363ffd3c8d82"

--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -1,3 +1,0 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-
-SRC_URI:append = " file://lmp.cfg"


### PR DESCRIPTION
Same as linux-tegra, but with the RT (available in the linux/rt-patches folder) applied, as suggested by meta-tegra.