### PR TITLE
bsp: mfgtool-files: imx93-11x11-lpddr4x-evk: flash uncompressed wic

### DIFF
--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx93-11x11-lpddr4x-evk/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx93-11x11-lpddr4x-evk/full_image.uuu.in
@@ -5,7 +5,7 @@ SDPS: boot -f imx-boot-mfgtool
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd setenv mmcdev 0
 FB: ucmd mmc dev ${mmcdev} 1; mmc erase 0 0x3C00
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
 FB: flash bootloader ../imx-boot-@@MACHINE@@
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
 FB: flash bootloader_s ../imx-boot-@@MACHINE@@


### PR DESCRIPTION
Prefer uncompressed wic in full_image in order to be aligned with all other NXP boards.

We should switch all at the same time as this also impacts documentation, so aligning imx93 with the rest and transition all later once properly tested.