### PR TITLE
base:rs: Bump ostreeuploader version to b18f2c3

### DIFF
--- a/meta-lmp-base/recipes-sota/ostreeuploader/ostreeuploader_git.bb
+++ b/meta-lmp-base/recipes-sota/ostreeuploader/ostreeuploader_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=2a944942e1496af1886903d2
 GO_IMPORT = "github.com/foundriesio/ostreeuploader"
 GO_IMPORT_PROTO ?= "https"
 SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO};branch=master"
-SRCREV = "54daa6777667ab9263c65a379453b65d9a2eb19a"
+SRCREV = "b18f2c3728c4cfc219f4c872ae58e444c212b254"
 
 UPSTREAM_CHECK_COMMITS = "1"
 


### PR DESCRIPTION
Related changes:
- bbf045d Pass URL to ostreeuploader module for token authentication
- 8fc3962 Use POST call for doing object check
- 867760d cli: Add a fio token as an input parameter
- ae83a21 Do request retry if makes sense
- cb1e821 Set timeouts for check and push requests.
- 0372bd4 ostreeuploader: print response body if error
- f102075 ostreeuploader: upload and check delta indexes
- e9f4390 fiocheck: check delta objects for v2 API
- 29ca44f fiosync: use the last available download origin
- deef2d3 ostreeuploader: use API v2 by default