### PR TITLE
xilinx: libmali and weston build fixes

### DIFF
--- a/meta-lmp-base/conf/distro/include/non-clangable.inc
+++ b/meta-lmp-base/conf/distro/include/non-clangable.inc
@@ -178,3 +178,6 @@ TOOLCHAIN:pn-u-boot-fio = "gcc"
 TOOLCHAIN:pn-u-boot-fio-mfgtool = "gcc"
 TOOLCHAIN:pn-u-boot-xlnx = "gcc"
 TOOLCHAIN:pn-u-boot-ti-staging = "gcc"
+
+# libmali-xlnx calls gcc directly on do_install
+TOOLCHAIN:pn-libmali-xlnx = "gcc"

--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-graphics/wayland/weston-init.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-graphics/wayland/weston-init.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:prepend:zynqmp:lmp-wayland = " \
+    file://weston.service.zynqmp.patch \
+"

--- a/meta-lmp-bsp/dynamic-layers/xilinx/recipes-graphics/wayland/weston-init/weston.service.zynqmp.patch
+++ b/meta-lmp-bsp/dynamic-layers/xilinx/recipes-graphics/wayland/weston-init/weston.service.zynqmp.patch
@@ -1,0 +1,11 @@
+--- weston-init/weston.service	2021-07-28 20:36:49.967058683 -0300
++++ weston-init/weston.service_new	2021-07-28 20:37:49.593091101 -0300
+@@ -34,7 +34,7 @@
+ # Requires systemd-notify.so Weston plugin.
+ Type=notify
+ EnvironmentFile=/etc/default/weston
+-ExecStart=/usr/bin/weston --continue-without-input --modules=systemd-notify.so
++ExecStart=/usr/bin/weston --modules=systemd-notify.so
+ 
+ # Optional watchdog setup
+ TimeoutStartSec=60


### PR DESCRIPTION
Not yet fully functional as it requires a BSP update, which will follow v90.