### PR TITLE
base: u-boot-ostree-scr-fit: sync is_secondary_boot handling

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common-alternative.cmd.in
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-common-alternative.cmd.in
@@ -23,8 +23,6 @@ run bootcmd_ostree_bootpart
 run bootcmd_otenv
 # Get deployment sysroot absolute path
 run bootcmd_getroot
-# Check state of SECONDARY_BOOT bit
-run check_secondary_boot
 # Check if board is on closed state
 run check_board_closed
 
@@ -52,6 +50,8 @@ if fiovb init ${devnum} && test -n "${board_is_closed}"; then
 	if test ! $? -eq 0; then run bootcmd_bootenv; fiovb write_pvalue bootfirmware_version "${bootfirmware_version}"; fi
 	fiovb read_pvalue debug 4
 	if test ! $? -eq 0; then fiovb write_pvalue debug 0; fi
+	fiovb read_pvalue is_secondary_boot 4
+	if test ! $? -eq 0; then fiovb write_pvalue is_secondary_boot 0; fi
 else
 	echo "${fio_msg} Using ubootenv"
 	# Make sure initial environment is valid
@@ -94,6 +94,22 @@ if test "${fiovb.debug}" = "1"; then
 	echo "${fio_msg} secondary boot image offset = ${bootloader_s}"
 	echo "${fio_msg} secondary FIT offset = ${bootloader2_s}"
 	echo "${fio_msg} ###########################################"
+fi
+
+# Check state of SECONDARY_BOOT bit
+setenv fiovb.old_is_secondary_boot ${fiovb.is_secondary_boot}
+run check_secondary_boot
+
+# Check if we store correct secondary boot value in ubootenv/fiovb storage
+# if not - we should update it
+if test ! "${fiovb.is_secondary_boot}" = "${fiovb.old_is_secondary_boot}"; then
+	# Save fiovb.is_secondary_boot state for allowing userspace
+	# to easily identify the boot mode via environment
+	if test -z "${fiovb_rpmb}"; then
+		run saveenv_mmc
+	else
+		fiovb write_pvalue is_secondary_boot "${fiovb.is_secondary_boot}";
+	fi
 fi
 
 # Handle boot firmware updates


### PR DESCRIPTION
Sync and align handling of "is_secondary_boot" variable between on boot-common and boot-common-alternative boot scripts.