### PR TITLE
docker: fix dockerd failed start conditions

### DIFF
--- a/meta-lmp-base/recipes-containers/docker/files/docker.service
+++ b/meta-lmp-base/recipes-containers/docker/files/docker.service
@@ -9,7 +9,7 @@ StartLimitBurst=3
 StartLimitIntervalSec=60
 # Reboot the system in case docker daemon fails. This will trigger a rollback
 # after three consecutive failures.
-FailureAction=reboot
+StartLimitAction=reboot
 
 [Service]
 Type=notify


### PR DESCRIPTION
When dockerd fails to start after OTA, systemd will reboot the system to force rollback. This patch allows dockerd 3 attempts before rebooting.