### PR TITLE
Further patches for kernel 6.1

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0003-FIO-toup-gpu-drm-cadence-select-hdmi-helper.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0003-FIO-toup-gpu-drm-cadence-select-hdmi-helper.patch
@@ -1,0 +1,37 @@
+From 7edfba994d7eb53ad76d8de0cf8a92687e4f86e6 Mon Sep 17 00:00:00 2001
+From: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
+Date: Sat, 3 Jun 2023 20:11:26 +0300
+Subject: [PATCH 3/4] [FIO toup] gpu: drm: cadence: select hdmi helper
+
+drm_hdmi_helper driver is required for cdns-hdmi-core driver to be
+built well. Select the option DRM_DISPLAY_HDMI_HELPER to fix building
+error [1].
+
+[1]
+aarch64-none-linux-gnu-ld: drivers/gpu/drm/bridge/cadence/cdns-hdmi-core.o: in function `cdns_hdmi_mode_set':
+cdns-hdmi-core.c:(.text+0xfec): undefined reference to `drm_hdmi_avi_infoframe_colorimetry'
+aarch64-none-linux-gnu-ld: cdns-hdmi-core.c:(.text+0x10ac): undefined reference to `drm_hdmi_infoframe_set_hdr_metadata'
+
+Upstream-Status: Pending
+
+Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
+---
+
+ drivers/gpu/drm/bridge/cadence/Kconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpu/drm/bridge/cadence/Kconfig b/drivers/gpu/drm/bridge/cadence/Kconfig
+index 736b107fab74d..76dc4cb60ba58 100644
+--- a/drivers/gpu/drm/bridge/cadence/Kconfig
++++ b/drivers/gpu/drm/bridge/cadence/Kconfig
+@@ -40,6 +40,7 @@ config DRM_CDNS_MHDP
+ config DRM_CDNS_HDMI
+ 	tristate "Cadence HDMI DRM driver"
+ 	depends on DRM_CDNS_MHDP
++	select DRM_DISPLAY_HDMI_HELPER
+ 
+ config DRM_CDNS_DP
+ 	tristate "Cadence DP DRM driver"
+-- 
+2.40.1
+

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0004-FIO-toup-media-imx8-select-v4l2_-for-mxc-mipi-csi2_y.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0004-FIO-toup-media-imx8-select-v4l2_-for-mxc-mipi-csi2_y.patch
@@ -1,0 +1,39 @@
+From 75fd604dbdc332e02cd5d1c6bee60058ed0a509f Mon Sep 17 00:00:00 2001
+From: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
+Date: Sat, 3 Jun 2023 20:25:35 +0300
+Subject: [PATCH 4/4] [FIO toup] media: imx8: select v4l2_* for
+ mxc-mipi-csi2_yav
+
+v4l2-fwnode and v4l2-async modules are required by mxc-mipi-csi2_yav
+driver. Select V4L2_FWNODE in IMX8_MIPI_CSI2_YAV to fix the building
+error [1].
+
+[1]
+ERROR: modpost: "v4l2_fwnode_endpoint_parse" [drivers/media/platform/imx8/mxc-mipi-csi2_yav.ko] undefined!
+ERROR: modpost: "v4l2_async_register_subdev" [drivers/media/platform/imx8/mxc-mipi-csi2_yav.ko] undefined!
+ERROR: modpost: "v4l2_async_nf_init" [drivers/media/platform/imx8/mxc-mipi-csi2_yav.ko] undefined!
+...
+
+Upstream-Status: Pending
+
+Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
+---
+
+ drivers/media/platform/imx8/Kconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/media/platform/imx8/Kconfig b/drivers/media/platform/imx8/Kconfig
+index eb42572ef27f3..d5ecd749e516b 100644
+--- a/drivers/media/platform/imx8/Kconfig
++++ b/drivers/media/platform/imx8/Kconfig
+@@ -4,6 +4,7 @@ menu "IMX8 Camera ISI/MIPI Features support"
+ config IMX8_MIPI_CSI2_YAV
+ 	tristate "IMX8 MIPI CSI2 Controller Yet Another Version"
+ 	default y
++	select V4L2_FWNODE
+ 
+ endmenu
+ endif #VIDEO_MX8_CAPTURE
+-- 
+2.40.1
+

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.1.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.1.bb
@@ -14,6 +14,8 @@ SRC_URI += " \
     file://0001-arm64-dts-imx8mq-drop-cpu-idle-states.patch \
     file://0001-FIO-toimx-of-enable-using-OF_DYNAMIC-without-OF_UNIT.patch \
     file://0002-FIO-toup-media-Kconfig-fix-double-VIDEO_DEV.patch \
+    file://0003-FIO-toup-gpu-drm-cadence-select-hdmi-helper.patch \
+    file://0004-FIO-toup-media-imx8-select-v4l2_-for-mxc-mipi-csi2_y.patch \
 "
 
 SRC_URI:append:imx8mp-lpddr4-evk = " \


### PR DESCRIPTION
     
Add more patches to fix issues with building imx8mp and imx8mq:
- select hdmi helper cdns-hdmi-core driver
- select v4l2_* modules for mxc-mipi-csi2_yav driver
