### PR TITLE
base: u-boot-fio: 2022.04: bump to a97c174e

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
@@ -1,6 +1,6 @@
 require u-boot-fio-common.inc
 
-SRCREV = "8dbf7957dc3c9abd6223190e9c0d929d0d59577b"
+SRCREV = "a97c174ef41f2c78a9c0314f399211069f4a232b"
 SRCBRANCH = "2022.04+lf-5.15.71-2.2.0-fio"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 


### PR DESCRIPTION
Relevant changes:
- a97c174e fastboot: fsl: imx8qm: extend bootloader2 partition