### PR TITLE
Aligning SDMA firmware version and load logic with NXP BSP

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.15.y"
-KERNEL_META_COMMIT ?= "ff4abc73d823bb995e8e4c56d940a1775e96d63d"
+KERNEL_META_COMMIT ?= "d55fd7d3f993b21108fe5d4cdb49ec29189cddfa"

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -362,7 +362,6 @@ KERNEL_IMAGETYPE:sota:mx8mm-generic-bsp = "fitImage"
 KERNEL_CLASSES:sota:mx8mm-generic-bsp = " kernel-lmp-fitimage "
 ## iMX8: Use latest NXP BSP downstream kernel
 PREFERRED_PROVIDER_virtual/kernel:mx8mm-nxp-bsp ?= "linux-lmp-fslc-imx"
-MACHINE_FIRMWARE:mx8mm-nxp-bsp = "linux-firmware-imx-sdma-imx7d"
 IMXBOOT_TARGETS:mx8mm-nxp-bsp = "flash_evk_spl"
 ## LUKS
 OSTREE_SPLIT_BOOT:mx8mm-nxp-bsp = "${@bb.utils.contains('DISTRO_FEATURES', 'luks', '1', '0', d)}"
@@ -410,7 +409,6 @@ KERNEL_IMAGETYPE:sota:mx8mp-generic-bsp = "fitImage"
 KERNEL_CLASSES:sota:mx8mp-generic-bsp = " kernel-lmp-fitimage "
 ## iMX8: Use latest NXP BSP downstream kernel
 PREFERRED_PROVIDER_virtual/kernel:mx8mp-nxp-bsp ?= "linux-lmp-fslc-imx"
-MACHINE_FIRMWARE:mx8mp-nxp-bsp = "linux-firmware-imx-sdma-imx7d"
 WKS_FILE:sota:mx8mp-nxp-bsp = "sdimage-imx8-spl-sota.wks.in"
 IMXBOOT_TARGETS:mx8mp-nxp-bsp = "flash_evk_spl"
 ## iMX8MP EVK
@@ -451,7 +449,6 @@ KERNEL_IMAGETYPE:sota:mx8mn-generic-bsp = "fitImage"
 KERNEL_CLASSES:sota:mx8mn-generic-bsp = " kernel-lmp-fitimage "
 ## iMX8: Use latest NXP BSP downstream kernel
 PREFERRED_PROVIDER_virtual/kernel:mx8mn-generic-bsp ?= "linux-lmp-fslc-imx"
-MACHINE_FIRMWARE:mx8mn-generic-bsp = "linux-firmware-imx-sdma-imx7d"
 WKS_FILE:sota:mx8mn-generic-bsp = "sdimage-imx8-spl-sota.wks.in"
 # iMX8MN DDR4 EVK
 KMACHINE:imx8mn-ddr4-evk = "imx8mn-evk"
@@ -676,3 +673,8 @@ UBOOT_PROVIDES_BOOT_CONTAINER:mx8-generic-bsp = ""
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS:remove:imx-generic-bsp = "u-boot-fslc"
 ## OP-TEE is a dependency of u-boot (fit), no need for WKS_FILE_DEPENDS
 OPTEE_WKS_FILE_DEPENDS:imx-generic-bsp = ""
+# Use latest SDMA firmware from firmware-imx instead of upstream linux-firmware
+MACHINE_FIRMWARE:remove:mx6-nxp-bsp = "linux-firmware-imx-sdma-imx6q"
+MACHINE_FIRMWARE:remove:mx8-nxp-bsp = "linux-firmware-imx-sdma-imx7d"
+MACHINE_FIRMWARE:append:mx6-nxp-bsp = " firmware-imx-sdma-imx6q firmwared"
+MACHINE_FIRMWARE:append:mx8-nxp-bsp = " firmware-imx-sdma-imx7d firmwared"

--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/firmware-imx/firmware-imx_8.%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/firmware-imx/firmware-imx_8.%.bbappend
@@ -1,0 +1,4 @@
+do_install:append() {
+    install -m 0644 ${S}/firmware/sdma/sdma-imx6q.bin ${D}${nonarch_base_libdir}/firmware/imx/sdma
+    install -m 0644 ${S}/firmware/sdma/sdma-imx7d.bin ${D}${nonarch_base_libdir}/firmware/imx/sdma
+}

--- a/meta-lmp-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-lmp-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -36,6 +36,11 @@ do_install:append:beaglebone-yocto() {
 }
 
 do_install:append:imx-nxp-bsp () {
+    # Drop upstream sdma firmware binaries (prefer from the BSP)
+    if [ -d ${D}${base_libdir}/firmware/imx/sdma ]; then
+        rm -rf ${D}${base_libdir}/firmware/imx/sdma
+    fi
+
     # Install Murata 1MW NVRAM and HCD files
     install -m 0644 ${WORKDIR}/imx-firmware/cyw-wifi-bt/1MW_CYW43455/BCM4345C0.1MW.hcd ${D}${nonarch_base_libdir}/firmware/brcm/BCM4345C0.hcd
     install -m 0644 ${WORKDIR}/imx-firmware/cyw-wifi-bt/1MW_CYW43455/brcmfmac43455-sdio.txt ${D}${nonarch_base_libdir}/firmware/brcm/brcmfmac43455-sdio.fsl,${MACHINE}.txt
@@ -62,3 +67,5 @@ FILES:${PN}-bcm4356-pcie += " \
        ${nonarch_base_libdir}/firmware/brcm/brcmfmac4356-pcie.txt \
        ${nonarch_base_libdir}/firmware/brcm/BCM4356A2.hcd \
 "
+
+PACKAGES:remove:imx-nxp-bsp = "${PN}-imx-sdma-license ${PN}-imx-sdma-imx6q ${PN}-imx-sdma-imx7d"


### PR DESCRIPTION
Have SDMA provided by firmware-imx (latest revision) and add firmwared as it is required for early loading of the firmware when booting the system.