### PR TITLE
aktualizr-lite: reboot on failed start

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
@@ -3,6 +3,10 @@ Description=Aktualizr Lite SOTA Client
 After=network.target boot-complete.target
 Requires=boot-complete.target
 ConditionPathExists=|/var/sota/sota.toml
+# this should be StartLimitBurst * RestartSec + 1
+StartLimitIntervalSec=541
+StartLimitBurst=3
+StartLimitAction=reboot
 
 [Service]
 RestartSec=180


### PR DESCRIPTION
This patch will force systemd to reboot the board in case aktualizr-lite fails to start. It prevents going into a state when aktualizr-lite doesn't start after OTA and there is no other service that would force a rollback.