### PR TITLE
Revert "base: lmp: add make-mod-scripts to RM_WORK_EXCLUDE"

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -140,9 +140,6 @@ WARN_QA:remove = "${WARN_TO_ERROR_QA}"
 ERROR_QA:append = " ${WARN_TO_ERROR_QA}"
 ERROR_QA:remove = "version-going-backwards"
 
-# Required to avoid removing libraries used during signing
-RM_WORK_EXCLUDE += "make-mod-scripts"
-
 LMP_USER ?= "fio"
 # LMP_PASSWORD is a hassed password. To generate the hash use the following command on a host machine
 # mkpasswd -m sha512crypt


### PR DESCRIPTION
This reverts commit 336254ea5acc67dda182c407789f5414dcfe1fec.

Fixed upstream [1] with RM_WORK_EXCLUDE_ITEMS.
[1] https://lists.openembedded.org/g/openembedded-core/message/180113