### PR TITLE
Revert "base: lmp: mask meta-updater nfs-utils append"

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -105,7 +105,6 @@ BBMASK += " \
     /meta-virtualization/recipes-kernel/linux/linux-%.bbappend \
     /meta-virtualization/dynamic-layers/xilinx/recipes-extended/xen/xen_4.14.bbappend \
     /meta-security/meta-integrity/recipes-core/systemd/systemd_%.bbappend \
-    /meta-updater/recipes-connectivity/nfs-utils/nfs-utils_%.bbappend \
 "
 
 # meta-xilinx/meta-xilinx-tools: mask recipes not required for lmp


### PR DESCRIPTION
This reverts commit 9630be90bb0f0c63a4e268db778adf4100ecb9fb.

The systemd tmpfiles is now porvided in meta-updater nfs-utils append [1]
This is needed to create the required directory structure at runtime for nfsd.

[1] https://github.com/uptane/meta-updater/commit/bfcf400813c4ff6f97ac9fd8bf44f5b8b0eb12c9