### PR TITLE
stm32-mfgtool-files: fix tar's "--transform" to rename dir

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files/FlashLayout_stm32mp1-usb.tsv.in
+++ b/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files/FlashLayout_stm32mp1-usb.tsv.in
@@ -1,3 +1,3 @@
 #Opt	Id	Name		Type		IP	Offset		Binary
--	0x01	fsbl-boot	Binary		none	0x0		../stm32-mfgtool-files/tf-a-@@BOARD_NAME@@-usb.stm32
--	0x03	fip-boot	Binary		none	0x0		../stm32-mfgtool-files/fip-@@BOARD_NAME@@-optee.bin
+-	0x01	fsbl-boot	Binary		none	0x0		../mfgtool-files-@@MACHINE@@/tf-a-@@BOARD_NAME@@-usb.stm32
+-	0x03	fip-boot	Binary		none	0x0		../mfgtool-files-@@MACHINE@@/fip-@@BOARD_NAME@@-optee.bin

--- a/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files_0.1.bb
+++ b/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files_0.1.bb
@@ -43,7 +43,7 @@ do_deploy() {
     install -m 0644 ${DEPLOY_DIR_IMAGE}/fitImage-${INITRAMFS_IMAGE}-${MACHINE}-${MACHINE} ${DEPLOYDIR}/${PN}/fitImage-mfgtool
 
     tar -czf ${DEPLOYDIR}/${PN}-${MACHINE}.tar.gz \
-            --transform "s,^mfgtool-files,mfgtool-files-${MACHINE}," \
+            --transform "s,^${PN},mfgtool-files-${MACHINE}," \
             -C ${DEPLOYDIR} ${PN}
 
     ln -s ${PN}-${MACHINE}.tar.gz ${DEPLOYDIR}/${PN}.tar.gz


### PR DESCRIPTION
As explained by Arnout Vandecappelle in a review, the "`--transform`" in:
 ```
 tar -czf ${DEPLOYDIR}/${PN}-${MACHINE}.tar.gz \
          --transform "s,^mfgtool-files,mfgtool-files-${MACHINE}," \
          -C ${DEPLOYDIR} ${PN}
```

in the "`do_deploy()`" task in "`stm32-mfgtool-files_0.1.bb`" [1] does not work:
```
  This transform isn’t doing anything, because the directory is called
  "stm32-mfgtool-files", not "mfgtool-files"... Should use "${PN}"
  here. I do think the transform is useful.
```

We should use "`${PN}`" instead of "`mfgtool-files`" as source of the name transformation, because the directory name is "`${PN}`", as shown by the first line of "`do_deploy()`" on line 38:
```
  install -d ${DEPLOYDIR}/${PN}
```
"`${PN}`" is the recipe name [3], "`stm32-mfgtool-files`" in our case.

This recipe was moved since the review but it is still part of the "lmp" open-source code [1] and the "`--transform`" option is likely a cut-and-paste of [2].

Fixed the directory "`--transform`" when generating the archive: used "`${PN}`". Fixed the directory names in the associated "`FlashLayout_stm32mp1-usb.tsv.in`".

Caveat: the directory name is changed, this could impact the users of the mfgtool archive.

**References:**
- [1]      "_stm32-mfgtool-files_0.1.bb - line 46_"
           <https://github.com/foundriesio/meta-lmp/blob/mp-90/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files_0.1.bb#L46>
- [2]      "_mfgtool-files_0.1.bb - line 48_"
           <https://github.com/foundriesio/meta-lmp/blob/mp-90/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb#L48>
- [3]      "_Yocto - PN variable_"
           <https://docs.yoctoproject.org/ref-manual/variables.html#term-PN>

Suggested-by: Arnout Vandecappelle <arnout.vandecappelle@mind.be>