### PR TITLE
base: recipe-sota: aktualizr-lite: bump to 2d6fade

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "a7032fb7f8df5455fb6552409d0889397930b031"
+SRCREV:lmp = "2d6fade7123f1dfdb11cda4e6501686a8f8c828f"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
Relevant changes:
- d931a79 bootloader: Allow any version format if no rollback protection
- b3f60e8 bootloader: Handle bootloader update if malformed version