### PR TITLE
Add back support for grub-based installers and images (for arm64)

### DIFF
--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-module-install-efi/init-install-efi.sh
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-module-install-efi/init-install-efi.sh
@@ -214,7 +214,33 @@ while true; do
         done
         break
     elif [ "$answer" = "n" ]; then
-        echo "Not erasing current partition table for device ${device}, assuming ${bootfs} as boot/ESP and ${rootfs} as rootfs."
+        echo "Not erasing current partition table for device ${device}. Use ${bootfs} as boot/ESP and ${rootfs} as rootfs? (y - default / n)"
+        echo
+        read answer
+        if [ "$answer" = "n" ]; then
+            while true; do
+                echo "Please define the partition to be used as boot/ESP (e.g. ${bootfs}): "
+                echo
+                read answer
+                if [ -n "${answer}" ] && [ -b ${answer} ]; then
+                    bootfs=${answer}
+                    break;
+                else
+                    echo "Invalid block device for boot/ESP"
+                fi
+            done
+            while true; do
+                echo "Now please define the partition to be used as rootfs (e.g. ${rootfs}): "
+                echo
+                read answer
+                if [ -n "${answer}" ] && [ -b ${answer} ]; then
+                    rootfs=${answer}
+                    break;
+                else
+                    echo "Invalid block device for rootfs"
+                fi
+            done
+        fi
         echo
         echo "Format ${bootfs} (ESP) partition? (n - default / y): "
         read answer

--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v6.1.y"
-KERNEL_META_COMMIT ?= "7cb2b18109bf03df3fc12757f511ba770eb34f92"
+KERNEL_META_COMMIT ?= "3ccc9bd1bed2c6b08c5056facd5d4033e657805a"

--- a/meta-lmp-base/wic/image-efi-installer-grub.wks.in
+++ b/meta-lmp-base/wic/image-efi-installer-grub.wks.in
@@ -1,0 +1,8 @@
+# create an EFI compatible installer disk image
+# populate content to install using IMAGE_BOOT_FILES (e.g. rootfs)
+
+part /boot --source bootimg-efi --sourceparams="loader=${EFI_PROVIDER},title=Install ${DISTRO_NAME} (${DISTRO_VERSION}),label=install-efi,initrd=${INITRD_IMAGE_LIVE}-${MACHINE}.${INITRAMFS_FSTYPES}" --ondisk sda --label install --active --align 1024 --use-uuid --size 100
+
+part / --source bootimg-partition --ondisk sda --fstype=ext4 --label image --use-uuid --align 1024
+
+bootloader --ptable gpt --timeout=5

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -118,20 +118,13 @@ QB_DRIVE_TYPE:qemuarm = "/dev/vdb"
 QB_OPT_APPEND:qemuarm = "-no-acpi -bios ${DEPLOY_DIR_IMAGE}/u-boot.bin -d unimp"
 
 # ARM64 Generic (SystemReady)
-OSTREE_BOOTLOADER:generic-arm64 ?= "none"
+OSTREE_BOOTLOADER:generic-arm64 ?= "grub"
 MACHINE_FEATURES:append:generic-arm64 = " acpi pci usbhost"
-EFI_PROVIDER:generic-arm64 ?= "systemd-boot"
-OSTREE_SPLIT_BOOT:generic-arm64 = "1"
-OSTREE_LOADER_LINK:generic-arm64 = "0"
-WKS_FILE:generic-arm64:sota ?= "image-efi-installer.wks.in"
+EFI_PROVIDER:generic-arm64 ?= "grub-efi"
+WKS_FILE:generic-arm64:sota ?= "image-efi-installer-grub.wks.in"
 WKS_FILE_DEPENDS:append:generic-arm64 = " ${INITRD_IMAGE_LIVE}"
 ## wic-based installer requires image to be available via IMAGE_BOOT_FILES
-IMAGE_BOOT_FILES:generic-arm64 = "${@bb.utils.contains('WKS_FILE', 'image-efi-installer.wks.in', 'systemd-bootaa64.efi;EFI/BOOT/bootaa64.efi systemd-bootaa64.efi;EFI/systemd/systemd-bootaa64.efi ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ota-ext4;rootfs.img', '', d)}"
-# ARM64 Generic with Qemu support
-OSTREE_BOOTLOADER:qemu-generic-arm64 ?= "grub"
-EFI_PROVIDER:qemu-generic-arm64 ?= "grub-efi"
-OSTREE_SPLIT_BOOT:qemu-generic-arm64 = "0"
-OSTREE_LOADER_LINK:qemu-generic-arm64 = "1"
+IMAGE_BOOT_FILES:generic-arm64 = "${@bb.utils.contains('WKS_FILE', 'image-efi-installer-grub.wks.in', 'grub-efi-bootaa64.efi;EFI/BOOT/bootaa64.efi ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ota-ext4;rootfs.img', '', d)}"
 
 # Intel
 MACHINE_FEATURES:append:intel-corei7-64 = " tpm2"


### PR DESCRIPTION
Needed on arm64 as the current sd-boot version does not support loading initrds via LINUX_INITRD_MEDIA_GUID (only via sd-stub, which requires UKI).