### PR TITLE
base: u-boot-fio: 2022.04: bump to ea62f691709

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2022.04.bb
@@ -1,5 +1,5 @@
 require u-boot-fio-common.inc
 
-SRCREV = "3eb76326d0fca7330ce530e6975b5d92d7b011c7"
+SRCREV = "ea62f69170949dbb0a283cfbedb3d612b09c2ddb"
 SRCBRANCH = "2022.04+fio"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"


### PR DESCRIPTION
Relevant changes:
- ea62f691709 [FIO extras] board: rpi: always set fdt_addr if provided by firmware