### PR TITLE
base: openssl: refresh patch to the backported version

### DIFF
--- a/meta-lmp-base/recipes-connectivity/openssl/openssl/0001-translation-EC-legacy-keys-handle-OSSL_PKEY_PARAM_EC.patch
+++ b/meta-lmp-base/recipes-connectivity/openssl/openssl/0001-translation-EC-legacy-keys-handle-OSSL_PKEY_PARAM_EC.patch
@@ -1,4 +1,4 @@
-From dac5f70e5b8a3a533fe712f490938c1ab69314eb Mon Sep 17 00:00:00 2001
+From 9adbce74933b87dd4fe776b70fef55f2f468f5f7 Mon Sep 17 00:00:00 2001
 From: Jorge Ramirez-Ortiz <jorge@foundries.io>
 Date: Wed, 8 Mar 2023 12:50:25 +0100
 Subject: [PATCH] translation: EC legacy keys, handle
@@ -9,89 +9,81 @@ Required by tpm2-tss to load legacy EC keys using the OpenSSL engine.
 Fixes: https://github.com/tpm2-software/tpm2-tss/issues/2581
 Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
 
-Upstream-Status: Submitted
+Reviewed-by: Shane Lontis <shane.lontis@oracle.com>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/20535)
+
+Upstream-Status: Backport
 ---
- crypto/evp/ctrl_params_translate.c | 72 ++++++++++++++++++++++++++++++
- 1 file changed, 72 insertions(+)
+ crypto/evp/ctrl_params_translate.c | 60 ++++++++++++++++++++++++++++++
+ 1 file changed, 60 insertions(+)
 
 diff --git a/crypto/evp/ctrl_params_translate.c b/crypto/evp/ctrl_params_translate.c
-index c767c31..ba9806f 100644
+index a3db7aed34..21be0d115c 100644
 --- a/crypto/evp/ctrl_params_translate.c
 +++ b/crypto/evp/ctrl_params_translate.c
-@@ -1644,6 +1644,72 @@ static int get_payload_public_key(enum state state,
+@@ -1642,6 +1642,60 @@ static int get_payload_public_key(enum state state,
      return ret;
  }
  
 +static int get_payload_public_key_ec(enum state state,
-+                                     const struct translation_st* translation,
-+                                     struct translation_ctx_st* ctx)
++                                     const struct translation_st *translation,
++                                     struct translation_ctx_st *ctx)
 +{
-+    EVP_PKEY* pkey = ctx->p2;
-+    unsigned char* buf = NULL;
-+    BIGNUM* bn = NULL;
++#ifndef OPENSSL_NO_EC
++    EVP_PKEY *pkey = ctx->p2;
++    const EC_KEY *eckey = EVP_PKEY_get0_EC_KEY(pkey);
++    BN_CTX *bnctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(eckey));
++    const EC_POINT *point = EC_KEY_get0_public_key(eckey);
++    const EC_GROUP *ecg = EC_KEY_get0_group(eckey);
++    BIGNUM *x = NULL;
++    BIGNUM *y = NULL;
 +    int ret = 0;
 +
++    if (bnctx == NULL)
++        return 0;
++
 +    ctx->p2 = NULL;
-+    switch (EVP_PKEY_get_base_id(pkey)) {
-+#ifndef OPENSSL_NO_EC
-+        case EVP_PKEY_EC:
-+            if (ctx->params->data_type != OSSL_PARAM_UNSIGNED_INTEGER)
-+                return 0;
 +
-+            const EC_KEY* eckey = EVP_PKEY_get0_EC_KEY(pkey);
-+            BN_CTX* bnctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(eckey));
-+            const EC_GROUP* ecg = EC_KEY_get0_group(eckey);
-+            const EC_POINT* point = EC_KEY_get0_public_key(eckey);
-+            if (bnctx == NULL)
-+                return 0;
-+            size_t len = EC_POINT_point2buf(ecg, point,
-+                                            POINT_CONVERSION_UNCOMPRESSED,
-+                                            &buf, bnctx);
-+            if (!len) {
-+                ret = 0;
-+                goto out;
-+            }
-+
-+            /* skip tag */
-+            len = len - 1;
-+
-+            if (!memcmp(ctx->params->key, OSSL_PKEY_PARAM_EC_PUB_X,
-+                        strnlen(OSSL_PKEY_PARAM_EC_PUB_X, 2))) {
-+                bn = BN_new();
-+                BN_bin2bn(buf + 1, len / 2, bn);
-+            }
-+
-+            if (!memcmp(ctx->params->key, OSSL_PKEY_PARAM_EC_PUB_Y,
-+                             strnlen(OSSL_PKEY_PARAM_EC_PUB_Y, 2))) {
-+                bn = BN_new();
-+                BN_bin2bn(buf + 1 + len / 2, len / 2, bn);
-+            }
-+
-+            if (bn)
-+                ctx->p2 = bn;
-+
-+            BN_CTX_free(bnctx);
-+            break;
-+#endif
-+        default:
-+            ERR_raise(ERR_LIB_EVP, EVP_R_UNSUPPORTED_KEY_TYPE);
-+            return 0;
++    if (eckey == NULL) {
++        ERR_raise(ERR_LIB_EVP, EVP_R_UNSUPPORTED_KEY_TYPE);
++        goto out;
 +    }
 +
-+    if (ctx->p2)
-+        ret = default_fixup_args(state, translation, ctx);
-+out:
-+    OPENSSL_free(buf);
-+    if (bn)
-+        BN_free(bn);
++    /* Caller should have requested a BN, fail if not */
++    if (ctx->params->data_type != OSSL_PARAM_UNSIGNED_INTEGER)
++        goto out;
 +
++    x = BN_CTX_get(bnctx);
++    y = BN_CTX_get(bnctx);
++    if (y == NULL)
++        goto out;
++
++    if (!EC_POINT_get_affine_coordinates(ecg, point, x, y, bnctx))
++        goto out;
++
++    if (strncmp(ctx->params->key, OSSL_PKEY_PARAM_EC_PUB_X, 2) == 0)
++        ctx->p2 = x;
++    else if (strncmp(ctx->params->key, OSSL_PKEY_PARAM_EC_PUB_Y, 2) == 0)
++        ctx->p2 = y;
++    else
++        goto out;
++
++    /* Return the payload */
++    ret = default_fixup_args(state, translation, ctx);
++out:
++    BN_CTX_free(bnctx);
 +    return ret;
++#else
++    ERR_raise(ERR_LIB_EVP, EVP_R_UNSUPPORTED_KEY_TYPE);
++    return 0;
++#endif
 +}
 +
  static int get_payload_bn(enum state state,
                            const struct translation_st *translation,
                            struct translation_ctx_st *ctx, const BIGNUM *bn)
-@@ -2330,6 +2396,12 @@ static const struct translation_st evp_pkey_translations[] = {
+@@ -2334,6 +2388,12 @@ static const struct translation_st evp_pkey_translations[] = {
        OSSL_PKEY_PARAM_PUB_KEY,
        0 /* no data type, let get_payload_public_key() handle that */,
        get_payload_public_key },


### PR DESCRIPTION
Update the patch in order to be aligned with what was merged in the end.