### PR TITLE
base: unify comparing values

### DIFF
--- a/meta-lmp-base/classes/kernel-lmp-fitimage.bbclass
+++ b/meta-lmp-base/classes/kernel-lmp-fitimage.bbclass
@@ -593,7 +593,7 @@ fitimage_assemble() {
 	#
 	# Step 6: Prepare a ramdisk section.
 	#
-	if [ "x${ramdiskcount}" = "x1" ] && [ "${ramdisk_bundle}" != "1" ]; then
+	if [ "${ramdiskcount}" = "1" ] && [ "${ramdisk_bundle}" != "1" ]; then
 		# Find and use the first initramfs image archive type we find
 		for img in cpio.lz4 cpio.lzo cpio.lzma cpio.xz cpio.zst cpio.gz ext2.gz cpio; do
 			initramfs_path="${DEPLOY_DIR_IMAGE}/${ramdisk_image_name}.${img}"
@@ -659,7 +659,7 @@ fitimage_assemble() {
 	#
 	# Step 9: Sign the image and add public key to U-Boot dtb
 	#
-	if [ "x${UBOOT_SIGN_ENABLE}" = "x1" ] ; then
+	if [ "${UBOOT_SIGN_ENABLE}" = "1" ] ; then
 		add_key_to_u_boot=""
 		if [ -n "${UBOOT_DTB_BINARY}" ]; then
 			# The u-boot.dtb is a symlink to UBOOT_DTB_IMAGE, so we need copy

--- a/meta-lmp-base/classes/uboot-fitimage.bbclass
+++ b/meta-lmp-base/classes/uboot-fitimage.bbclass
@@ -257,7 +257,7 @@ EOF
 #
 # $1 ... .itb filename
 uboot_fitimage_sign() {
-	if [ "x${UBOOT_SPL_SIGN_ENABLE}" = "x1" ]; then
+	if [ "${UBOOT_SPL_SIGN_ENABLE}" = "1" ]; then
 		if [ ! -f "${UBOOT_SPL_SIGN_KEYDIR}/${UBOOT_SPL_SIGN_KEYNAME}.crt"  -o  ! -f "${UBOOT_SPL_SIGN_KEYDIR}/${UBOOT_SPL_SIGN_KEYNAME}.key" ]; then
 			bbfatal "UBOOT_SPL_SIGN_KEYDIR or UBOOT_SPL_SIGN_KEYNAME is invalid"
 		fi

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit.bb
@@ -43,7 +43,7 @@ do_compile() {
 	    -e 's/@@UBOOT_SIGN_KEYNAME@@/${UBOOT_SIGN_KEYNAME}/' \
 			"${S}/boot.its.in" > boot.its
 	uboot-mkimage -f boot.its -r boot.itb
-	if [ "x${UBOOT_SIGN_ENABLE}" = "x1" ]; then
+	if [ "${UBOOT_SIGN_ENABLE}" = "1" ]; then
 		uboot-mkimage -F -k "${UBOOT_SIGN_KEYDIR}" -r boot.itb
 	fi
 }


### PR DESCRIPTION
There are few places we use overweighted comparing. Simplify operations to unify them with the other code.