### PR TITLE
base: u-boot-fio: imx-2022.04: switch to 2022.04+lf-6.1.1-1.0.0-fio

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
@@ -1,7 +1,7 @@
 require u-boot-fio-common.inc
 
-SRCREV = "30e6a51d9e203b7509f3bbb144366e9d2ebf8bb9"
-SRCBRANCH = "2022.04+lf-5.15.71-2.2.0-fio"
+SRCREV = "7e751bd63f4ba9b59287ba7a5229ed25afd9cdd0"
+SRCBRANCH = "2022.04+lf-6.1.1-1.0.0-fio"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 
 DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
Use a u-boot version based on NXP u-boot branch lf_v2022.04 and tag lf-6.1.1-1.0.0 used in NXP BSP LF6.1.1_1.0.0.

Tested booting lmp-base:
- imx6ullevk: **OK**
- imx8mm-lpddr4-evk: **OK**.
- apalis-imx8: **OK**

Tested by Ricardo:
- imx8ulp
- imx93