### PR TITLE
base: u-boot-ostree-scr-fit: update fiovb.bootfirmware_version

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-upgrade-alternative.cmd.in
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-upgrade-alternative.cmd.in
@@ -78,6 +78,7 @@ if test "${fiovb.is_secondary_boot}" = "0"; then
 				setenv bootupgrade_available 0;
 				setenv bootupgrade_primary_updated 0;
 				setenv bootfirmware_version "${bootfirmware_version}";
+				setenv fiovb.bootfirmware_version "${bootfirmware_version}";
 			fi
 			run saveenv_mmc
 		fi

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-upgrade-regular.cmd.in
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-upgrade-regular.cmd.in
@@ -71,6 +71,7 @@ if test "${fiovb.is_secondary_boot}" = "0"; then
 		else
 			setenv bootupgrade_available 0;
 			setenv bootfirmware_version "${bootfirmware_version}";
+			setenv fiovb.bootfirmware_version "${bootfirmware_version}";
 		fi
 
 		run saveenv_mmc


### PR DESCRIPTION
Update a value of fiovb.bootfirmware_version during boot firmware upgrade procedure alongside with bootfirmware_version.