### PR TITLE
[all relevant imx] Switch to kernel 6.1

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.1.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.1.bb
@@ -30,5 +30,3 @@ SRC_URI:append:imx8mm-lpddr4-evk = " \
 SRC_URI:append:mx8mn-nxp-bsp = " \
     file://0001-FIO-internal-arm64-dts-imx8mn-evk.dtsi-re-add-blueto.patch \
 "
-
-DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
This PR switches all imx machines that use linux-lmp-fslc-imx kernel to 6.1.

This version includes both arm64/arm32 archs.

This PR is splitter to smaller ones:
https://github.com/foundriesio/meta-lmp/pull/1194
https://github.com/foundriesio/meta-lmp/pull/1195