### PR TITLE
base: lmp-device-register: bump to 0e65a28

### DIFF
--- a/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl glib-2.0 libp11 openssl"
 
-SRCREV = "263d11e77d0489e0daa8ed515eb5b4f2a6ad835d"
+SRCREV = "0e65a282f11bf5fac5744c0ba149edf8a5e958bf"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https;branch=main"
 


### PR DESCRIPTION
Relevant changes:
- 0e65a28 Merge pull request #44 from ldts/pacman-fix
- 45b6d27 main: fix missing pacman tags
- 85675c3 auth: Make the oauth api configurable