### PR TITLE
base: pkcs11-provider: add recipe

### DIFF
--- a/meta-lmp-base/conf/layer.conf
+++ b/meta-lmp-base/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "meta-lmp-base"
 BBFILE_PATTERN_meta-lmp-base := "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-lmp-base = "9"
+BBFILE_PRIORITY_meta-lmp-base = "10"
 
 LAYERDEPENDS_meta-lmp-base = " \
     core \

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0001-lib-ecdh1-derive-simple-implementation-for-KDF-null.patch
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0001-lib-ecdh1-derive-simple-implementation-for-KDF-null.patch
@@ -1,0 +1,616 @@
+From e5ac5598c69d3f7e50ecf19056eff6038248441e Mon Sep 17 00:00:00 2001
+From: Jorge Ramirez-Ortiz <jorge@foundries.io>
+Date: Thu, 9 Feb 2023 11:43:46 +0100
+Subject: [PATCH] lib: ecdh1 derive: simple implementation for KDF null
+
+Use TPM2_ECDH_ZGen as provided by tss2-esys (Esys_ECDH_ZGen()).
+
+Test:
+1) create two EC:prime256v1 keypairs (01, 02)
+2) read 02 pubkey to pub2.der
+3) --derive -m ECDH1-DERIVE --id 01 --input-file pub2.der --output-file /tmp/bytes1
+4) read 01 pubkey to pub1.der
+5) --derive -m ECDH1-DERIVE --id 02 --input-file pub1.der --output-file /tmp/bytes2
+6) diff bytes1 bytes2
+
+Upstream-Status: Backport [https://github.com/tpm2-software/tpm2-pkcs11/commit/cd7b486414a2e8819e94a6ef60c0243726c9f68f]
+
+Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ src/lib/attrs.c  |   1 +
+ src/lib/derive.c | 263 +++++++++++++++++++++++++++++++++++++++++++++++
+ src/lib/derive.h |  15 +++
+ src/lib/mech.c   |  18 ++++
+ src/lib/object.c |  27 +++++
+ src/lib/tpm.c    |  43 ++++++++
+ src/lib/tpm.h    |   1 +
+ src/lib/utils.c  |  58 +++++++++++
+ src/lib/utils.h  |  17 +++
+ src/pkcs11.c     |   3 +-
+ 10 files changed, 445 insertions(+), 1 deletion(-)
+ create mode 100644 src/lib/derive.c
+ create mode 100644 src/lib/derive.h
+
+diff --git a/src/lib/attrs.c b/src/lib/attrs.c
+index c55cffa..0c81e6a 100644
+--- a/src/lib/attrs.c
++++ b/src/lib/attrs.c
+@@ -979,6 +979,7 @@ static CK_RV ecc_gen_mechs(attr_list *new_pub_attrs, attr_list *new_priv_attrs)
+         CKM_ECDSA_SHA256,
+         CKM_ECDSA_SHA384,
+         CKM_ECDSA_SHA512,
++        CKM_ECDH1_DERIVE,
+     };
+ 
+     bool r = attr_list_add_int_seq(new_pub_attrs, CKA_ALLOWED_MECHANISMS,
+diff --git a/src/lib/derive.c b/src/lib/derive.c
+new file mode 100644
+index 0000000..fdf35b7
+--- /dev/null
++++ b/src/lib/derive.c
+@@ -0,0 +1,263 @@
++/* SPDX-License-Identifier: BSD-2-Clause */
++
++#include "config.h"
++#include <assert.h>
++#include <stdlib.h>
++
++#include <openssl/ec.h>
++#include <openssl/ecdsa.h>
++#include <openssl/evp.h>
++
++#include "attrs.h"
++#include "backend.h"
++#include "checks.h"
++#include "derive.h"
++#include "digest.h"
++#include "encrypt.h"
++#include "log.h"
++#include "mech.h"
++#include "ssl_util.h"
++#include "session.h"
++#include "session_ctx.h"
++#include "token.h"
++#include "tpm.h"
++
++typedef struct sanity_check_data sanity_check_data;
++struct sanity_check_data {
++    size_t len;
++};
++
++CK_RV handle_token(const CK_ATTRIBUTE_PTR attr, void* userdat) {
++    CK_BBOOL value;
++    UNUSED(userdat);
++    CK_RV rv = attr_CK_BBOOL(attr, &value);
++
++    LOGV("attr: name %s,\t\t val = %d", attr_get_name(attr->type), value);
++    return rv;
++}
++
++CK_RV handle_class(const CK_ATTRIBUTE_PTR attr, void* userdat) {
++    CK_OBJECT_CLASS value = 0;
++    UNUSED(userdat);
++    CK_RV rv = attr_CK_OBJECT_CLASS(attr, &value);
++
++    if (value != CKO_SECRET_KEY)
++        rv = CKR_ARGUMENTS_BAD;
++
++    LOGV("attr: name %s, \t\t val = %s", attr_get_name(attr->type), "CKO_SECRET_KEY");
++    return rv;
++}
++
++CK_RV handle_key_type(const CK_ATTRIBUTE_PTR attr, void* userdat) {
++    CK_KEY_TYPE value;
++    UNUSED(userdat);
++    CK_RV rv = attr_CK_KEY_TYPE(attr, &value);
++
++    if (value != CKK_GENERIC_SECRET)
++        rv = CKR_ARGUMENTS_BAD;
++
++    LOGV("attr: name %s,\t val = %s", attr_get_name(attr->type), "CKK_GENERIC_SECRET");
++    return rv;
++}
++
++CK_RV handle_sensitive(const CK_ATTRIBUTE_PTR attr, void* userdat) {
++    UNUSED(userdat);
++
++    LOGV("attr: name %s", attr_get_name(attr->type));
++    return CKR_OK;
++}
++
++CK_RV handle_extractable(const CK_ATTRIBUTE_PTR attr, void* userdat) {
++    UNUSED(userdat);
++
++    LOGV("attr: name %s", attr_get_name(attr->type));
++    return CKR_OK;
++}
++
++CK_RV handle_encrypt(const CK_ATTRIBUTE_PTR attr, void* userdat) {
++    CK_BBOOL value;
++    UNUSED(userdat);
++    CK_RV rv = attr_CK_BBOOL(attr, &value);
++
++    LOGV("attr: name %s,\t\t val = %d", attr_get_name(attr->type), value);
++    return rv;
++}
++
++CK_RV handle_decrypt(const CK_ATTRIBUTE_PTR attr, void* userdat) {
++    CK_BBOOL value;
++    UNUSED(userdat);
++    CK_RV rv = attr_CK_BBOOL(attr, &value);
++
++    LOGV("attr: name %s,\t\t val = %d", attr_get_name(attr->type), value);
++    return rv;
++}
++
++CK_RV handle_wrap(const CK_ATTRIBUTE_PTR attr, void* userdat) {
++    CK_BBOOL value;
++    UNUSED(userdat);
++    CK_RV rv = attr_CK_BBOOL(attr, &value);
++
++    LOGV("attr: name %s,\t\t val = %d", attr_get_name(attr->type), value);
++    return rv;
++}
++
++CK_RV handle_unwrap(const CK_ATTRIBUTE_PTR attr, void* userdat) {
++    CK_BBOOL value;
++    UNUSED(userdat);
++    CK_RV rv = attr_CK_BBOOL(attr, &value);
++
++    LOGV("attr: name %s,\t\t val = %d", attr_get_name(attr->type), value);
++    return rv;
++}
++
++CK_RV handle_value_len(const CK_ATTRIBUTE_PTR attr, void* userdat) {
++    CK_ULONG value;
++    CK_RV rv = attr_CK_ULONG(attr, &value);
++
++    if (rv == CKR_OK) {
++        ((sanity_check_data*)userdat)->len = value;
++    }
++
++    LOGV("attr: name %s,\t val = 0x%lx", attr_get_name(attr->type), value);
++    return rv;
++}
++
++CK_RV derive(session_ctx* ctx,  CK_MECHANISM_PTR mechanism, /* public EC point */
++             CK_OBJECT_HANDLE tpm_key,   /* private key */
++             CK_ATTRIBUTE_PTR secret_template, CK_ULONG secret_template_count,
++             CK_OBJECT_HANDLE_PTR secret) { /* secret buffer in CKA_VALUE */
++    CK_RV rv = CKR_GENERAL_ERROR;
++
++    check_pointer(mechanism);
++
++    LOGV("mechanism: 0x%lx\n\thas_params: %s\n\tlen: %lu",
++         mechanism->mechanism,
++         mechanism->pParameter ? "yes" : "no", mechanism->ulParameterLen);
++
++    if (mechanism->mechanism != CKM_ECDH1_DERIVE)
++        return CKR_MECHANISM_INVALID;
++
++    if (session_ctx_opdata_is_active(ctx))
++        return CKR_OPERATION_ACTIVE;
++
++    token* tok = session_ctx_get_token(ctx);
++    assert(tok);
++
++    tobject* tobj = NULL;
++    rv = token_load_object(tok, tpm_key, &tobj);
++    if (rv != CKR_OK) {
++        return rv;
++    }
++
++    rv = object_mech_is_supported(tobj, mechanism);
++    if (rv != CKR_OK) {
++        tobject_user_decrement(tobj);
++        return rv;
++    }
++
++    /*  Validate the keysize against the one provided by the mechanism */
++    CK_ATTRIBUTE_PTR a = attr_get_attribute_by_type(tobj->attrs, CKA_EC_PARAMS);
++    if (!a) {
++        LOGE("Expected tobject to have attribute CKA_EC_PARAMS");
++        return CKR_GENERAL_ERROR;
++    }
++
++    int nid = 0;
++    rv = ssl_util_params_to_nid(a, &nid);
++    if (rv != CKR_OK) {
++        return rv;
++    }
++
++    unsigned keysize;
++    switch (nid) {
++        case NID_X9_62_prime192v1:
++            keysize = 24;
++            break;
++        case NID_secp224r1:
++            keysize = 28;
++            break;
++        case NID_X9_62_prime256v1:
++            keysize = 32;
++            break;
++        case NID_secp384r1:
++            keysize = 48;
++            break;
++        case NID_secp521r1:
++            keysize = 66;
++            break;
++        default:
++            return CKR_CURVE_NOT_SUPPORTED;
++    }
++
++    /* 1. Get the public EC point to use in the derivation from the mechanism */
++    CK_ECDH1_DERIVE_PARAMS_PTR mecha_params;
++    SAFE_CAST(mechanism, mecha_params);
++
++    if (mecha_params->kdf != CKD_NULL) {
++        return CKR_MECHANISM_PARAM_INVALID;
++    }
++
++    /* 2. Uncompressed EC_POINT: is a DER OCTECT string of 04||x||y */
++    if (!mecha_params->public_data_len ||
++        (mecha_params->public_data_len - 1) != 2 * keysize) {
++        return CKR_MECHANISM_PARAM_INVALID;
++    }
++
++    /* Validate the shared secret attributes */
++    static const attr_handler secret_check_handlers[] = {
++        { CKA_TOKEN, handle_token },
++        { CKA_CLASS, handle_class },
++        { CKA_KEY_TYPE, handle_key_type },
++        { CKA_SENSITIVE, handle_sensitive },
++        { CKA_EXTRACTABLE, handle_extractable },
++        { CKA_ENCRYPT, handle_encrypt },
++        { CKA_DECRYPT, handle_decrypt },
++        { CKA_WRAP, handle_wrap },
++        { CKA_UNWRAP, handle_unwrap },
++        { CKA_VALUE_LEN, handle_value_len },
++    };
++    sanity_check_data udata = { 0 };
++
++    rv = attr_list_raw_invoke_handlers(secret_template, secret_template_count,
++                                       secret_check_handlers,
++                                       ARRAY_LEN(secret_check_handlers),
++                                       &udata);
++    if (rv != CKR_OK) {
++        tobject_user_decrement(tobj);
++        return rv;
++    }
++
++    /* Get the shaed secret */
++    CK_BYTE* shared_secret = NULL;
++    rv = tpm_ec_ecdh1_derive(tok->tctx, tobj, /* EC private */
++                             mecha_params->public_data, /* EC point */
++                             mecha_params->public_data_len,
++                             &shared_secret, &udata.len);
++    if (rv != CKR_OK) {
++         tobject_user_decrement(tobj);
++         return rv;
++    }
++
++    CK_ATTRIBUTE shared_secret_attr = {
++        .ulValueLen = udata.len,
++        .pValue = shared_secret,
++        .type = CKA_VALUE,
++    };
++
++    /* Return the shared secret in a CKO_SECRET_KEY class object */
++    rv = object_create(ctx, secret_template, secret_template_count, secret);
++    if (rv != CKR_OK) {
++        tobject_user_decrement(tobj);
++        goto out;
++    }
++
++    rv = object_set_attributes(ctx, *secret, &shared_secret_attr, 1);
++    if (rv != CKR_OK) {
++        tobject_user_decrement(tobj);
++        goto out;
++    }
++
++out:
++    free(shared_secret);
++    return rv;
++}
+diff --git a/src/lib/derive.h b/src/lib/derive.h
+new file mode 100644
+index 0000000..419c1fa
+--- /dev/null
++++ b/src/lib/derive.h
+@@ -0,0 +1,15 @@
++/* SPDX-License-Identifier: BSD-2-Clause */
++
++#ifndef _SRC_LIB_DERIVE_H_
++#define _SRC_LIB_DERIVE_H_
++
++#include "pkcs11.h"
++#include "session_ctx.h"
++
++CK_RV derive(session_ctx *ctx,
++	     CK_MECHANISM *mechanism,
++	     CK_OBJECT_HANDLE tpm_key,
++	     CK_ATTRIBUTE_PTR secret_template,
++	     CK_ULONG secret_template_count,
++	     CK_OBJECT_HANDLE_PTR secret);
++#endif
+diff --git a/src/lib/mech.c b/src/lib/mech.c
+index 58c04ec..7e4f363 100644
+--- a/src/lib/mech.c
++++ b/src/lib/mech.c
+@@ -36,6 +36,7 @@ enum mechanism_flags {
+     mf_aes           = 1 << 11,
+     mf_force_synthetic = 1 << 12,
+     mf_hmac          = 1 << 13,
++    mf_derive        = 1 << 14,
+ };
+ 
+ typedef struct mdetail_entry mdetail_entry;
+@@ -106,6 +107,7 @@ static CK_RV rsa_pkcs_hash_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_lis
+ static CK_RV rsa_pss_hash_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs);
+ static CK_RV ecc_keygen_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs);
+ static CK_RV ecdsa_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs);
++static CK_RV ecdh1_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs);
+ static CK_RV hash_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs);
+ static CK_RV hmac_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs);
+ static CK_RV rsa_pkcs_synthesizer(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs,
+@@ -175,6 +177,8 @@ static const mdetail_entry _g_mechs_templ[] = {
+     { .type = CKM_ECDSA_SHA384,    .flags = mf_sign|mf_verify|mf_ecc, .validator = ecdsa_validator, .get_halg = sha384_get_halg, .get_digester = sha384_get_digester, .get_tpm_opdata = tpm_ec_ecdsa_sha384_get_opdata },
+     { .type = CKM_ECDSA_SHA512,    .flags = mf_sign|mf_verify|mf_ecc, .validator = ecdsa_validator, .get_halg = sha512_get_halg, .get_digester = sha512_get_digester, .get_tpm_opdata = tpm_ec_ecdsa_sha512_get_opdata },
+ 
++    { .type = CKM_ECDH1_DERIVE,    .flags = mf_derive | mf_ecc, .validator = ecdh1_validator },
++
+     /* AES */
+     { .type = CKM_AES_KEY_GEN, .flags = mf_is_keygen|mf_aes },
+ 
+@@ -723,6 +727,20 @@ CK_RV ecdsa_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs) {
+     return CKR_OK;
+ }
+ 
++CK_RV ecdh1_validator(mdetail *m, CK_MECHANISM_PTR mech, attr_list *attrs)
++{
++    UNUSED(attrs);
++    UNUSED(m);
++
++    CK_ECDH1_DERIVE_PARAMS *params = mech->pParameter;
++
++    if (!params || !mech->ulParameterLen) {
++        return CKR_MECHANISM_PARAM_INVALID;
++    }
++
++    return CKR_OK;
++}
++
+ CK_RV sha1_get_halg(CK_MECHANISM_PTR mech, CK_MECHANISM_TYPE_PTR halg) {
+     UNUSED(mech);
+     *halg = CKM_SHA_1;
+diff --git a/src/lib/object.c b/src/lib/object.c
+index e0f3786..9a3faba 100644
+--- a/src/lib/object.c
++++ b/src/lib/object.c
+@@ -1084,6 +1084,31 @@ out:
+     return rv;
+ }
+ 
++static CK_RV handle_secret_object(CK_ATTRIBUTE_PTR templ, CK_ULONG count, attr_list **new_attrs)
++{
++    CK_RV rv = CKR_OK;
++    /*
++     * Create a new typed attr list
++     */
++    attr_list *tmp_attrs = NULL;
++    bool res = attr_typify(templ, count, &tmp_attrs);
++    if (!res) {
++        return CKR_GENERAL_ERROR;
++    }
++    assert(tmp_attrs);
++
++    /* Set any defaults and do error checking */
++    rv = attr_common_add_storage(&tmp_attrs);
++    if (rv != CKR_OK) {
++        return rv;
++    }
++
++    /* transfer ownership to caller */
++    *new_attrs = tmp_attrs;
++    tmp_attrs = NULL;
++
++    return rv;
++}
+ 
+ CK_RV object_create(session_ctx *ctx, CK_ATTRIBUTE *templ, CK_ULONG count, CK_OBJECT_HANDLE *object) {
+     assert(ctx);
+@@ -1166,6 +1191,8 @@ CK_RV object_create(session_ctx *ctx, CK_ATTRIBUTE *templ, CK_ULONG count, CK_OB
+         rv = handle_data_object(tok, templ, count, &new_attrs);
+     } else if (clazz == CKO_CERTIFICATE) {
+         rv = handle_cert_object(templ, count, &new_attrs);
++    } else if (clazz == CKO_SECRET_KEY) {
++        rv = handle_secret_object(templ, count, &new_attrs);
+     } else {
+         LOGE("Can only create RSA Public key objects or"
+                 " data objects, CKA_CLASS(%lu), CKA_KEY_TYPE(%lu)",
+diff --git a/src/lib/tpm.c b/src/lib/tpm.c
+index 456a904..1646624 100644
+--- a/src/lib/tpm.c
++++ b/src/lib/tpm.c
+@@ -4637,3 +4637,46 @@ out:
+     return rv;
+ }
+ 
++CK_RV tpm_ec_ecdh1_derive(tpm_ctx *tctx, tobject *tobj, uint8_t *ecc_point,
++                          size_t ecc_point_len, uint8_t **secret,
++                          size_t *secret_len)
++{
++    TPM2B_ECC_POINT *out_point = NULL;
++    TPM2B_ECC_POINT in_point = { };
++    CK_RV rv = CKR_GENERAL_ERROR;
++
++    if (!tobj || !tctx || !ecc_point || !ecc_point_len || !secret_len) {
++        return CKR_ARGUMENTS_BAD;
++    }
++
++    rv = utils_uncompressed_ecpoint_to_tpm2b(ecc_point, &in_point, ecc_point_len);
++    if (rv != CKR_OK) {
++        return rv;
++    }
++
++    bool res = set_esys_auth(tctx->esys_ctx, tobj->tpm_handle, tobj->unsealed_auth);
++    if (!res) {
++        return CKR_GENERAL_ERROR;
++    }
++
++    rv = Esys_ECDH_ZGen(tctx->esys_ctx, tobj->tpm_handle, ESYS_TR_PASSWORD,
++                        ESYS_TR_NONE, ESYS_TR_NONE, &in_point, &out_point);
++    if (rv != CKR_OK) {
++        return rv;
++    }
++
++    *secret = calloc(1, out_point->point.x.size);
++    if (!*secret) {
++        rv = CKR_HOST_MEMORY;
++        goto out;
++    }
++
++    *secret_len = out_point->point.x.size;
++    memcpy(*secret, out_point->point.x.buffer, *secret_len);
++
++out:
++    free(out_point);
++
++    return rv;
++}
++
+diff --git a/src/lib/tpm.h b/src/lib/tpm.h
+index c26252e..2424608 100644
+--- a/src/lib/tpm.h
++++ b/src/lib/tpm.h
+@@ -122,6 +122,7 @@ CK_RV tpm_ec_ecdsa_sha1_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR m
+ CK_RV tpm_ec_ecdsa_sha256_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);
+ CK_RV tpm_ec_ecdsa_sha384_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);
+ CK_RV tpm_ec_ecdsa_sha512_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);
++CK_RV tpm_ec_ecdh1_derive(tpm_ctx *tctx, tobject *tobj, unsigned char *pubkey, size_t pubkey_len, unsigned char **psec, size_t *pseclen);
+ 
+ CK_RV tpm_aes_cbc_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);
+ CK_RV tpm_aes_cfb_get_opdata(mdetail *m, tpm_ctx *tctx, CK_MECHANISM_PTR mech, tobject *tobj, tpm_op_data **opdata);
+diff --git a/src/lib/utils.c b/src/lib/utils.c
+index e0539ab..882f1bd 100644
+--- a/src/lib/utils.c
++++ b/src/lib/utils.c
+@@ -555,3 +555,61 @@ void parse_lib_version(const char *userbuf, CK_BYTE *major, CK_BYTE *minor) {
+ out:
+     free(buf);
+ }
++
++CK_RV utils_uncompressed_ecpoint_to_tpm2b(uint8_t* from, TPM2B_ECC_POINT* to, size_t len) {
++
++    const size_t ecc_key_sizes[] = { 24, 28, 32, 48, 64, 66 };
++    size_t tpm2b_size = 0;
++    size_t i = 0;
++
++    /*
++     * Uncompressed EC_POINT is DER OCTET STRING of "04||x||y"
++     * (discard the 0x04 and adjust the length)
++     */
++    if (!from || !to || !len || len < 49 || len > 133) {
++        return CKR_ARGUMENTS_BAD;
++    }
++
++    if (*from++ != 0x04) {
++        return CKR_ARGUMENTS_BAD;
++    }
++
++    /* Remove the 0x04 tag from the length */
++    len = len - 1;
++
++    tpm2b_size = len / 2;
++    for (i = 0; i < ARRAY_LEN(ecc_key_sizes); i++) {
++        if (tpm2b_size == ecc_key_sizes[i]) {
++            break;
++        }
++    }
++
++    if (i >= ARRAY_LEN(ecc_key_sizes)) {
++        return CKR_ARGUMENTS_BAD;
++    }
++
++    /* Key has the expected length */
++    if (tpm2b_size > sizeof(to->point.x.buffer)) {
++        LOGW("TPM2B_ECC_POINT buffer too small, truncate possible padding");
++        memcpy(to->point.x.buffer, from, sizeof(to->point.x.buffer));
++        to->point.x.size = sizeof(to->point.x.buffer);
++    } else {
++        memcpy(to->point.x.buffer, from, tpm2b_size);
++        to->point.x.size = tpm2b_size;
++    }
++
++    from = from + tpm2b_size;
++
++    if (tpm2b_size > sizeof(to->point.y.buffer)) {
++        LOGW("TPM2B_ECC_POINT buffer too small, truncate possible padding");
++        memcpy(to->point.y.buffer, from, sizeof(to->point.y.buffer));
++        to->point.y.size = sizeof(to->point.y.buffer);
++    } else {
++        memcpy(to->point.y.buffer, from, tpm2b_size);
++        to->point.y.size = tpm2b_size;
++    }
++
++    to->size = to->point.y.size + to->point.x.size;
++
++    return CKR_OK;
++}
+diff --git a/src/lib/utils.h b/src/lib/utils.h
+index 3c176c6..33c8be7 100644
+--- a/src/lib/utils.h
++++ b/src/lib/utils.h
+@@ -8,6 +8,8 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
++#include <tss2/tss2_tpm2_types.h>
++
+ #include "config.h"
+ #include "log.h"
+ #include "pkcs11.h"
+@@ -128,6 +130,21 @@ CK_RV apply_pkcs7_pad(const CK_BYTE_PTR in, CK_ULONG inlen,
+  */
+ void parse_lib_version(const char *buf, CK_BYTE *major, CK_BYTE *minor);
+ 
++/**
++*
++* Given an uncompressed ECC point in DER (0x04||x||y) populate a TPM2B_ECC_POINT
++* @param from
++*  ECC point in uncompressed DER format (0x04||x||y)
++* @param to
++*  Pointer to the TPM2B_ECC_POINT to populate
++* @param len
++*  Length of the ECC point in uncompressed DER format
++* @return CK_RV
++*   CKR_ARGUMENTS_BAD if the uncompressed ECC point is invalid
++*   CKR_OK on success
++*/
++CK_RV utils_uncompressed_ecpoint_to_tpm2b(uint8_t* from, TPM2B_ECC_POINT* to, size_t len);
++
+ /*
+  * Work around bugs in clang not including the builtins, and when asan is enabled
+  * ending up in a nightmare of having both the ASAN and BUILTINS defined and linked
+diff --git a/src/pkcs11.c b/src/pkcs11.c
+index 4494c68..6d7b596 100644
+--- a/src/pkcs11.c
++++ b/src/pkcs11.c
+@@ -7,6 +7,7 @@
+ 
+ #include "pkcs11.h"
+ 
++#include "derive.h"
+ #include "digest.h"
+ #include "encrypt.h"
+ #include "key.h"
+@@ -630,7 +631,7 @@ CK_RV C_UnwrapKey (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT
+ }
+ 
+ CK_RV C_DeriveKey (CK_SESSION_HANDLE session, CK_MECHANISM *mechanism, CK_OBJECT_HANDLE base_key, CK_ATTRIBUTE *templ, CK_ULONG attribute_count, CK_OBJECT_HANDLE *key) {
+-    TOKEN_UNSUPPORTED;
++    TOKEN_WITH_LOCK_BY_SESSION_USER_RO(derive, session, mechanism, base_key, templ, attribute_count, key);
+ }
+ 
+ CK_RV C_SeedRandom (CK_SESSION_HANDLE session, CK_BYTE_PTR seed, CK_ULONG seed_len) {

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0002-test-pkcs11-tool.sh-ECDH1-shared-secret-generation.patch
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0002-test-pkcs11-tool.sh-ECDH1-shared-secret-generation.patch
@@ -1,0 +1,59 @@
+From d0c07ea1f8172d706eee1f36f8c3ca88d7cb48eb Mon Sep 17 00:00:00 2001
+From: Jorge Ramirez-Ortiz <jorge@foundries.io>
+Date: Thu, 16 Feb 2023 17:45:31 +0100
+Subject: [PATCH] test/pkcs11-tool.sh: ECDH1, shared secret generation
+
+Validate ECDH1 shared secret generation.
+
+Upstream-Status: Backport [https://github.com/tpm2-software/tpm2-pkcs11/commit/c616c6c47824a3e01e42f3e216c12b0c8c384e83]
+
+Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ test/integration/pkcs11-tool.sh | 33 +++++++++++++++++++++++++++++++++
+ 1 file changed, 33 insertions(+)
+
+diff --git a/test/integration/pkcs11-tool.sh b/test/integration/pkcs11-tool.sh
+index ae49371..b5919fd 100755
+--- a/test/integration/pkcs11-tool.sh
++++ b/test/integration/pkcs11-tool.sh
+@@ -73,6 +73,39 @@ echo "Deleting pubkey"
+ pkcs11_tool --slot=1 --pin=myuserpin --login --delete-object --type=pubkey --label=myecckey
+ echo "Pubkey deleted"
+ 
++# test ECHD1 derive
++echo "Test ECDH1-DERIVE"
++echo "Create EC keys"
++tmp=$TPM2_PKCS11_STORE
++pkcs11_tool --slot=1 --keypairgen --login --pin myuserpin \
++            --key-type EC:prime256v1 --id 01 --label key1
++
++pkcs11_tool --slot=1 --keypairgen --login --pin myuserpin \
++            --key-type EC:prime256v1 --id 02 --label key2
++
++echo "Read public components"
++if pkcs11_tool --read-object --login --pin myuserpin --type pubkey -id 01 -o {tmp}/key1_pub.der ; then
++    pkcs11_tool --read-object --login --pin myuserpin --type pubkey --id 02 -o {tmp}/key2_pub.der
++
++    echo "Derive secrets"
++    pkcs11_tool  --derive -m ECDH1-DERIVE --id 01 --label key1 \
++                 --login --pin myuserpin \
++                 --input-file {tmp}/key2_pub.der \
++                 --output-file {tmp}/shared_secret_1
++
++    pkcs11_tool  --derive -m ECDH1-DERIVE --id 02 --label key2 \
++                 --login --pin myuserpin \
++                 --input-file {tmp}/key1_pub.der \
++                 --output-file {tmp}/shared_secret_2
++
++    echo "Validate output"
++    diff {tmp}/shared_secret_2 {tmp}/shared_secret_1 > /dev/null 2>&1
++    test "$?" -eq "0"
++else
++    echo "pkcs11-tool can't read EC key public components"
++    echo "Skipp ECDH1-1 derive test"
++fi
++
+ # Verify we can add a certificate, since this is a setup a test, the store should contain a cert to use.
+ echo "Writing certificate"
+ # Not all versions of pkcs11-tool handle PEM to DER conversions, 0.15 doesn't, 0.19 does. So always

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0003-test-pkcs11-tool.sh-replace-call-to-pkcs11-tool-for-.patch
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0003-test-pkcs11-tool.sh-replace-call-to-pkcs11-tool-for-.patch
@@ -1,0 +1,28 @@
+From 00da5d5e8ec1c15f67b548b6f11f243c3affa977 Mon Sep 17 00:00:00 2001
+From: Jorge Ramirez-Ortiz <jorge@foundries.io>
+Date: Thu, 16 Feb 2023 17:48:42 +0100
+Subject: [PATCH] test/pkcs11-tool.sh: replace call to pkcs11-tool for wrap
+
+Replace the last instance of the pkcs11-tool call for its wrapped version.
+
+Upstream-Status: Backport [https://github.com/tpm2-software/tpm2-pkcs11/commit/7ea26bb5f68f8a64faf215173d25c9996a5bdcf9]
+
+Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ test/integration/pkcs11-tool.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/integration/pkcs11-tool.sh b/test/integration/pkcs11-tool.sh
+index b5919fd..afd7e4a 100755
+--- a/test/integration/pkcs11-tool.sh
++++ b/test/integration/pkcs11-tool.sh
+@@ -38,7 +38,7 @@ echo "Found privkey"
+ 
+ # test pin change
+ echo "Attempting pin change"
+-pkcs11-tool --module "$modpath" --slot=1 --login --pin myuserpin --change-pin --new-pin mynewpin
++pkcs11_tool --slot=1 --login --pin myuserpin --change-pin --new-pin mynewpin
+ echo "Pin changed"
+ 
+ # change userpin from sopin

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0004-test-integration-validate-ECDH-1-with-EC-NIST-P256.patch
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0004-test-integration-validate-ECDH-1-with-EC-NIST-P256.patch
@@ -1,0 +1,270 @@
+From cea8d29d95df4c55122f818e456d4d644052ce33 Mon Sep 17 00:00:00 2001
+From: Jorge Ramirez-Ortiz <jorge@foundries.io>
+Date: Wed, 22 Feb 2023 23:17:14 +0100
+Subject: [PATCH] test: integration: validate ECDH-1 with EC NIST-P256
+
+Create two EC pairs, derive shared secrets and verify they are the same.
+
+Upstream-Status: Backport [https://github.com/tpm2-software/tpm2-pkcs11/commit/e331fe53d2e887beb6167cdbd54a4f8e3a35c70e]
+
+Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ Makefile-integration.am          |   7 +-
+ test/integration/pkcs-ecdh.int.c | 222 +++++++++++++++++++++++++++++++
+ 2 files changed, 228 insertions(+), 1 deletion(-)
+ create mode 100644 test/integration/pkcs-ecdh.int.c
+
+diff --git a/Makefile-integration.am b/Makefile-integration.am
+index 12af137..e2255de 100644
+--- a/Makefile-integration.am
++++ b/Makefile-integration.am
+@@ -41,7 +41,8 @@ check_PROGRAMS += \
+     test/integration/pkcs-crypt.int \
+     test/integration/pkcs-keygen.int \
+     test/integration/pkcs-session-state.int \
+-    test/integration/pkcs-lockout.int
++    test/integration/pkcs-lockout.int \
++    test/integration/pkcs-ecdh.int
+ 
+ # add test scripts
+ check_SCRIPTS += $(integration_scripts)
+@@ -97,6 +98,10 @@ test_integration_pkcs_keygen_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
+ test_integration_pkcs_keygen_int_LDADD   = $(TESTS_LDADD)  $(SQLITE3_LIBS)
+ test_integration_pkcs_keygen_int_SOURCES = test/integration/pkcs-keygen.int.c test/integration/test.c
+ 
++test_integration_pkcs_ecdh_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
++test_integration_pkcs_ecdh_int_LDADD   = $(TESTS_LDADD)  $(SQLITE3_LIBS)
++test_integration_pkcs_ecdh_int_SOURCES = test/integration/pkcs-ecdh.int.c test/integration/test.c
++
+ test_integration_pkcs_session_state_int_CFLAGS  = $(AM_CFLAGS) $(TESTS_CFLAGS)
+ test_integration_pkcs_session_state_int_LDADD   = $(TESTS_LDADD)  $(SQLITE3_LIBS)
+ test_integration_pkcs_session_state_int_SOURCES = test/integration/pkcs-session-state.c test/integration/test.c
+diff --git a/test/integration/pkcs-ecdh.int.c b/test/integration/pkcs-ecdh.int.c
+new file mode 100644
+index 0000000..188244e
+--- /dev/null
++++ b/test/integration/pkcs-ecdh.int.c
+@@ -0,0 +1,222 @@
++/* SPDX-License-Identifier: BSD-2-Clause */
++
++#include <openssl/evp.h>
++#include <openssl/rsa.h>
++#include <openssl/err.h>
++#include <assert.h>
++
++#include "test.h"
++
++#define ATTR(a, v, t) { a, &(t){v}, sizeof(t) }
++#define ATTR_VAR(a, v, len) { a, v, len }
++
++struct test_info {
++    CK_SESSION_HANDLE handle;
++    CK_SLOT_ID slot_id;
++};
++
++static test_info *test_info_new(void) {
++
++    test_info *ti = calloc(1, sizeof(*ti));
++    assert_non_null(ti);
++
++    /* Get the slots */
++    CK_SLOT_ID slots[6];
++    CK_ULONG count = ARRAY_LEN(slots);
++    CK_RV rv = C_GetSlotList(true, slots, &count);
++    assert_int_equal(rv, CKR_OK);
++
++    ti->slot_id = slots[0];
++
++    return ti;
++}
++
++static int test_setup(void **state) {
++
++    test_info *ti = test_info_new();
++
++    CK_RV rv = C_OpenSession(ti->slot_id, CKF_SERIAL_SESSION | CKF_RW_SESSION,
++            NULL, NULL, &ti->handle);
++    assert_int_equal(rv, CKR_OK);
++
++    *state = ti;
++
++    return 0;
++}
++
++static int test_teardown(void **state) {
++
++    test_info *ti = test_info_from_state(state);
++
++    CK_RV rv = C_CloseAllSessions(ti->slot_id);
++    assert_int_equal(rv, CKR_OK);
++
++    free(ti);
++
++    return 0;
++}
++
++static void gen_ecc_keypair(CK_SESSION_HANDLE session, CK_BYTE id,
++                            CK_BYTE *curve, size_t curve_size,
++                            uint8_t *pubkey, size_t *pubkey_len) {
++
++    CK_MECHANISM mechanism = { CKM_EC_KEY_PAIR_GEN, NULL, 0 };
++    CK_ATTRIBUTE pub_template[] = {
++        ATTR(CKA_CLASS, CKO_PUBLIC_KEY, CK_OBJECT_CLASS),
++        ATTR(CKA_KEY_TYPE, CKK_EC, CK_KEY_TYPE),
++        ATTR(CKA_DERIVE, CK_TRUE, CK_BBOOL),
++        ATTR(CKA_TOKEN, CK_TRUE, CK_BBOOL),
++        /* */
++        ATTR_VAR(CKA_EC_PARAMS, curve, curve_size),
++    };
++    CK_ATTRIBUTE priv_template[] = {
++        ATTR(CKA_CLASS, CKO_PRIVATE_KEY, CK_OBJECT_CLASS),
++        ATTR(CKA_KEY_TYPE, CKK_EC, CK_KEY_TYPE),
++        ATTR(CKA_PRIVATE, CK_TRUE, CK_BBOOL),
++        ATTR(CKA_SENSITIVE, CK_TRUE, CK_BBOOL),
++        ATTR(CKA_DERIVE, CK_TRUE, CK_BBOOL),
++        ATTR(CKA_DECRYPT, CK_TRUE, CK_BBOOL),
++        ATTR(CKA_TOKEN, CK_TRUE, CK_BBOOL),
++        /* */
++        ATTR(CKA_ID, id, CK_BYTE),
++    };
++    CK_ATTRIBUTE ec_point = { CKA_EC_POINT, NULL, 0 };
++    CK_OBJECT_HANDLE private = CK_INVALID_HANDLE;
++    CK_OBJECT_HANDLE public = CK_INVALID_HANDLE;
++    CK_RV rv = CKR_GENERAL_ERROR;
++
++    rv = C_GenerateKeyPair(session, & mechanism,
++                           pub_template, ARRAY_LEN(pub_template),
++                           priv_template, ARRAY_LEN(priv_template),
++                           &public, &private);
++    assert_int_equal(rv, CKR_OK);
++
++    rv = C_GetAttributeValue(session, public, &ec_point, 1);
++    assert_int_equal(rv, CKR_OK);
++
++    assert(*pubkey_len >= ec_point.ulValueLen);
++    ec_point.pValue = pubkey;
++
++    rv = C_GetAttributeValue(session, public, &ec_point, 1);
++    assert_int_equal(rv, CKR_OK);
++
++    *pubkey_len = ec_point.ulValueLen;
++}
++
++static void gen_nistp256(CK_SESSION_HANDLE session, CK_BYTE id,
++                         uint8_t* pubkey, size_t *pubkey_len) {
++    CK_BYTE curve[] = {
++        0x06, 0x08, 0x2a, 0x86, 0x48,
++        0xce, 0x3d, 0x03, 0x01, 0x07
++    };
++
++    gen_ecc_keypair(session, id, curve, sizeof(curve), pubkey, pubkey_len);
++}
++
++static void ecdh1_derive(CK_SESSION_HANDLE session, CK_BYTE id,
++                         uint8_t *pubkey, size_t pubkey_len,
++                         uint8_t *secret, size_t secret_len) {
++
++    CK_MECHANISM mechanism = { CKM_ECDH1_DERIVE, NULL, 0 };
++    CK_ATTRIBUTE secret_template[] = {
++        ATTR(CKA_KEY_TYPE, CKK_GENERIC_SECRET, CK_KEY_TYPE),
++        ATTR(CKA_CLASS, CKO_SECRET_KEY, CK_OBJECT_CLASS),
++        ATTR(CKA_EXTRACTABLE, CK_TRUE, CK_BBOOL),
++        ATTR(CKA_TOKEN, CK_FALSE, CK_BBOOL),
++        ATTR(CKA_SENSITIVE, CK_FALSE, CK_BBOOL),
++        /* */
++        ATTR(CKA_VALUE_LEN, secret_len, CK_ULONG),
++    };
++    CK_ATTRIBUTE priv_template[] = {
++        ATTR(CKA_CLASS, CKO_PRIVATE_KEY, CK_OBJECT_CLASS),
++        ATTR(CKA_KEY_TYPE, CKK_EC, CK_KEY_TYPE),
++        ATTR(CKA_PRIVATE, CK_TRUE, CK_BBOOL),
++        ATTR(CKA_SENSITIVE, CK_TRUE, CK_BBOOL),
++        ATTR(CKA_DERIVE, CK_TRUE, CK_BBOOL),
++        ATTR(CKA_DECRYPT, CK_TRUE, CK_BBOOL),
++        ATTR(CKA_TOKEN, CK_TRUE, CK_BBOOL),
++        /* */
++        ATTR(CKA_ID, id, CK_BYTE),
++    };
++    CK_ATTRIBUTE derived_template[] = {
++        ATTR_VAR(CKA_VALUE, secret, secret_len),
++    };
++    CK_ECDH1_DERIVE_PARAMS params = {
++        .kdf = CKD_NULL,
++        .ulSharedDataLen = 0,
++        .pSharedData = secret,
++        .ulPublicDataLen = 0,
++        .pPublicData = NULL,
++    };
++    CK_OBJECT_HANDLE private = CK_INVALID_HANDLE;
++    CK_OBJECT_HANDLE derived = CK_INVALID_HANDLE;
++    CK_RV rv = CKR_GENERAL_ERROR;
++    CK_ULONG count = 0;
++
++    /* Populate the mechanism, skip the DER header */
++    mechanism.ulParameterLen = sizeof(params);
++    mechanism.mechanism = CKM_ECDH1_DERIVE;
++    mechanism.pParameter = &params;
++    params.ulPublicDataLen = pubkey_len - 2;
++    pubkey++;
++    pubkey++;
++    params.pPublicData = pubkey;
++
++    /* Retrieve the private key */
++    rv = C_FindObjectsInit(session, priv_template, ARRAY_LEN(priv_template));
++    assert_int_equal(rv, CKR_OK);
++
++    rv = C_FindObjects(session, &private, 2, &count);
++    assert_int_equal(rv, CKR_OK);
++    assert_int_equal(count, 1);
++
++    rv = C_FindObjectsFinal(session);
++    assert_int_equal(rv, CKR_OK);
++
++    /* Derive */
++    rv = C_DeriveKey(session, &mechanism, private, secret_template,
++                     ARRAY_LEN(secret_template), &derived);
++    assert_int_equal(rv, CKR_OK);
++
++    /* Get the secret */
++    rv = C_GetAttributeValue(session, derived, derived_template,
++                             ARRAY_LEN(derived_template));
++    assert_int_equal(rv, CKR_OK);
++}
++
++static void test_ecc_derive_nist_p256_templ(void **state) {
++
++    test_info *ti = test_info_from_state(state);
++    CK_SESSION_HANDLE session = ti->handle;
++
++    /* NIST P-256: 32 bytes */
++    struct {
++        CK_BYTE shr[32];    /* Shared secret is the length of the key */
++        CK_BYTE pub[70];    /* Allocate extra space for encoding      */
++        size_t plen;
++        CK_BYTE id;
++    } key[] = {
++        [0] = { .id = 0x00, .shr = { 0 }, .pub = { 0 }, .plen = 70 },
++        [1] = { .id = 0x01, .shr = { 1 }, .pub = { 1 }, .plen = 70 },
++    };
++
++    user_login(session);
++
++    gen_nistp256(session, key[0].id, key[0].pub, &key[0].plen);
++    gen_nistp256(session, key[1].id, key[1].pub, &key[1].plen);
++
++    ecdh1_derive(session, key[0].id, key[1].pub, key[1].plen, key[0].shr, 32);
++    ecdh1_derive(session, key[1].id, key[0].pub, key[0].plen, key[1].shr, 32);
++
++    assert(memcmp(key[0].shr, key[1].shr, 32) == 0);
++}
++
++int main() {
++
++    const struct CMUnitTest tests[] = {
++        cmocka_unit_test_setup_teardown(test_ecc_derive_nist_p256_templ,
++                                        test_setup, test_teardown),
++    };
++
++    return cmocka_run_group_tests(tests, group_setup, group_teardown);
++}

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0005-Fix-failing-database-upgrade.patch
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0005-Fix-failing-database-upgrade.patch
@@ -1,0 +1,29 @@
+From 9230de009e3e37a27927c241e3a70a6330ccbdbf Mon Sep 17 00:00:00 2001
+From: Tobias Wackenhut <tobias@wackenhut.at>
+Date: Fri, 17 Feb 2023 00:15:43 +0100
+Subject: [PATCH] Fix failing database upgrade
+
+Fix double conversion to int, causing a failing database upgrade
+
+Upstream-Status: Backport [https://github.com/tpm2-software/tpm2-pkcs11/commit/2d97e4cb40ca2d5becb5a2e7adbf0eca2f067efe]
+
+Signed-off-by: Tobias Wackenhut <tobias@wackenhut.at>
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ tools/tpm2_pkcs11/db.py | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/tools/tpm2_pkcs11/db.py b/tools/tpm2_pkcs11/db.py
+index 6d5fa68..36edc7e 100644
+--- a/tools/tpm2_pkcs11/db.py
++++ b/tools/tpm2_pkcs11/db.py
+@@ -557,8 +557,7 @@ class Db(object):
+                 if attr == CKA_ALLOWED_MECHANISMS and \
+                     isinstance(attrs[attr], str):
+                         list_hexa = [socket.ntohl(int(attrs[attr][i:i+long_size], 16)) for i in range(0, len(attrs[attr]), long_size)]
+-                        list_int = [int(x,16) for x in list_hexa]
+-                        attrs[attr] = list_int
++                        attrs[attr] = list_hexa
+ 
+             Db._updatetertiary(dbbakcon, t['id'], attrs)
+ 

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0006-db-add-test-for-building-lock-file-path.patch
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0006-db-add-test-for-building-lock-file-path.patch
@@ -1,0 +1,140 @@
+From 3c75be6f597a1dbf11b78f5e612647d1b2449985 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?P=C3=A9ter=20V=C3=A1g=C3=A1ny?= <pevagany@gmail.com>
+Date: Thu, 23 Feb 2023 17:24:58 +0200
+Subject: [PATCH] db: add test for building lock file path
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Make sure to create correct paths and respect PKCS11_SQL_LOCK env var.
+
+Upstream-Status: Backport [https://github.com/tpm2-software/tpm2-pkcs11/commit/98876b388c185781afa346cc9e124c8265dacd5f]
+
+Signed-off-by: Péter Vágány <pevagany@gmail.com>
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ src/lib/db.c        | 13 +++++++++++--
+ src/lib/db.h        |  1 +
+ test/unit/test_db.c | 45 ++++++++++++++++++++++++++++++++++++++++++++-
+ 3 files changed, 56 insertions(+), 3 deletions(-)
+
+diff --git a/src/lib/db.c b/src/lib/db.c
+index 8532904..d7792ea 100644
+--- a/src/lib/db.c
++++ b/src/lib/db.c
+@@ -2387,7 +2387,7 @@ static CK_RV db_create(char *path, size_t len) {
+     return db_for_path(path, len, db_create_handler);
+ }
+ 
+-DEBUG_VISIBILITY FILE *take_lock(const char *path, char *lockpath) {
++DEBUG_VISIBILITY int get_lock_path(const char *path, char *lockpath) {
+ 
+     unsigned l;
+ 
+@@ -2405,7 +2405,7 @@ DEBUG_VISIBILITY FILE *take_lock(const char *path, char *lockpath) {
+         }
+         if ((lenv_lock + 1 + strlen(path) + strlen(".lock")) >= PATH_MAX) {
+             LOGE("Lock file path would be longer than PATH_MAX");
+-            return NULL;
++            return SQLITE_ERROR;
+         }
+         strncpy(lockpath, env_lock, PATH_MAX-1);
+         strcat(lockpath, "/");
+@@ -2424,6 +2424,15 @@ DEBUG_VISIBILITY FILE *take_lock(const char *path, char *lockpath) {
+     }
+     if (l >= PATH_MAX) {
+         LOGE("Lock file path is longer than PATH_MAX");
++        return SQLITE_ERROR;
++    }
++
++    return SQLITE_OK;
++}
++
++DEBUG_VISIBILITY FILE *take_lock(const char *path, char *lockpath) {
++
++    if (get_lock_path(path, lockpath) != SQLITE_OK) {
+         return NULL;
+     }
+ 
+diff --git a/src/lib/db.h b/src/lib/db.h
+index 9653c16..52b7851 100644
+--- a/src/lib/db.h
++++ b/src/lib/db.h
+@@ -92,6 +92,7 @@ int init_pobject(unsigned pid, pobject *pobj, tpm_ctx *tpm);
+ int __real_init_pobject(unsigned pid, pobject *pobj, tpm_ctx *tpm);
+ int init_sealobjects(unsigned tokid, sealobject *sealobj);
+ int __real_init_sealobjects(unsigned tokid, sealobject *sealobj);
++int get_lock_path(const char *path, char *lockpath);
+ FILE *take_lock(const char *path, char *lockpath);
+ #endif
+ 
+diff --git a/test/unit/test_db.c b/test/unit/test_db.c
+index a3e3f0d..00e0739 100644
+--- a/test/unit/test_db.c
++++ b/test/unit/test_db.c
+@@ -1,6 +1,7 @@
+ /* SPDX-License-Identifier: BSD-2-Clause */
+ 
+ #include <errno.h>
++#include <limits.h>
+ #include <stdarg.h>
+ #include <stdbool.h>
+ #include <stddef.h>
+@@ -2838,6 +2839,47 @@ static void test_db_add_token_sqlite3_step_2_fail(void **state) {
+     assert_int_equal(rv, CKR_GENERAL_ERROR);
+ }
+ 
++static void test_db_get_lock_path(void **state) {
++    UNUSED(state);
++
++    const char *db_path = "/etc/tpm2_pkcs11/tpm2_pkcs11.sqlite3";
++    char lock_path[PATH_MAX];
++
++    memset(lock_path, 0, sizeof lock_path);
++    unsetenv("PKCS11_SQL_LOCK");
++    assert_int_equal(get_lock_path(db_path, lock_path), SQLITE_OK);
++    assert_string_equal(lock_path, "/etc/tpm2_pkcs11/tpm2_pkcs11.sqlite3.lock");
++
++    memset(lock_path, 0, sizeof lock_path);
++    setenv("PKCS11_SQL_LOCK", "", 1);
++    assert_int_equal(get_lock_path(db_path, lock_path), SQLITE_OK);
++    assert_string_equal(lock_path, "/etc/tpm2_pkcs11/tpm2_pkcs11.sqlite3.lock");
++
++    memset(lock_path, 0, sizeof lock_path);
++    setenv("PKCS11_SQL_LOCK", "/tmp", 1);
++    assert_int_equal(get_lock_path(db_path, lock_path), SQLITE_OK);
++    assert_string_equal(lock_path, "/tmp/_etc_tpm2_pkcs11_tpm2_pkcs11.sqlite3.lock");
++
++    memset(lock_path, 0, sizeof lock_path);
++    setenv("PKCS11_SQL_LOCK", "/tmp/", 1);
++    assert_int_equal(get_lock_path(db_path, lock_path), SQLITE_OK);
++    assert_string_equal(lock_path, "/tmp/_etc_tpm2_pkcs11_tpm2_pkcs11.sqlite3.lock");
++
++    char long_path[PATH_MAX];
++    memset(long_path, 'l', sizeof long_path);
++    long_path[PATH_MAX - 1] = '\0';
++
++    memset(lock_path, 0, sizeof lock_path);
++    setenv("PKCS11_SQL_LOCK", long_path, 1);
++    assert_int_equal(get_lock_path(db_path, lock_path), SQLITE_ERROR);
++
++    memset(lock_path, 0, sizeof lock_path);
++    unsetenv("PKCS11_SQL_LOCK");
++    assert_int_equal(get_lock_path(long_path, lock_path), SQLITE_ERROR);
++
++    unsetenv("PKCS11_SQL_LOCK");
++}
++
+ int main(int argc, char* argv[]) {
+     (void) argc;
+     (void) argv;
+@@ -2950,7 +2992,8 @@ int main(int argc, char* argv[]) {
+         cmocka_unit_test(test_db_add_token_sqlite3_bind_text_3_fail),
+         cmocka_unit_test(test_db_add_token_sqlite3_bind_blob_1_fail),
+         cmocka_unit_test(test_db_add_token_sqlite3_bind_blob_2_fail),
+-        cmocka_unit_test(test_db_add_token_sqlite3_step_2_fail)
++        cmocka_unit_test(test_db_add_token_sqlite3_step_2_fail),
++        cmocka_unit_test(test_db_get_lock_path),
+     };
+ 
+     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0007-db-fix-PKCS11_SQL_LOCK-usage.patch
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0007-db-fix-PKCS11_SQL_LOCK-usage.patch
@@ -1,0 +1,33 @@
+From 5ef1c96324e28c6cfafb322c461e4e9bf97105f3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?P=C3=A9ter=20V=C3=A1g=C3=A1ny?= <pevagany@gmail.com>
+Date: Thu, 23 Feb 2023 17:53:37 +0200
+Subject: [PATCH] db: fix PKCS11_SQL_LOCK usage
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add parentheses for explicit order of preference.
+
+Fixes: #820
+
+Upstream-Status: Backport [https://github.com/tpm2-software/tpm2-pkcs11/commit/e8a3efd61736325a0296a4d9cf2c90c0f7144a2f]
+
+Signed-off-by: Péter Vágány <pevagany@gmail.com>
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ src/lib/db.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/lib/db.c b/src/lib/db.c
+index d7792ea..b4bbd1b 100644
+--- a/src/lib/db.c
++++ b/src/lib/db.c
+@@ -2394,7 +2394,7 @@ DEBUG_VISIBILITY int get_lock_path(const char *path, char *lockpath) {
+     size_t lenv_lock = 0;
+     char *env_lock = getenv("PKCS11_SQL_LOCK");
+ 
+-    if (env_lock && (lenv_lock = strlen(env_lock) > 0)) {
++    if (env_lock && ((lenv_lock = strlen(env_lock)) > 0)) {
+         /*
+          * lock file shall be "PKCS11_SQL_LOCK" + '/' + path + ".lock", but
+          * path's '/' will be substituted by '_'.

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0008-configure-update-with-fapi-configure-option.patch
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0008-configure-update-with-fapi-configure-option.patch
@@ -1,0 +1,50 @@
+From dc423b6913dcc1e96aee006c42b8c2a7d6f39de6 Mon Sep 17 00:00:00 2001
+From: William Roberts <william.c.roberts@intel.com>
+Date: Mon, 27 Feb 2023 12:14:05 -0600
+Subject: [PATCH] configure: update --with-fapi configure option
+
+Update configure.ac to use AC_ARG_WITH and update the docs to the proper
+argument. Keep the option the same for downstream packagers.
+
+Fixes: #822
+
+Upstream-Status: Backport [https://github.com/tpm2-software/tpm2-pkcs11/commit/7ad56b0faa30691e22a110b4ddc91251846d48a4]
+
+Signed-off-by: William Roberts <william.c.roberts@intel.com>
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ configure.ac     | 4 ++--
+ docs/BUILDING.md | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index d31f854..771004b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -114,11 +114,11 @@ AC_ARG_ENABLE(
+ AS_IF([test "x$esapi_sf" = "xyes"],
+        [do_esapi_manage_flags])
+ 
+-AC_ARG_ENABLE(
++AC_ARG_WITH(
+   [fapi],
+   [AS_HELP_STRING([--with-fapi],
+     [enable or disable the fapi backend. Default is "auto" to autodetect])],
+-    [enable_fapi=$enableval],
++    [enable_fapi=$withval],
+     [enable_fapi=auto])
+ 
+ AC_DEFUN([do_fapi_configure], [
+diff --git a/docs/BUILDING.md b/docs/BUILDING.md
+index e0bf9fd..5c725d2 100644
+--- a/docs/BUILDING.md
++++ b/docs/BUILDING.md
+@@ -120,7 +120,7 @@ Building the project and running tests can be also done with specific shell comm
+ ```sh
+ # Configure tpm2-pkcs11 to build unit and integration tests
+ ./bootstrap
+-./configure --enable-fapi --enable-unit --enable-integration
++./configure --with-fapi --enable-unit --enable-integration
+ 
+ # Build the project and run tests
+ make -j $(nproc)

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0009-test-use-default-not-base-in-openssl-provider.patch
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11/0009-test-use-default-not-base-in-openssl-provider.patch
@@ -1,0 +1,49 @@
+From 574e17cfae790bf3227f8e4a25cabe59822a462e Mon Sep 17 00:00:00 2001
+From: William Roberts <william.c.roberts@intel.com>
+Date: Wed, 1 Mar 2023 12:14:47 -0600
+Subject: [PATCH] test: use default not base in openssl provider
+
+Fixes things like:
+openssl req -provider tpm2 -provider base -new -x509 -days 365 -subj '/CN=my key/' -sha256 -key /tmp/tpm_simulator_TKIAAZ/14.pem --passin pass:1a4b7d67c5a2cce3f2a04cdaf1c062e3 -out /tmp/tpm_simulator_TKIAAZ/cert.pem.ec1
+Error adding x509 extensions from section v3_ca
+809BACAF177F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:../crypto/evp/evp_fetch.c:349:Global default library context, Algorithm (SHA1 : 94), Properties (<null>)
+809BACAF177F0000:error:11000080:X509 V3 routines:X509V3_EXT_nconf_int:error in extension:../crypto/x509/v3_conf.c:48:section=v3_ca, name=subjectKeyIdentifier, value=hash
+
+Upstream-Status: Backport [https://github.com/tpm2-software/tpm2-pkcs11/commit/1b3aab90ee5f7debbce82c7e229aa2950a9e8f0d]
+
+Signed-off-by: William Roberts <william.c.roberts@intel.com>
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ test/integration/scripts/create_pkcs_store.sh | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/test/integration/scripts/create_pkcs_store.sh b/test/integration/scripts/create_pkcs_store.sh
+index c7699d5..2b03ea7 100755
+--- a/test/integration/scripts/create_pkcs_store.sh
++++ b/test/integration/scripts/create_pkcs_store.sh
+@@ -181,21 +181,21 @@ if [ "$OSSL3_DETECTED" -eq "1" ]; then
+     setup_asan
+ 
+     TPM2OPENSSL_PARENT_AUTH="mypobjpin" openssl \
+-        req -provider tpm2 -provider base -new -x509 -days 365 -subj '/CN=my key/' -sha256 \
++        req -provider tpm2 -provider default -new -x509 -days 365 -subj '/CN=my key/' -sha256 \
+             -key "$TPM2_PKCS11_STORE/14.pem" --passin "pass:$auth_14" -out "$cert.ec1"
+ 
+     TPM2OPENSSL_PARENT_AUTH="mypobjpin" openssl \
+-        req -provider tpm2 -provider base -new -x509 -days 365 -subj '/CN=my key/' -sha256 \
++        req -provider tpm2 -provider default -new -x509 -days 365 -subj '/CN=my key/' -sha256 \
+         -key "$TPM2_PKCS11_STORE/6.pem" --passin "pass:$auth_6" \
+         -config "$TEST_FIXTURES/ossl-req-ca.cnf" -extensions ca_ext -out "$cert.rsa1"
+ 
+ 	# sign a certificate for rsa2 using the rsa1 key
+ 	TPM2OPENSSL_PARENT_AUTH="mypobjpin" openssl \
+-	    req -provider tpm2 -provider base -new -subj '/CN=my sub key/' -sha256 \
++	    req -provider tpm2 -provider default -new -subj '/CN=my sub key/' -sha256 \
+ 	    -key "$TPM2_PKCS11_STORE/8.pem" --passin "pass:$auth_8" -out "$cert.csr.rsa2"
+ 
+ 	TPM2OPENSSL_PARENT_AUTH="mypobjpin" openssl \
+-    	x509 -provider tpm2 -provider base -req -days 365 -sha256 -in "$cert.csr.rsa2" \
++        x509 -provider tpm2 -provider default -req -days 365 -sha256 -in "$cert.csr.rsa2" \
+     	-CA "$cert.rsa1" -CAkey "$TPM2_PKCS11_STORE/6.pem" --passin "pass:$auth_6"\
+     	-CAcreateserial -extfile "$TEST_FIXTURES/ossl-req-cert.cnf" -extensions cert_ext \
+     	-out "$cert.rsa2"

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_1.9.0.bb
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_1.9.0.bb
@@ -1,0 +1,47 @@
+SUMMARY = "A PKCS#11 interface for TPM2 hardware"
+DESCRIPTION = "PKCS #11 is a Public-Key Cryptography Standard that defines a standard method to access cryptographic services from tokens/ devices such as hardware security modules (HSM), smart cards, etc. In this project we intend to use a TPM2 device as the cryptographic token."
+SECTION = "security/tpm"
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=0fc19f620a102768d6dbd1e7166e78ab"
+
+DEPENDS = "autoconf-archive pkgconfig sqlite3 openssl libtss2-dev tpm2-tools libyaml p11-kit python3-setuptools-native"
+
+SRC_URI = "https://github.com/tpm2-software/${BPN}/releases/download/${PV}/${BPN}-${PV}.tar.gz"
+
+SRC_URI[sha256sum] = "35bf06c30cfa76fc0eba2c5f503cf7dd0d34a66afb2d292fee896b90362f633b"
+
+UPSTREAM_CHECK_URI = "https://github.com/tpm2-software/${BPN}/releases"
+
+inherit autotools-brokensep pkgconfig python3native
+
+EXTRA_OECONF += "--disable-ptool-checks"
+
+do_compile:append() {
+    cd ${S}/tools
+    python3 setup.py build
+}
+
+do_install:append() {
+    cd ${S}/tools
+    export PYTHONPATH="${D}${PYTHON_SITEPACKAGES_DIR}"
+    ${PYTHON_PN} setup.py install --root="${D}" --prefix="${prefix}" --install-lib="${PYTHON_SITEPACKAGES_DIR}" --optimize=1 --skip-build
+
+    sed -i -e "s:${PYTHON}:${USRBINPATH}/env ${PYTHON_PN}:g" "${D}${bindir}"/tpm2_ptool
+}
+
+PACKAGES =+ "${PN}-tools"
+
+FILES:${PN}-tools = "\
+    ${bindir}/tpm2_ptool \
+    ${libdir}/${PYTHON_DIR}/* \
+    "
+
+FILES:${PN} += "\
+    ${libdir}/pkcs11/* \
+    ${datadir}/p11-kit/* \
+    "
+
+INSANE_SKIP:${PN}   += "dev-so"
+
+RDEPENDS:${PN} = "p11-kit tpm2-tools "
+RDEPENDS:${PN}-tools = "${PYTHON_PN}-pyyaml ${PYTHON_PN}-cryptography ${PYTHON_PN}-pyasn1-modules"

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_1.9.0.bb
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_1.9.0.bb
@@ -24,6 +24,9 @@ UPSTREAM_CHECK_URI = "https://github.com/tpm2-software/${BPN}/releases"
 
 inherit autotools-brokensep pkgconfig python3native
 
+PACKAGECONFIG ?= ""
+PACKAGECONFIG[fapi] = "--with-fapi=yes,--with-fapi=no,tpm2-tss"
+
 EXTRA_OECONF += "--disable-ptool-checks"
 
 do_compile:append() {

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_1.9.0.bb
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_1.9.0.bb
@@ -6,7 +6,17 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=0fc19f620a102768d6dbd1e7166e78ab"
 
 DEPENDS = "autoconf-archive pkgconfig sqlite3 openssl libtss2-dev tpm2-tools libyaml p11-kit python3-setuptools-native"
 
-SRC_URI = "https://github.com/tpm2-software/${BPN}/releases/download/${PV}/${BPN}-${PV}.tar.gz"
+SRC_URI = "https://github.com/tpm2-software/${BPN}/releases/download/${PV}/${BPN}-${PV}.tar.gz \
+           file://0001-lib-ecdh1-derive-simple-implementation-for-KDF-null.patch \
+           file://0002-test-pkcs11-tool.sh-ECDH1-shared-secret-generation.patch \
+           file://0003-test-pkcs11-tool.sh-replace-call-to-pkcs11-tool-for-.patch \
+           file://0004-test-integration-validate-ECDH-1-with-EC-NIST-P256.patch \
+           file://0005-Fix-failing-database-upgrade.patch \
+           file://0006-db-add-test-for-building-lock-file-path.patch \
+           file://0007-db-fix-PKCS11_SQL_LOCK-usage.patch \
+           file://0008-configure-update-with-fapi-configure-option.patch \
+           file://0009-test-use-default-not-base-in-openssl-provider.patch \
+           "
 
 SRC_URI[sha256sum] = "35bf06c30cfa76fc0eba2c5f503cf7dd0d34a66afb2d292fee896b90362f633b"
 

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_1.9.0.bb
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_1.9.0.bb
@@ -24,7 +24,7 @@ UPSTREAM_CHECK_URI = "https://github.com/tpm2-software/${BPN}/releases"
 
 inherit autotools-brokensep pkgconfig python3native
 
-PACKAGECONFIG ?= ""
+PACKAGECONFIG ?= "fapi"
 PACKAGECONFIG[fapi] = "--with-fapi=yes,--with-fapi=no,tpm2-tss"
 
 EXTRA_OECONF += "--disable-ptool-checks"

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_1.9.0.bb
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-pkcs11/tpm2-pkcs11_1.9.0.bb
@@ -24,7 +24,7 @@ UPSTREAM_CHECK_URI = "https://github.com/tpm2-software/${BPN}/releases"
 
 inherit autotools-brokensep pkgconfig python3native
 
-PACKAGECONFIG ?= "fapi"
+PACKAGECONFIG ?= ""
 PACKAGECONFIG[fapi] = "--with-fapi=yes,--with-fapi=no,tpm2-tss"
 
 EXTRA_OECONF += "--disable-ptool-checks"

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-tss/tpm2-tss_%.bbappend
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-tss/tpm2-tss_%.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG += "fapi"

--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-tss/tpm2-tss_%.bbappend
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-tss/tpm2-tss_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG += "fapi"

--- a/meta-lmp-base/recipes-samples/images/lmp-feature-tpm2.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-tpm2.inc
@@ -1,4 +1,5 @@
 # TPM2 package group from meta-tpm
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-security-tpm2 \
+    pkcs11-provider \
 "

--- a/meta-lmp-base/recipes-security/pkcs11/files/0001-configure.ac-fix-libsoftokn3-detection-when-cross-co.patch
+++ b/meta-lmp-base/recipes-security/pkcs11/files/0001-configure.ac-fix-libsoftokn3-detection-when-cross-co.patch
@@ -1,0 +1,45 @@
+From 4e17314c73ba7d50dacd74615d7db9d226085282 Mon Sep 17 00:00:00 2001
+From: Jose Quaresma <jose.quaresma@foundries.io>
+Date: Thu, 2 Mar 2023 15:45:40 +0000
+Subject: [PATCH] configure.ac: fix libsoftokn3 detection when cross compiling
+
+These fix cross compilation with bitbake:
+
+| checking for /build/tmp-lmp/work/corei7-64-lmp-linux/pkcs11-provider/0.1+git999-r0/recipe-sysroot/usr/lib/libsoftokn3.so... configure: error: cannot check for file existence when cross compiling
+
+Upstream-Status: Pending
+
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ configure.ac | 14 ++++++++++----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 7d3f163..0f66844 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -95,11 +95,17 @@ PKG_CHECK_EXISTS(
+         )]
+ )
+ 
+-AC_CHECK_FILE($SOFTOKENDIR/libsoftokn3$SHARED_EXT, [],
+-    [AC_CHECK_FILE($SOFTOKENDIR/nss/libsoftokn3$SHARED_EXT,
+-        [AC_SUBST([SOFTOKEN_SUBDIR], "nss/")],
++if test "$cross_compiling" != "yes"; then
++    AC_CHECK_FILE($SOFTOKENDIR/libsoftokn3$SHARED_EXT, [],
++        [AC_CHECK_FILE($SOFTOKENDIR/nss/libsoftokn3$SHARED_EXT,
++            [AC_SUBST([SOFTOKEN_SUBDIR], "nss/")],
++            [AC_MSG_WARN([Softoken library missing, tests will fail!])])
++        ])
++else
++    AS_IF([test -a "$SOFTOKENDIR/libsoftokn3$SHARED_EXT"],
++        [],
+         [AC_MSG_WARN([Softoken library missing, tests will fail!])])
+-    ])
++fi
+ 
+ # find p11-kit-client to separate softhsm openssl context from our tests
+ PKG_CHECK_EXISTS([p11-kit-1],
+-- 
+2.34.1
+

--- a/meta-lmp-base/recipes-security/pkcs11/pkcs11-provider_git.bb
+++ b/meta-lmp-base/recipes-security/pkcs11/pkcs11-provider_git.bb
@@ -1,0 +1,23 @@
+HOMEPAGE = "https://github.com/latchset/pkcs11-provider"
+SUMMARY =  "A pkcs#11 provider for OpenSSL 3.0+"
+DESCRIPTION = "This is an Openssl 3.x provider to access Hardware or Software \
+ Tokens using the PKCS#11 Cryptographic Token Interface"
+
+LICENSE = "Apache-2.0 & OASIS"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b53b787444a60266932bd270d1cf2d45 \
+                    file://LICENSES/LicenseRef-OASIS-IPR.txt;md5=d709b4c4f378c7ed5e113342135bfe57"
+
+SRC_URI = "git://github.com/latchset/pkcs11-provider;protocol=https;branch=main \
+           file://0001-configure.ac-fix-libsoftokn3-detection-when-cross-co.patch \
+           "
+
+PV = "0.1+git${SRCPV}"
+SRCREV = "f6d320951b61697986f57123b396962287764195"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "autoconf-archive nss p11-kit openssl"
+
+inherit pkgconfig autotools
+
+FILES:${PN} += "${nonarch_base_libdir}/ossl-modules/pkcs11.so"


### PR DESCRIPTION
A pkcs#11 provider for OpenSSL 3.0+

This is an Openssl 3.x provider to access Hardware or Software
Tokens using the PKCS#11 Cryptographic Token Interface

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>