### PR TITLE
base: move var clean up from base-files to lmp.bbclass

### DIFF
--- a/meta-lmp-base/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-lmp-base/recipes-core/base-files/base-files_%.bbappend
@@ -5,18 +5,6 @@ SRC_URI += "file://tmpfiles.conf"
 do_install:append () {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
         install -D -m 0644 ${WORKDIR}/tmpfiles.conf ${D}${nonarch_libdir}/tmpfiles.d/${PN}.conf
-        (
-            # Remove /var stuff
-            cd ${D}${localstatedir};
-            rmdir -v backups spool local;
-            rmdir -v --parents lib/misc;
-            # there may be another folder volatile/log, so this
-            # command may fail and it's ok
-            rmdir -v volatile/tmp;
-            rmdir -v ${@'volatile/' if oe.types.boolean('${VOLATILE_LOG_DIR}') else ''}log;
-            # symlinks
-            rm -v run lock;
-        )
     fi
 }
 

--- a/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
@@ -85,6 +85,7 @@ do_install:append() {
 	else
 		# Make sure /var/log is not a link to volatile (e.g. after system updates)
 		sed -i '/\[Service\]/aExecStartPre=-/bin/rm -f /var/log' ${D}${systemd_system_unitdir}/systemd-journal-flush.service
+		(cd ${D}${localstatedir}; rmdir -v --parents log/journal)
 	fi
 
 	# Workaround for https://github.com/systemd/systemd/issues/11329


### PR DESCRIPTION
Var directories, created by base-files, are also used by the rootfs task while performing the image bootstrap process (via packages), so they can't be removed at the base-files package level.

Move the removal logic to lmp.bbclass via ROOTFS_POSTPROCESS_COMMAND task, which is executed only when ota-ext4 is set in IMAGE_FSTYPES (only way to know when an ostree image is to be created), after all required rootfs packages are installed. Only dirs that can't be removed at this stage are /var/lib and /var/cache as they are used to store packaging related metadata.