### PR TITLE
bsp: optee-os-fio-bsp: drop sw prng settings for am62xx

### DIFF
--- a/meta-lmp-bsp/recipes-security/optee/optee-os-fio-bsp.inc
+++ b/meta-lmp-bsp/recipes-security/optee/optee-os-fio-bsp.inc
@@ -51,9 +51,6 @@ EXTRA_OEMAKE:append:versal = " \
 "
 
 # Machine Settings
-EXTRA_OEMAKE:append:am62xx-evm = " \
-    CFG_WITH_SOFTWARE_PRNG=y \
-"
 EXTRA_OEMAKE:append:apalis-imx6 = " \
     CFG_DDR_SIZE=0x80000000 CFG_NS_ENTRY_ADDR=0x17800000 CFG_NXP_CAAM=y \
     CFG_TZDRAM_START=0x4e000000 CFG_DT=y CFG_OVERLAY_ADDR=0x16000000 \


### PR DESCRIPTION
OP-TEE 3.20 has proper TRNG support, so no need to force the software based implementation.