### PR TITLE
base: aktualizr: set default curl timeout for ostree

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
@@ -13,6 +13,7 @@ RestartSec=180
 Restart=always
 ExecStartPre=/usr/bin/mkdir -p /run/aktualizr
 Environment="TMPDIR=/run/aktualizr"
+Environment="OSTREE_CURL_TIMEOUT=@@OSTREE_CURL_TIMEOUT@@"
 Environment="COMPOSE_HTTP_TIMEOUT=@@COMPOSE_HTTP_TIMEOUT@@"
 Environment="REGISTRY_AUTH_FILE=@@DOCKER_CRED_HELPER_CFG@@"
 ExecStart=/usr/bin/aktualizr-lite daemon

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -22,6 +22,7 @@ SYSTEMD_PACKAGES += "${PN}-lite"
 SYSTEMD_SERVICE:${PN}-lite = "aktualizr-lite.service"
 
 COMPOSE_HTTP_TIMEOUT ?= "60"
+OSTREE_CURL_TIMEOUT ?= "780"
 DOCKER_CRED_HELPER_CFG ?= "${libdir}/docker/config.json"
 
 # Workaround as aktualizr is a submodule of aktualizr-lite
@@ -34,6 +35,7 @@ do_configure:prepend:lmp() {
 
 do_compile:append:lmp() {
     sed -e 's|@@COMPOSE_HTTP_TIMEOUT@@|${COMPOSE_HTTP_TIMEOUT}|g' \
+        -e 's|@@OSTREE_CURL_TIMEOUT@@|${OSTREE_CURL_TIMEOUT}|g' \
         -e 's|@@DOCKER_CRED_HELPER_CFG@@|${DOCKER_CRED_HELPER_CFG}|g' \
         ${WORKDIR}/aktualizr-lite.service.in > ${WORKDIR}/aktualizr-lite.service
 }


### PR DESCRIPTION
Ostree already has a default curl timeout set of 780 seconds, and also the support for fetching a custom timeout via the environment variable OSTREE_CURL_TIMEOUT, so in order to allow user customization, set OSTREE_CURL_TIMEOUT to 780 by default.