### PR TITLE
base: lmp-staging: add our BB_HASHCHECK_FUNCTION function wrapper

### DIFF
--- a/meta-lmp-base/classes/lmp-staging.bbclass
+++ b/meta-lmp-base/classes/lmp-staging.bbclass
@@ -31,3 +31,10 @@ python __anonymous() {
 }
 
 inherit ${LMPSTAGING_INHERIT_KERNEL_MODSIGN}
+
+BB_HASHCHECK_FUNCTION:lmp = "lmp_sstate_checkhashes"
+def lmp_sstate_checkhashes(sq_data, d, **kwargs):
+    mirrors = d.getVar("SSTATE_MIRRORS")
+    if mirrors:
+        bb.plain("SState mirrors: %s" % mirrors)
+    return sstate_checkhashes(sq_data, d, **kwargs)


### PR DESCRIPTION
With this wrapper we can show what is the SSTATE_MIRRORS in use for the build.
This will show something like the following:
```
Initialising tasks: 100% |##############################################################################################################################################################################| Time: 0:00:12
SState mirrors: file://.* https://storage.googleapis.com/lmp-cache/v90-sstate-cache/PATH
Checking sstate mirror object availability: 100% |######################################################################################################################################################| Time: 0:00:42
Sstate summary: Wanted 2184 Local 893 Mirrors 1263 Missed 28 Current 0 (98% match, 0% complete)
NOTE: Executing Tasks
```