### PR TITLE
Install files to /usr/lib instead of /var

### DIFF
--- a/meta-lmp-base/conf/distro/lmp.conf
+++ b/meta-lmp-base/conf/distro/lmp.conf
@@ -54,3 +54,7 @@ WKS_FILE_DEPENDS_BOOTLOADERS:remove = "syslinux"
 # WKS partition default configuration
 OSTREE_WKS_EFI_SIZE ?= "--size 512M"
 OSTREE_WKS_BOOT_SIZE ?= "--size 200M --overhead-factor 1"
+
+# This is needed to move fontcache for all installed packages
+# from /var/cache/fontconfig to /usr/lib/fontconfig/cache
+FONTCONFIG_CACHE_DIR = "${libdir}/fontconfig/cache"

--- a/meta-lmp-bsp/recipes-bsp/alsa/alsa-state-stm32mp1.bbappend
+++ b/meta-lmp-bsp/recipes-bsp/alsa/alsa-state-stm32mp1.bbappend
@@ -1,0 +1,43 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://system-generator-alsa-states"
+
+# Install vendor-specific asound-*.state filed into
+# /usr/lib/alsa/.
+VAR_STATEDIR  = "${localstatedir}/lib/alsa"
+SYS_STATEDIR = "${prefix}/lib/alsa"
+
+do_install() {
+    install -d ${D}${sysconfdir}
+    install -m 0644 ${WORKDIR}/*.conf ${D}${sysconfdir}/
+    install -d ${D}${SYS_STATEDIR}
+    install -m 0644 ${WORKDIR}/*.state ${D}${SYS_STATEDIR}/
+
+    # create link to support all packages configuration
+    for p in a b c d e f;
+    do
+        for n in 1 3 7;
+        do
+            cd ${D}${sysconfdir}/
+            ln -sf asound-stm32mp15yx-ev.conf asound-stm32mp15$n$p-ev.conf
+            ln -sf asound-stm32mp15yx-dk.conf asound-stm32mp15$n$p-dk.conf
+            cd ${D}${SYS_STATEDIR}
+            ln -sf asound-stm32mp15yx-ev.state asound-stm32mp15$n$p-ev.state
+            ln -sf asound-stm32mp15yx-dk.state asound-stm32mp15$n$p-dk.state
+        done
+    done
+
+    # Enable systemd automatic selection
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        install -d ${D}${systemd_unitdir}/system-generators/
+        install -m 0755 ${WORKDIR}/system-generator-alsa-states ${D}${systemd_unitdir}/system-generators/
+        sed -i -e "s:#VARSTATEDIR#:${VAR_STATEDIR}:g" \
+               -e "s:#SYSSTATEDIR#:${SYS_STATEDIR}:g" \
+            ${D}${systemd_unitdir}/system-generators/system-generator-alsa-states
+        if [ -f ${WORKDIR}/system-generator-alsa-conf ]; then
+            install -m 0755 ${WORKDIR}/system-generator-alsa-conf ${D}${systemd_unitdir}/system-generators/
+        fi
+    fi
+}
+
+FILES:${PN} += "${SYS_STATEDIR}/*.state"

--- a/meta-lmp-bsp/recipes-bsp/alsa/alsa-state-stm32mp1/system-generator-alsa-states
+++ b/meta-lmp-bsp/recipes-bsp/alsa/alsa-state-stm32mp1/system-generator-alsa-states
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+# Script which detect automaticaly the alsa-states file to put
+# in place in fuonction of board on which the script are executed.
+#
+# This script are use with systemd-generators
+# see man for more information or
+# https://www.freedesktop.org/software/systemd/man/systemd.generator.html
+#
+# How to debug:
+# mkdir /tmp/normal-dir /tmp/early-dir /tmp/late-dir
+# SYSTEMD_LOG_LEVEL=debug /lib/systemd/system-generators/system-generator-alsa-states \
+#        /tmp/normal-dir /tmp/early-dir /tmp/late-dir
+# find /tmp/normal-dir /tmp/early-dir /tmp/late-dir
+#
+
+function debug_print() {
+    if `echo $SYSTEMD_LOG_LEVEL |grep -q debug` ;
+    then
+        echo "[DEBUG] $@"
+    fi
+}
+
+#
+# Main
+#
+if [ ! -d /proc/device-tree/ ];
+then
+    debug_print "Proc Device tree are not available, Could not detect on which board we are"
+    exit 1
+fi
+if [ -e #VARSTATEDIR#/asound.state ];
+then
+    LINE=`cat #VARSTATEDIR#/asound.state | wc -l`
+    if [ $LINE -lt 3 ];
+    then
+        # dummy alsa-state file contains only one comment
+        debug_print "remove previous dummy alsa-state file"
+        rm -f #VARSTATEDIR#/asound.state
+    else
+        debug_print "alsa-state file already configured"
+        exit 0
+    fi
+fi
+# get the name file available for alsa-states
+ALSA_STATE_FILES=`ls -1 #SYSSTATEDIR#/asound-*`
+
+for f in $ALSA_STATE_FILES;
+do
+    #extract name of board
+    board=`echo $f | sed -e "s|#SYSSTATEDIR#/asound-\(.*\).state|\1|"`
+    #search on device tree compatible entry if the board are present
+    if `grep -q $board /proc/device-tree/compatible` ;
+    then
+        # device tree compatible entry match with board name
+        # configure alsa-state
+        if test -x /usr/sbin/alsactl
+        then
+            debug_print "active alsactl with $f"
+            #/usr/sbin/alsactl -f $f restore
+            cp $f #VARSTATEDIR#/asound.state
+            break;
+        fi
+    fi
+done
+exit 0


### PR DESCRIPTION
- fixed alsa-state-stm32mp1 recipe
- fixed all recipes that install fonts as a font cache.