### PR TITLE
base: aktualizr-lite.service: drop old conditions for the service

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
@@ -3,8 +3,6 @@ Description=Aktualizr Lite SOTA Client
 After=network.target boot-complete.target
 Requires=boot-complete.target
 ConditionPathExists=|/var/sota/sota.toml
-ConditionPathExists=|/usr/lib/sota/conf.d/10-lite-public-stream.toml
-ConditionPathExists=!/usr/bin/mbedCloudClient
 
 [Service]
 RestartSec=180


### PR DESCRIPTION
Drop condition on public-stream and on mbedCloudClient, as they are not really used / supported anymore.