### PR TITLE
Xenomai4

### DIFF
--- a/meta-lmp-base/conf/distro/include/non-clangable.inc
+++ b/meta-lmp-base/conf/distro/include/non-clangable.inc
@@ -99,6 +99,8 @@ OBJCOPY:pn-linux-lmp-fslc-imx:toolchain-clang = "${HOST_PREFIX}objcopy"
 STRIP:pn-linux-lmp-fslc-imx:toolchain-clang = "${HOST_PREFIX}strip"
 OBJCOPY:pn-linux-lmp-fslc-imx-rt:toolchain-clang = "${HOST_PREFIX}objcopy"
 STRIP:pn-linux-lmp-fslc-imx-rt:toolchain-clang = "${HOST_PREFIX}strip"
+OBJCOPY:pn-linux-lmp-fslc-imx-xeno4:toolchain-clang = "${HOST_PREFIX}objcopy"
+STRIP:pn-linux-lmp-fslc-imx-xeno4:toolchain-clang = "${HOST_PREFIX}strip"
 OBJCOPY:pn-linux-lmp-ti-staging:toolchain-clang = "${HOST_PREFIX}objcopy"
 STRIP:pn-linux-lmp-ti-staging:toolchain-clang = "${HOST_PREFIX}strip"
 OBJCOPY:pn-linux-tegra:toolchain-clang = "${HOST_PREFIX}objcopy"
@@ -109,6 +111,12 @@ STRIP:pn-linux-tegra-rt:toolchain-clang = "${HOST_PREFIX}strip"
 # jailhouse (includes kernel module)
 # | warning: the compiler differs from the one used to build the kernel
 TOOLCHAIN:pn-jailhouse = "gcc"
+
+# use gcc for now as it fail with clang with some compile errors:
+# error: passing 'unsigned int *' to parameter of type 'int *' converts between pointers to integer types with different sign [-Werror,-Wpointer-sign]
+# error: fields must have a constant size: 'variable length array in structure' extension will never be supported
+# error: passing 'typeof (((fundle_t)0)) *' (aka 'unsigned int *') to parameter of type '__s32 *' (aka 'int *') converts between pointers to integer types with different sign [-Werror,-Wpointer-sign]
+TOOLCHAIN:pn-xenomai4 = "gcc"
 
 # qemuarm64-secureboot
 # | ld.lld: error: cannot open /usr/lib/clang/14.0.3/lib/linux/libclang_rt.builtins-aarch64.a: No such file or directory

--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.15.y"
-KERNEL_META_COMMIT ?= "a7ae63e31fd6f59add8d54bf6d28179485d72ec4"
+KERNEL_META_COMMIT ?= "8e6ac16ef2bc7875b0173b84b97669e59a936638"

--- a/meta-lmp-base/recipes-kernel/xenomai4/xenomai4_git.bb
+++ b/meta-lmp-base/recipes-kernel/xenomai4/xenomai4_git.bb
@@ -1,0 +1,35 @@
+SUMMARY = "Xenomai 4"
+DESCRIPTION = "Xenomai 4 user support (libevl)"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2500c28da9dacbee31a3f4d4f69b74d0"
+
+SRCBRANCH = "master"
+
+SRC_URI = "git://source.denx.de/Xenomai/xenomai4/libevl.git;protocol=https;branch=${SRCBRANCH}"
+SRCREV = "dbb1a86f011d7b87f1420fbf13753ea9fccef6af"
+
+S = "${WORKDIR}/git"
+
+# We need the kernel sources to be available, so build it first.
+DEPENDS += "virtual/kernel"
+
+# We may need this for 64bit atomic ops.
+RDEPENDS:${PN}:append:libc-glibc = " libgcc"
+
+inherit pkgconfig meson features_check
+
+REQUIRED_MACHINE_FEATURES = "xeno"
+
+PACKAGECONFIG ?= ""
+PACKAGECONFIG[debug] = "-Doptimization=0 -Ddebug=true,,,"
+
+EXTRA_OEMESON = "-Duapi=${STAGING_KERNEL_DIR}"
+
+PACKAGES += "${PN}-test"
+
+FILES:${PN}-test = "${prefix}/tests"
+
+# install the test by default and use BAD_RECOMMENDATIONS when not desired
+RRECOMMENDS:${PN} += "${PN}-test"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx-xeno4_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx-xeno4_git.bb
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/linux-lmp-fslc-imx:"
+
+include linux-lmp-fslc-imx_git.bb
+
+KERNEL_REPO = "git://github.com/foundriesio/linux.git"
+LINUX_VERSION = "5.15.87"
+KERNEL_BRANCH = "5.15-2.2.x-imx-xeno4"
+
+SRCREV_machine = "dbd918d3a96e088088307b4a62886efd889058a6"
+LINUX_KERNEL_TYPE = "xeno4"


### PR DESCRIPTION
Depends on lmp-kernel-cache being merged

Enabling xeno4 should not only select the kernel but also select the libraries and utilities recipes[ TODO]

initial tests done on imx8mm-lpddr4-evk, imx8mm-lpddr4-evk 5.15.87-lmp-xeno4 