### PR TITLE
base: u-boot-fio: 2022.04: bump to 3eb7632

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2022.04.bb
@@ -1,5 +1,5 @@
 require u-boot-fio-common.inc
 
-SRCREV = "08452551bfa6fad7af475757be88d9cb0879eeff"
+SRCREV = "3eb76326d0fca7330ce530e6975b5d92d7b011c7"
 SRCBRANCH = "2022.04+fio"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"


### PR DESCRIPTION
Relevant changes:
- 3eb7632 Revert "[FIO internal] fiovb: simplify code"