### PR TITLE
base: u-boot/fip: fix bootfirmware version without firmware node

### DIFF
--- a/meta-lmp-base/classes/fip-utils.bbclass
+++ b/meta-lmp-base/classes/fip-utils.bbclass
@@ -138,7 +138,7 @@ do_deploy:append:class-target() {
             # Add boot firmware version to U-Boot DTB (if it's defined and is not zero)
             if [ -n "${LMP_BOOT_FIRMWARE_VERSION}" -a "${LMP_BOOT_FIRMWARE_VERSION}" != "0" ]; then
                 # Might return "FDT_ERR_EXISTS" error, if "lmp" node already exists
-                fdtput -c -t s "${WORKDIR}/${FIP_UBOOT_DTB}.${FIP_UBOOT_DTB_SUFFIX}" /firmware/bootloader || true
+                fdtput -c -p -t s "${WORKDIR}/${FIP_UBOOT_DTB}.${FIP_UBOOT_DTB_SUFFIX}" /firmware/bootloader || true
                 fdtput -t s "${WORKDIR}/${FIP_UBOOT_DTB}.${FIP_UBOOT_DTB_SUFFIX}" /firmware/bootloader compatible "lmp,bootloader"
                 fdtput -t s "${WORKDIR}/${FIP_UBOOT_DTB}.${FIP_UBOOT_DTB_SUFFIX}" /firmware/bootloader bootfirmware-version "${LMP_BOOT_FIRMWARE_VERSION}"
             fi

--- a/meta-lmp-base/classes/uboot-fitimage.bbclass
+++ b/meta-lmp-base/classes/uboot-fitimage.bbclass
@@ -252,7 +252,7 @@ EOF
 	# Add boot firmware version to U-Boot DTB (if it's defined and is not zero)
 	if [ -n "${LMP_BOOT_FIRMWARE_VERSION}" -a "${LMP_BOOT_FIRMWARE_VERSION}" != "0" ]; then
 		# Might return "FDT_ERR_EXISTS" error, if "lmp" node already exists
-		fdtput -c -t s ${uboot_dtb} /firmware/bootloader || true
+		fdtput -c -p -t s ${uboot_dtb} /firmware/bootloader || true
 		fdtput -t s ${uboot_dtb} /firmware/bootloader compatible "lmp,bootloader"
 		fdtput -t s ${uboot_dtb} /firmware/bootloader bootfirmware-version "${LMP_BOOT_FIRMWARE_VERSION}"
 	fi


### PR DESCRIPTION
Create the /firmware/bootloader node using auto-path, in order to automatically create all nodes required for the node path (useful for cases where /firmware is not defined by the board).