### PR TITLE
base: recipe-sota: aktualizr-lite: bump to a7032fb

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "8045ff19bedc6a2965a63b69b33c30192bbf99c9"
+SRCREV:lmp = "a7032fb7f8df5455fb6552409d0889397930b031"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
Relevant changes:
- 03d1340 api: Add method to obtain device's UUID
- 2a0ff47 offline-client: Fix app blob download
- c598868 offline: Fix dockerless system support
- cba285f offline: Don't pull images at App start
- 6fef010 custom client: Handle rollback for failed apps
- 5a43c1f offline: Handle a normal rollback correctly
- c4d9cc1 pacman: Do correct install "finalization" if no ostree update
- 361b985 offline: Rollback to unknown if initial Target set fails
- 46bfcf5 offline: Finalize Apps install after rollback
- fd850e1 bootloader: Reject update if bootloader rollback is detected