### PR TITLE
base: recipe-sota: aktualizr-lite: bump to bb55a33

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "2d6fade7123f1dfdb11cda4e6501686a8f8c828f"
+SRCREV:lmp = "bb55a33b9d6e2b973b77f1f4d60df30b59b5e764"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
Relevant changes:
- bb55a33 Merge pull request #237 from foundriesio/custom-client-target
- 447bbbe readme: Add info on building running the custom client
- 7dbcead custom-client: Add env var to specify config dir
- c528030 makefile: Add the custom client target
- a05f2a1 Merge pull request #236 from foundriesio/fix-events-draining-at-exit
- dbcfa31 liteclient: Drain events before destruction
- 404d643 Merge pull request #235 from foundriesio/kprosise/cleanup-markdown
- c12719d Cleanup documentation in aktualizr-lite