### PR TITLE
bsp: linux-lmp-fslc-imx: add patches for kernel 6.1

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-FIO-toimx-of-enable-using-OF_DYNAMIC-without-OF_UNIT.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-FIO-toimx-of-enable-using-OF_DYNAMIC-without-OF_UNIT.patch
@@ -1,0 +1,36 @@
+From c7ad24edca81bd463235ebe8399bac243bae177b Mon Sep 17 00:00:00 2001
+From: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
+Date: Tue, 30 May 2023 17:59:47 +0300
+Subject: [PATCH 1/2] [FIO toimx] of: enable using OF_DYNAMIC without
+ OF_UNITTEST
+
+Since commit [1] there are i.MX drivers which use the OF_DYNAMIC
+feature. Let the option OF_DYNAMIC enable independently of
+OF_UNITTEST.
+
+[1]
+commit a553d46954894 ("MLK-17275-1 drm/bridge: adv7511: Add support for OF_DYNAMIC")
+
+Upstream-Status: Pending
+Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
+---
+
+ drivers/of/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/of/Kconfig b/drivers/of/Kconfig
+index 80b5fd44ab1c7..89204c537b06c 100644
+--- a/drivers/of/Kconfig
++++ b/drivers/of/Kconfig
+@@ -55,7 +55,7 @@ config OF_KOBJ
+ # Hardly any platforms need this.  It is safe to select, but only do so if you
+ # need it.
+ config OF_DYNAMIC
+-	bool "Support for dynamic device trees" if OF_UNITTEST
++	bool "Support for dynamic device trees"
+ 	select OF_KOBJ
+ 	help
+ 	  On some platforms, the device tree can be manipulated at runtime.
+-- 
+2.40.1
+

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0002-FIO-toup-media-Kconfig-fix-double-VIDEO_DEV.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0002-FIO-toup-media-Kconfig-fix-double-VIDEO_DEV.patch
@@ -1,0 +1,32 @@
+From 5359b7f5ba75a3b93d4195d66290aa92c802cad4 Mon Sep 17 00:00:00 2001
+From: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
+Date: Tue, 30 May 2023 18:04:50 +0300
+Subject: [PATCH 2/2] [FIO toup] media: Kconfig: fix double VIDEO_DEV
+
+The VIDEO_IMX_MEDIA dependency of VIDEO_DEV has 2 entries.
+Remove a duplicate.
+
+Upstream-Status: Pending
+
+Fixes: commit 9958d30f38b96 ("media: Kconfig: cleanup VIDEO_DEV dependencies")
+Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
+---
+
+ drivers/staging/media/imx/Kconfig | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/staging/media/imx/Kconfig b/drivers/staging/media/imx/Kconfig
+index 58f3ebd53bfba..a154edad36333 100644
+--- a/drivers/staging/media/imx/Kconfig
++++ b/drivers/staging/media/imx/Kconfig
+@@ -4,7 +4,6 @@ config VIDEO_IMX_MEDIA
+ 	depends on ARCH_MXC || COMPILE_TEST
+ 	depends on HAS_DMA
+ 	depends on VIDEO_DEV
+-	depends on VIDEO_DEV
+ 	select MEDIA_CONTROLLER
+ 	select V4L2_FWNODE
+ 	select V4L2_MEM2MEM_DEV
+-- 
+2.40.1
+

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.1.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.1.bb
@@ -12,6 +12,8 @@ SRC_URI += " \
     file://0004-FIO-toup-hwrng-optee-support-generic-crypto.patch \
     file://0001-FIO-extras-arm64-dts-imx8mm-evk-use-imx8mm-evkb-for-.patch \
     file://0001-arm64-dts-imx8mq-drop-cpu-idle-states.patch \
+    file://0001-FIO-toimx-of-enable-using-OF_DYNAMIC-without-OF_UNIT.patch \
+    file://0002-FIO-toup-media-Kconfig-fix-double-VIDEO_DEV.patch \
 "
 
 SRC_URI:append:imx8mp-lpddr4-evk = " \


### PR DESCRIPTION
Add and apply patches to fix issues with kernel 6.1:
- let OF_DYNAMIC enable independently, it is required by ADV bridge driver to be probed properly and not break the whole DRM stack.
- minor fix of Kconfig.