### PR TITLE
Skopeo max parallel pulls param

### DIFF
--- a/meta-lmp-base/recipes-containers/skopeo/skopeo/0001-cmd-copy-max-parallel-pulls-param.patch
+++ b/meta-lmp-base/recipes-containers/skopeo/skopeo/0001-cmd-copy-max-parallel-pulls-param.patch
@@ -1,0 +1,43 @@
+From 897767edb5dda313483ba5496138230eb5383e3a Mon Sep 17 00:00:00 2001
+From: Mike Sul <mike.sul@foundries.io>
+Date: Tue, 6 Jun 2023 20:33:48 +0200
+Subject: [PATCH] [fio up]: cmd: copy: Add param to specify max parallel pulls
+
+Upstream-Status: Pending
+
+Signed-off-by: Mike <mike.sul@foundries.io>
+---
+ cmd/skopeo/copy.go | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/cmd/skopeo/copy.go b/cmd/skopeo/copy.go
+index 6a7e8013..0e9e97ec 100644
+--- a/cmd/skopeo/copy.go
++++ b/cmd/skopeo/copy.go
+@@ -44,6 +44,7 @@ type copyOptions struct {
+ 	encryptLayer             []int                     // The list of layers to encrypt
+ 	encryptionKeys           []string                  // Keys needed to encrypt the image
+ 	decryptionKeys           []string                  // Keys needed to decrypt the image
++	maxParallelDownloads     uint                      // The maximum layers to pull at the same time. Applies to a single copy operation.
+ }
+ 
+ func copyCmd(global *globalOptions) *cobra.Command {
+@@ -95,6 +96,7 @@ See skopeo(1) section "IMAGE NAMES" for the expected format
+ 	flags.StringSliceVar(&opts.encryptionKeys, "encryption-key", []string{}, "*Experimental* key with the encryption protocol to use needed to encrypt the image (e.g. jwe:/path/to/key.pem)")
+ 	flags.IntSliceVar(&opts.encryptLayer, "encrypt-layer", []int{}, "*Experimental* the 0-indexed layer indices, with support for negative indexing (e.g. 0 is the first layer, -1 is the last layer)")
+ 	flags.StringSliceVar(&opts.decryptionKeys, "decryption-key", []string{}, "*Experimental* key needed to decrypt the image")
++	flags.UintVar(&opts.maxParallelDownloads, "max-parallel-pulls", 6, "The maximum layers to pull at the same time (defaults to `6` if not specified or zet to `0`). Applies to a single copy operation.")
+ 	return cmd
+ }
+ 
+@@ -300,6 +302,7 @@ func (opts *copyOptions) run(args []string, stdout io.Writer) (retErr error) {
+ 			OciDecryptConfig:                 decConfig,
+ 			OciEncryptLayers:                 encLayers,
+ 			OciEncryptConfig:                 encConfig,
++			MaxParallelDownloads:             opts.maxParallelDownloads,
+ 		})
+ 		if err != nil {
+ 			return err
+-- 
+2.40.1
+

--- a/meta-lmp-base/recipes-containers/skopeo/skopeo_git.bbappend
+++ b/meta-lmp-base/recipes-containers/skopeo/skopeo_git.bbappend
@@ -1,3 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://docker-config-support-default-system-config.patch;patchdir=src/import"
+SRC_URI += " \
+    file://docker-config-support-default-system-config.patch;patchdir=src/import \
+    file://0001-cmd-copy-max-parallel-pulls-param.patch;patchdir=src/import \
+"

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
@@ -15,6 +15,8 @@ ExecStartPre=/usr/bin/mkdir -p /run/aktualizr
 Environment="TMPDIR=/run/aktualizr"
 Environment="COMPOSE_HTTP_TIMEOUT=@@COMPOSE_HTTP_TIMEOUT@@"
 Environment="REGISTRY_AUTH_FILE=@@DOCKER_CRED_HELPER_CFG@@"
+# Allowed values are in the [1, 10] range. Aklite adjusts value to the corresponding limit if the specified value is higher or lower than [1, 10].
+Environment="SKOPEO_MAX_PARALLEL_PULLS=@@SKOPEO_MAX_PARALLEL_PULLS@@"
 ExecStart=/usr/bin/aktualizr-lite daemon
 
 [Install]

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "bb55a33b9d6e2b973b77f1f4d60df30b59b5e764"
+SRCREV:lmp = "0d8c0e3749629e18c4f998c2a863b5e5935c2a2d"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -23,6 +23,7 @@ SYSTEMD_SERVICE:${PN}-lite = "aktualizr-lite.service"
 
 COMPOSE_HTTP_TIMEOUT ?= "60"
 DOCKER_CRED_HELPER_CFG ?= "${libdir}/docker/config.json"
+SKOPEO_MAX_PARALLEL_PULLS ?= "3"
 
 # Workaround as aktualizr is a submodule of aktualizr-lite
 do_configure:prepend:lmp() {
@@ -35,6 +36,7 @@ do_configure:prepend:lmp() {
 do_compile:append:lmp() {
     sed -e 's|@@COMPOSE_HTTP_TIMEOUT@@|${COMPOSE_HTTP_TIMEOUT}|g' \
         -e 's|@@DOCKER_CRED_HELPER_CFG@@|${DOCKER_CRED_HELPER_CFG}|g' \
+        -e 's|@@SKOPEO_MAX_PARALLEL_PULLS@@|${SKOPEO_MAX_PARALLEL_PULLS}|g' \
         ${WORKDIR}/aktualizr-lite.service.in > ${WORKDIR}/aktualizr-lite.service
 }
 


### PR DESCRIPTION
- Patch `skopeo` to expose a new CLI param `--max-parallel-pulls`.
- Add a new env. variable to control the maximum concurrent pulls in `skopeo copy` command.
- Bump the new aklite version that supports the new env. var.