### PR TITLE
base: layer.conf: exclude os-release siggen dependencie on the initramfs

### DIFF
--- a/meta-lmp-base/conf/layer.conf
+++ b/meta-lmp-base/conf/layer.conf
@@ -35,6 +35,13 @@ BBFILES_DYNAMIC += " \
 # A list of recipes that are completely stable and will never change.
 SIGGEN_EXCLUDERECIPES_ABISAFE += "os-release"
 
+# A list of recipe dependencies that should not be used to determine signatures
+# of tasks from one recipe when they depend on tasks from another recipe.
+SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += " \
+    initramfs-ostree-lmp-image->os-release \
+    core-image-minimal-initramfs->os-release \
+"
+
 # Override for external layers
 ## Adjust priority for tpm-layer (too high by default)
 BBFILE_PRIORITY_tpm-layer:remove = "10"


### PR DESCRIPTION
This pacth fixes the CI rebuilding of the kernel that is currently triggered by:
```
 H_BUILD++ -> os-release -> initramfs -> kernel
```

The os-release is not installed on the initramfs image but because it is a condictional RRECOMMENDS dependencie of the systemd recipe they are used on the signature. The systemd recipe is used on the signature because they provide the udev as systemd-udevd installed on the image.

The os-release dependecie can be checked on the bitbake task-depends.dot file:

```
> bitbake --graphviz [ initramfs-ostree-lmp-image | core-image-minimal-initramfs ] 
> grep os-release task-depends.dot
"systemd.do_package_qa" -> "os-release.do_packagedata" 
"systemd.do_package_write_ipk" -> "os-release.do_packagedata"
```

The steps to reproduce the triggering of the rebuild are the follows:

```
# generate the cache
> echo "H_BUILD = "05"" >> conf/local.conf
> bitbake lmp-base-console-image
# simulate the CI build
> echo "H_BUILD = "06"" >> conf/local.conf
> bitbake os-release; bitbake lmp-base-console-image -S printdiff

Task lmp-base-console-image:do_prepare_recipe_sysroot couldn't be used from the cache because:
  We need hash 92134443e1557b709d56c2bb1d873dee3ac05ae4b5817dfbe31ca55121143df9, closest matching task was 63789c0b6eb01d60f3dcbfe663703282df9561aacf2887da2baa9e9e3bbd464f
  Hash for task dependency os-release/os-release.bb:do_populate_sysroot changed from 426cd31f712ec95a1d4d5efc9af1b095dbde0ce92ffca0ed2ff552f39d7a0736 to e1ba208a383353d5a0e7427851233b969f82bdb00909d06d698a9b2370683aaf
      Hash for task dependency os-release/os-release.bb:do_install changed from e93014fa21a06205ff0a99721d145cb08238ce59f028c37546dd639e393a5d13 to b06b2f124cf193c0531f8302d0ef614a9478cb71d33770f0da21a68e0f196408
          Hash for task dependency os-release/os-release.bb:do_compile changed from 5d2309b3d392067b676a37a31e3a098a0e54618d9edf4f36301fe419785c7b93 to eae61d34d606ebb7ddab4ba986e554cc8b1534da0dc5cd570a9be5dd23aebf91
              basehash changed from 0b189cf74e370a1fa1c3a0baac2bcb1a9dd2a2c5594ceb385596a3bf0c6aa463 to 5278655a87bd455b26714ce4f9aa342f38f5ed8dad92b55f1371efd7f643e7ca
              Variable H_BUILD value changed from '05' to '06'

Task core-image-minimal-initramfs:do_rootfs couldn't be used from the cache because:
  We need hash d28d8939069ce51752ecb1ec0d09de36346489225263c417806648dcc4c28358, closest matching task was 7e540070d624ae3e9a9b62413abb1f5675ba45ed6019b6b3058802c121da4af7
  Hash for task dependency os-release/os-release.bb:do_package_qa changed from 86535fbc24ab06f6f098ef28a1fa74f7c5a8137dff85198230f7fd0583d301ca to e30816f1b7b68bd24978ce765db678977f35f2d7243eb1fb91e29dab39306402
      Hash for task dependency os-release/os-release.bb:do_package changed from d7f80b73c6201370e07a4f704b2ddf25776381a821904194f6fcd04532c5683d to 6f695d7fd59f76c20cfd56db5c8e7804f61f2df8d9da8ad5b6fc53931cda5b1d
          Hash for task dependency os-release/os-release.bb:do_install changed from e93014fa21a06205ff0a99721d145cb08238ce59f028c37546dd639e393a5d13 to b06b2f124cf193c0531f8302d0ef614a9478cb71d33770f0da21a68e0f196408
              Hash for task dependency os-release/os-release.bb:do_compile changed from 5d2309b3d392067b676a37a31e3a098a0e54618d9edf4f36301fe419785c7b93 to eae61d34d606ebb7ddab4ba986e554cc8b1534da0dc5cd570a9be5dd23aebf91
                  basehash changed from 0b189cf74e370a1fa1c3a0baac2bcb1a9dd2a2c5594ceb385596a3bf0c6aa463 to 5278655a87bd455b26714ce4f9aa342f38f5ed8dad92b55f1371efd7f643e7ca
                  Variable H_BUILD value changed from '05' to '06'

Task initramfs-ostree-lmp-image:do_rootfs couldn't be used from the cache because:
  We need hash 94fc9a59daa1ee86dd8fb03033f6df39a159404f7629dcf0105c0d2004edb899, closest matching task was 9de93780312854af16a51692c26fab42af388f86cf17a71b5403b9ba49278c46
  Hash for task dependency os-release/os-release.bb:do_package_qa changed from 86535fbc24ab06f6f098ef28a1fa74f7c5a8137dff85198230f7fd0583d301ca to e30816f1b7b68bd24978ce765db678977f35f2d7243eb1fb91e29dab39306402
      Hash for task dependency os-release/os-release.bb:do_package changed from d7f80b73c6201370e07a4f704b2ddf25776381a821904194f6fcd04532c5683d to 6f695d7fd59f76c20cfd56db5c8e7804f61f2df8d9da8ad5b6fc53931cda5b1d
          Hash for task dependency os-release/os-release.bb:do_install changed from e93014fa21a06205ff0a99721d145cb08238ce59f028c37546dd639e393a5d13 to b06b2f124cf193c0531f8302d0ef614a9478cb71d33770f0da21a68e0f196408
              Hash for task dependency os-release/os-release.bb:do_compile changed from 5d2309b3d392067b676a37a31e3a098a0e54618d9edf4f36301fe419785c7b93 to eae61d34d606ebb7ddab4ba986e554cc8b1534da0dc5cd570a9be5dd23aebf91
                  basehash changed from 0b189cf74e370a1fa1c3a0baac2bcb1a9dd2a2c5594ceb385596a3bf0c6aa463 to 5278655a87bd455b26714ce4f9aa342f38f5ed8dad92b55f1371efd7f643e7ca
                  Variable H_BUILD value changed from '05' to '06'
```

So last command shows that the all the images will be rebuilded.