### PR TITLE
base: u-boot-fio: imx-2022.04: bump to 0e0855303e1

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
@@ -1,6 +1,6 @@
 require u-boot-fio-common.inc
 
-SRCREV = "9af5f2d5c60e170fe25cc1301c272169dafc8290"
+SRCREV = "0e0855303e11ec70e8a47f3bec9f05e629a552b3"
 SRCBRANCH = "2022.04+lf-5.15.71-2.2.0-fio"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 


### PR DESCRIPTION
This should fix booting imx8m devices.

Relevant changes:
- 0e0855303e1 ("[FIO squash] imx8m: ddr: fix changing padding")