### PR TITLE
lmp-staging: lmp_sstate_checkhashes: summary needs to be checked

### DIFF
--- a/meta-lmp-base/classes/lmp-staging.bbclass
+++ b/meta-lmp-base/classes/lmp-staging.bbclass
@@ -35,9 +35,10 @@ inherit ${LMPSTAGING_INHERIT_KERNEL_MODSIGN}
 
 BB_HASHCHECK_FUNCTION:lmp = "lmp_sstate_checkhashes"
 def lmp_sstate_checkhashes(sq_data, d, **kwargs):
-    mirrors = d.getVar("SSTATE_MIRRORS")
-    if mirrors:
-        bb.plain("SState mirrors: %s" % mirrors)
+    if 'summary' not in kwargs or kwargs.get('summary'):
+        mirrors = d.getVar("SSTATE_MIRRORS")
+        if mirrors:
+            bb.plain("SState mirrors: %s" % mirrors)
     return sstate_checkhashes(sq_data, d, **kwargs)
 
 # don't check images


### PR DESCRIPTION
We only show mirror in use when the summary is enabled
and because the default value of the function is summary=True
we need to considere and validate when the argument is not provided.


This fix a bug where multiple lines are printed for every sstate_checkhashes call:
```
SState mirrors: file://.* https://storage.googleapis.com/lmp-cache/v90-sstate-cache/PATH
SState mirrors: file://.* https://storage.googleapis.com/lmp-cache/v90-sstate-cache/PATH
SState mirrors: file://.* https://storage.googleapis.com/lmp-cache/v90-sstate-cache/PATH
SState mirrors: file://.* https://storage.googleapis.com/lmp-cache/v90-sstate-cache/PATH
```