### PR TITLE
base: linux-lmp-dev: update template to 6.4.0-rc2

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp-dev.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp-dev.bb
@@ -12,7 +12,7 @@ python __anonymous() {
 FIO_LMP_GIT_URL ?= "github.com"
 FIO_LMP_GIT_NAMESPACE ?= "foundriesio/"
 
-LINUX_VERSION ?= "5.15-rc"
+LINUX_VERSION ?= "6.4.0-rc2"
 LINUX_VERSION_EXTENSION ?= "-lmpdev-${LINUX_KERNEL_TYPE}"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 


### PR DESCRIPTION
Update template variables to use 6.4.0-rc2 by default, as that is the current development release.