### PR TITLE
bsp: u-boot-ostree-scr-fit: am62/am64: update fit config naming

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/am62xx-evm/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/am62xx-evm/boot.cmd
@@ -11,7 +11,7 @@ setenv loadaddr 0x90000000
 setenv bootcmd_resetvars 'setenv kernel_image; setenv bootargs; setenv kernel_image2; setenv bootargs2'
 setenv bootcmd_otenv 'run bootcmd_resetvars; ext4load ${devtype} ${devnum}:2 ${scriptaddr} /boot/loader/uEnv.txt; env import -t ${scriptaddr} ${filesize} kernel_image bootargs kernel_image2 bootargs2'
 setenv bootcmd_load_f 'ext4load ${devtype} ${devnum}:2 ${loadaddr} "/boot"${kernel_image}'
-setenv bootcmd_run 'bootm ${loadaddr}#conf-ti_${fdtfile}${dtoverlay}'
+setenv bootcmd_run 'bootm ${loadaddr}#conf-${fdtfile}${dtoverlay}'
 setenv bootcmd_rollbackenv 'setenv kernel_image ${kernel_image2}; setenv bootargs ${bootargs2}'
 setenv bootcmd_set_rollback 'if test ! "${rollback}" = "1"; then setenv rollback 1; setenv upgrade_available 0; saveenv; fi'
 setenv bootostree 'run bootcmd_load_f; run findfdt; run bootcmd_run'

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/am64xx-evm/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/am64xx-evm/boot.cmd
@@ -8,7 +8,7 @@ setenv loadaddr 0x90000000
 setenv bootcmd_resetvars 'setenv kernel_image; setenv bootargs; setenv kernel_image2; setenv bootargs2'
 setenv bootcmd_otenv 'run bootcmd_resetvars; ext4load ${devtype} ${devnum}:2 ${scriptaddr} /boot/loader/uEnv.txt; env import -t ${scriptaddr} ${filesize} kernel_image bootargs kernel_image2 bootargs2'
 setenv bootcmd_load_f 'ext4load ${devtype} ${devnum}:2 ${loadaddr} "/boot"${kernel_image}'
-setenv bootcmd_run 'bootm ${loadaddr}#conf-ti_${fdtfile}'
+setenv bootcmd_run 'bootm ${loadaddr}#conf-${fdtfile}'
 setenv bootcmd_rollbackenv 'setenv kernel_image ${kernel_image2}; setenv bootargs ${bootargs2}'
 setenv bootcmd_set_rollback 'if test ! "${rollback}" = "1"; then setenv rollback 1; setenv upgrade_available 0; saveenv; fi'
 setenv bootostree 'run bootcmd_load_f; run findfdt; run bootcmd_run'


### PR DESCRIPTION
Extra "ti_" is already part of the default fdtfile variable in the latest TI BSP (set via "run findfdt").