### PR TITLE
base: linux-lmp-rt: switch to 6.1 as default rt

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp-rt_6.1.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp-rt_6.1.bb
@@ -16,5 +16,3 @@ KMETA = "kernel-meta"
 
 require linux-lmp.inc
 include recipes-kernel/linux/linux-lmp-machine-custom.inc
-
-DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
Follow linux-lmp and switch to the 6.1 series by default.