### PR TITLE
base: docker-cli-config: Make hub.fio URL configurable

### DIFF
--- a/meta-lmp-base/recipes-support/docker-cli-config/docker-cli-config/config.json
+++ b/meta-lmp-base/recipes-support/docker-cli-config/docker-cli-config/config.json
@@ -1,5 +1,0 @@
-{
-	"credHelpers": {
-		"hub.foundries.io": "fio-helper"
-	}
-}

--- a/meta-lmp-base/recipes-support/docker-cli-config/docker-cli-config/config.json.in
+++ b/meta-lmp-base/recipes-support/docker-cli-config/docker-cli-config/config.json.in
@@ -1,0 +1,5 @@
+{
+	"credHelpers": {
+		"@@HUB_URL@@": "fio-helper"
+	}
+}

--- a/meta-lmp-base/recipes-support/docker-cli-config/docker-cli-config_0.1.bb
+++ b/meta-lmp-base/recipes-support/docker-cli-config/docker-cli-config_0.1.bb
@@ -4,15 +4,22 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 inherit allarch
 
-SRC_URI = "file://config.json"
+SRC_URI = "file://config.json.in"
 
 S = "${WORKDIR}"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
+FIO_HUB_URL ?= "hub.foundries.io"
+
+do_compile() {
+    sed -e 's|@@HUB_URL@@|${FIO_HUB_URL}|g' \
+        ${WORKDIR}/config.json.in > ${B}/config.json
+}
+
 do_install() {
         install -d ${D}${libdir}/docker
-        install -m 0644 ${WORKDIR}/config.json ${D}${libdir}/docker/config.json
+        install -m 0644 ${B}/config.json ${D}${libdir}/docker/config.json
 }
 
 FILES:${PN} += "${libdir}/docker"


### PR DESCRIPTION
This can be used to point a device at another factory backend instance.