### PR TITLE
Track the missing dependencies on SPDX documents

### DIFF
--- a/meta-lmp-base/classes/fip-utils.bbclass
+++ b/meta-lmp-base/classes/fip-utils.bbclass
@@ -76,6 +76,8 @@ python () {
     if len(fip_depends) > 0:
         for depend in fip_depends:
             d.appendVarFlag('do_deploy', 'depends', ' %s:do_deploy' % depend)
+            # we need to set the DEPENDS as well to produce valid SPDX documents
+            d.appendVar('DEPENDS', ' %s' % depend)
 
     # Manage FIP config settings
     fipconfigflags = d.getVarFlags('FIP_CONFIG')

--- a/meta-lmp-base/classes/lmp-staging.bbclass
+++ b/meta-lmp-base/classes/lmp-staging.bbclass
@@ -39,3 +39,37 @@ def lmp_sstate_checkhashes(sq_data, d, **kwargs):
     if mirrors:
         bb.plain("SState mirrors: %s" % mirrors)
     return sstate_checkhashes(sq_data, d, **kwargs)
+
+# don't check images
+LMPSTAGING_DEPLOYED_CHECK_SKIP ?= "${@d.getVar('PN') if bb.data.inherits_class('image', d) else ''}"
+
+# handler to warn when there are 'do_deploy' dependencies without setting the DEPENDS
+addhandler check_deployed_depends
+check_deployed_depends[eventmask] = "bb.build.TaskSucceeded"
+python check_deployed_depends() {
+    d = e.data
+
+    taskname = d.getVar('BB_RUNTASK')
+    pn = d.getVar('PN')
+    pn = [pn, '%s:%s' % (pn, taskname)]
+    excludes = (d.getVar('LMPSTAGING_DEPLOYED_CHECK_SKIP') or '').split()
+    for s in excludes:
+        if s in pn:
+            bb.debug(1, "skip '%s' deployed dependencies check" % s)
+            return
+
+    depends = (d.getVarFlag(taskname, 'depends') or '').split()
+    # remove duplicates
+    depends = [*set(depends)]
+    for depend in depends:
+        recipe, task = depend.split(':')
+        if task == 'do_deploy' and recipe not in d.getVar('DEPENDS'):
+            bb.error("Task '%s' depends on '%s' but '%s' is not in DEPENDS" % (taskname, depend, recipe))
+}
+
+def fix_deployed_depends(task, d):
+    # we need to set the DEPENDS as well to produce valid SPDX documents
+    for depend in (d.getVarFlag(task, 'depends') or '').split():
+        recipe, task = depend.split(':')
+        if task == 'do_deploy':
+            d.appendVar('DEPENDS', ' %s' % recipe)

--- a/meta-lmp-base/classes/lmp-staging.bbclass
+++ b/meta-lmp-base/classes/lmp-staging.bbclass
@@ -64,7 +64,7 @@ python check_deployed_depends() {
     for depend in depends:
         recipe, task = depend.split(':')
         if task == 'do_deploy' and recipe not in d.getVar('DEPENDS'):
-            bb.error("Task '%s' depends on '%s' but '%s' is not in DEPENDS" % (taskname, depend, recipe))
+            bb.warn("Task '%s' depends on '%s' but '%s' is not in DEPENDS" % (taskname, depend, recipe))
 }
 
 def fix_deployed_depends(task, d):

--- a/meta-lmp-base/classes/uboot-fitimage.bbclass
+++ b/meta-lmp-base/classes/uboot-fitimage.bbclass
@@ -347,3 +347,8 @@ do_deploy:prepend() {
 		fi
 	fi
 }
+
+python() {
+    # we need to set the DEPENDS as well to produce valid SPDX documents
+    fix_deployed_depends('do_compile', d)
+}

--- a/meta-lmp-base/recipes-bsp/lmp-boot-firmware/lmp-boot-firmware.bb
+++ b/meta-lmp-base/recipes-bsp/lmp-boot-firmware/lmp-boot-firmware.bb
@@ -86,3 +86,8 @@ FILES:${PN} = "\
 	${nonarch_base_libdir}/firmware \
 	${nonarch_base_libdir}/ostree-boot \
 "
+
+python() {
+    # we need to set the DEPENDS as well to produce valid SPDX documents
+    fix_deployed_depends('do_install', d)
+}

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
@@ -30,3 +30,6 @@ UBOOT_CLASSES ?= ""
 inherit ${UBOOT_CLASSES} fio-u-boot-localversion
 
 PROVIDES += "u-boot"
+
+# setting DEPENDS create dependency loops so skip the check
+LMPSTAGING_DEPLOYED_CHECK_SKIP += "${PN}:do_deploy"

--- a/meta-lmp-base/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_%.bbappend
+++ b/meta-lmp-base/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_%.bbappend
@@ -2,6 +2,8 @@ PACKAGES += "ostree-recovery-initramfs"
 ALLOW_EMPTY:ostree-recovery-initramfs = "1"
 FILES:ostree-recovery-initramfs = "${nonarch_base_libdir}/ostree-boot"
 
+INHIBIT_DEFAULT_DEPS = "1"
+
 do_install:append() {
     ostreeboot=${D}${nonarch_base_libdir}/ostree-boot
     install -d $ostreeboot

--- a/meta-lmp-base/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_%.bbappend
+++ b/meta-lmp-base/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_%.bbappend
@@ -17,3 +17,8 @@ do_install:append() {
 
 INITRAMFS_RECOVERY_IMAGE ?= ""
 do_install[depends] += "virtual/kernel:do_deploy ${@['${INITRAMFS_RECOVERY_IMAGE}:do_image_complete', ''][d.getVar('INITRAMFS_RECOVERY_IMAGE') == '']}"
+
+python() {
+    # we need to set the DEPENDS as well to produce valid SPDX documents
+    fix_deployed_depends('do_install', d)
+}

--- a/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb
+++ b/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb
@@ -56,3 +56,8 @@ do_deploy[depends] += "virtual/bootloader:do_deploy"
 do_deploy[depends] += "virtual/kernel:do_deploy"
 
 addtask deploy after do_compile before do_build
+
+python() {
+    # we need to set the DEPENDS as well to produce valid SPDX documents
+    fix_deployed_depends('do_deploy', d)
+}

--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-mkimage/imx-boot_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-mkimage/imx-boot_%.bbappend
@@ -83,3 +83,8 @@ do_deploy:append() {
         fi
     done
 }
+
+python() {
+    # we need to set the DEPENDS as well to produce valid SPDX documents
+    fix_deployed_depends('do_compile', d)
+}

--- a/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/flashlayouts-stm32mp1/flashlayouts-stm32mp1.bb
+++ b/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/flashlayouts-stm32mp1/flashlayouts-stm32mp1.bb
@@ -58,3 +58,8 @@ do_deploy[depends] += "sdcard-raw-tools-native:do_deploy"
 do_deploy[depends] += "${MFGTOOL_FLASH_IMAGE}:do_image_complete"
 
 addtask deploy after do_compile before do_build
+
+python() {
+    # we need to set the DEPENDS as well to produce valid SPDX documents
+    fix_deployed_depends('do_deploy', d)
+}

--- a/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files_0.1.bb
+++ b/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files_0.1.bb
@@ -55,3 +55,8 @@ do_deploy[depends] += "virtual/bootloader:do_deploy"
 do_deploy[depends] += "virtual/kernel:do_deploy"
 
 addtask deploy after do_compile before do_build
+
+python() {
+    # we need to set the DEPENDS as well to produce valid SPDX documents
+    fix_deployed_depends('do_deploy', d)
+}

--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx_2022.01.bb
+++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx_2022.01.bb
@@ -73,3 +73,8 @@ inherit ${UBOOT_CLASSES} fio-u-boot-localversion
 
 # setting DEPENDS create dependency loops so skip the check
 LMPSTAGING_DEPLOYED_CHECK_SKIP += "${PN}:do_deploy"
+
+python() {
+    # we need to set the DEPENDS as well to produce valid SPDX documents
+    fix_deployed_depends('do_install', d)
+}

--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx_2022.01.bb
+++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-bsp/u-boot/u-boot-xlnx_2022.01.bb
@@ -70,3 +70,6 @@ EXTRA_OEMAKE += "${@'EXT_DTB=${RECIPE_SYSROOT}/${DTB_PATH}/${DTB_NAME}' if (d.ge
 UBOOT_CLASSES ?= ""
 LOCALVERSION = "+xlnx"
 inherit ${UBOOT_CLASSES} fio-u-boot-localversion
+
+# setting DEPENDS create dependency loops so skip the check
+LMPSTAGING_DEPLOYED_CHECK_SKIP += "${PN}:do_deploy"

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-toradex-imx_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-toradex-imx_git.bb
@@ -21,3 +21,8 @@ include recipes-kernel/linux/linux-lmp.inc
 
 # make sure firmware-imx files are available in case they are needed by fit
 do_assemble_fitimage[depends] += "${@bb.utils.contains('MACHINE_FIRMWARE', 'firmware-imx-8', 'firmware-imx-8:do_deploy', '', d)}"
+
+python() {
+    # we need to set the DEPENDS as well to produce valid SPDX documents
+    fix_deployed_depends('do_assemble_fitimage', d)
+}


### PR DESCRIPTION
This handler will generate an ERROR when there are 'do_deploy' dependencies without setting the DEPENDS.
One of the side effect of this issues is SPDX documents not including the correct dependencies.
```
/
| ERROR: lmp-boot-firmware-0-r0 do_install: Task 'do_install' depends on 'virtual/bootloader:do_deploy' but 'virtual/bootloader' is not in DEPENDS
| ERROR: lmp-boot-firmware-0-r0 do_install: Task 'do_install' depends on 'virtual/trusted-firmware-a:do_deploy' but 'virtual/trusted-firmware-a' is not in DEPENDS
\
```

Explicit adds the dependencies of the 'do_deploy' in the task[depends].
With this patch the missed dependencies are now in the SPDX documents of the package as well as in the final SPDX of the combined image.

The following example is for the lmp-base-console-image on stm32mp15-disco machine:
```
/
| grep -E "u-boot|tf-a" deploy/images/stm32mp15-disco/lmp-base-console-image-stm32mp15-disco.spdx.index.json
| deploy/images/stm32mp15-disco/lmp-base-console-image-stm32mp15-disco.spdx.index.json:      "documentNamespace": "http://spdx.org/spdxdoc/recipe-tf-a-fio-546ca65d-3ceb-5456-93cd-e8acffa32a17",
| deploy/images/stm32mp15-disco/lmp-base-console-image-stm32mp15-disco.spdx.index.json:      "filename": "recipe-tf-a-fio.spdx.json",
| deploy/images/stm32mp15-disco/lmp-base-console-image-stm32mp15-disco.spdx.index.json:      "documentNamespace": "http://spdx.org/spdxdoc/recipe-tf-a-tools-native-52687ea6-9f82-5a2d-a8ab-f4e90f31e6fd",
| deploy/images/stm32mp15-disco/lmp-base-console-image-stm32mp15-disco.spdx.index.json:      "filename": "recipe-tf-a-tools-native.spdx.json",
| deploy/images/stm32mp15-disco/lmp-base-console-image-stm32mp15-disco.spdx.index.json:      "documentNamespace": "http://spdx.org/spdxdoc/recipe-u-boot-fio-cfb5b3c2-fc87-5d33-a223-5b46ae9bb0f5",
| deploy/images/stm32mp15-disco/lmp-base-console-image-stm32mp15-disco.spdx.index.json:      "filename": "recipe-u-boot-fio.spdx.json",
\
```