### PR TITLE
base: packagegroup-security-tpm2: remove trousers

### DIFF
--- a/meta-lmp-base/recipes-core/packagegroups/packagegroup-security-tpm2.bbappend
+++ b/meta-lmp-base/recipes-core/packagegroups/packagegroup-security-tpm2.bbappend
@@ -1,0 +1,2 @@
+# Trousers is relevant with TPM 1.2 (not supported by LmP)
+RDEPENDS:packagegroup-security-tpm2:remove = "trousers"


### PR DESCRIPTION
Remove trousers from tpm2 related packagegroup as it is relevant with tpm 1.2 only, which we don't officially support in LmP.