### PR TITLE
base: image-efi-installer: use ext4 for ota-boot content

### DIFF
--- a/meta-lmp-base/wic/image-efi-installer.wks.in
+++ b/meta-lmp-base/wic/image-efi-installer.wks.in
@@ -3,7 +3,7 @@
 
 part /boot --source bootimg-efi --sourceparams="loader=${EFI_PROVIDER},title=Install ${DISTRO_NAME} (${DISTRO_VERSION}),label=install-efi,initrd=${INITRD_IMAGE_LIVE}-${MACHINE}.${INITRAMFS_FSTYPES}" --ondisk sda --label install --active --align 1024 --use-uuid --size 100
 
-part /efi --source rootfs --ondisk sda --rootfs-dir=${WORKDIR}/ota-boot --fstype=vfat --label otaboot --align 4096 ${OSTREE_WKS_BOOT_SIZE}
+part /efi --source rootfs --ondisk sda --rootfs-dir=${WORKDIR}/ota-boot --fstype=ext4 --label otaboot --align 4096 ${OSTREE_WKS_BOOT_SIZE}
 part / --source bootimg-partition --ondisk sda --fstype=ext4 --label image --use-uuid --align 1024
 
 bootloader --ptable gpt --timeout=5


### PR DESCRIPTION
This avoids a possible UEFI bootloader confusion when searching for the right ESP partition to boot.

This change also won't affect the behavior of the installer since ota-boot is just used as a way to copy the /boot content that is supposed to be installed as part of the final image. The final ESP partition is created manually by the script.