### PR TITLE
Patch skopeo

### DIFF
--- a/meta-lmp-base/recipes-containers/skopeo/skopeo/0002-dont-store-signatures-if-none-is-present.patch
+++ b/meta-lmp-base/recipes-containers/skopeo/skopeo/0002-dont-store-signatures-if-none-is-present.patch
@@ -1,0 +1,42 @@
+From 35423f29e270bc63b788e6b70c736fbd1467dad1 Mon Sep 17 00:00:00 2001
+From: Mike Sul <mike.sul@foundries.io>
+Date: Thu, 15 Jun 2023 13:43:51 +0200
+Subject: [PATCH] Don't store signatures if none is present
+
+Currently, the copy command prints the message 'Storing signatures' and
+calls the signature storing function, even if there are no signatures
+present. This can mislead users and make them believe that there are
+image signatures.
+
+The proposed change modifies the copy function to print the message and
+invoke the image storing function only if there is at least one signature.
+
+Upstream-Status: Pending
+
+Signed-off-by: Mike <mike.sul@foundries.io>
+---
+ copy/copy.go | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/vendor/github.com/containers/image/v5/copy/copy.go b/vendor/github.com/containers/image/v5/copy/copy.go
+index 26521fe0..560b6c1a 100644
+--- a/vendor/github.com/containers/image/v5/copy/copy.go
++++ b/vendor/github.com/containers/image/v5/copy/copy.go
+@@ -810,9 +810,11 @@ func (c *copier) copyOneImage(ctx context.Context, policyContext *signature.Poli
+ 	}
+ 	sigs = append(sigs, newSigs...)
+ 
+-	c.Printf("Storing signatures\n")
+-	if err := c.dest.PutSignaturesWithFormat(ctx, sigs, targetInstance); err != nil {
+-		return nil, "", "", fmt.Errorf("writing signatures: %w", err)
++	if len(sigs) > 0 {
++		c.Printf("Storing signatures\n")
++		if err := c.dest.PutSignaturesWithFormat(ctx, sigs, targetInstance); err != nil {
++			return nil, "", "", fmt.Errorf("writing signatures: %w", err)
++		}
+ 	}
+ 
+ 	return manifestBytes, retManifestType, retManifestDigest, nil
+-- 
+2.40.1
+

--- a/meta-lmp-base/recipes-containers/skopeo/skopeo/0003-increase-tcp-dialer-timeouts.patch
+++ b/meta-lmp-base/recipes-containers/skopeo/skopeo/0003-increase-tcp-dialer-timeouts.patch
@@ -1,0 +1,41 @@
+From de6a62d5369bad2c32cdf8735b5195c857a8345f Mon Sep 17 00:00:00 2001
+From: Mike Sul <mike.sul@foundries.io>
+Date: Thu, 15 Jun 2023 17:48:41 +0200
+Subject: [PATCH] Increase TCP dialer timeouts
+
+Increase the TCP dialer timeouts that allegedly is supposed to minimize
+occurrence of TCP connection related errors/timeouts, including DNS
+resolution.
+
+Upstream-Status: Inappropriate [lmp specific]
+
+Signed-off-by: Mike <mike.sul@foundries.io>
+---
+ pkg/tlsclientconfig/tlsclientconfig.go | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/vendor/github.com/containers/image/v5/pkg/tlsclientconfig/tlsclientconfig.go b/vendor/github.com/containers/image/v5/pkg/tlsclientconfig/tlsclientconfig.go
+index 285203ba..ccea2c70 100644
+--- a/vendor/github.com/containers/image/v5/pkg/tlsclientconfig/tlsclientconfig.go
++++ b/vendor/github.com/containers/image/v5/pkg/tlsclientconfig/tlsclientconfig.go
+@@ -91,14 +91,14 @@ func hasFile(files []os.DirEntry, name string) bool {
+ // NewTransport Creates a default transport
+ func NewTransport() *http.Transport {
+ 	direct := &net.Dialer{
+-		Timeout:   30 * time.Second,
+-		KeepAlive: 30 * time.Second,
++		Timeout:   60 * time.Second,
++		KeepAlive: 60 * time.Second,
+ 		DualStack: true,
+ 	}
+ 	tr := &http.Transport{
+ 		Proxy:               http.ProxyFromEnvironment,
+ 		DialContext:         direct.DialContext,
+-		TLSHandshakeTimeout: 10 * time.Second,
++		TLSHandshakeTimeout: 30 * time.Second,
+ 		// TODO(dmcgowan): Call close idle connections when complete and use keep alive
+ 		DisableKeepAlives: true,
+ 	}
+-- 
+2.40.1
+

--- a/meta-lmp-base/recipes-containers/skopeo/skopeo_git.bbappend
+++ b/meta-lmp-base/recipes-containers/skopeo/skopeo_git.bbappend
@@ -3,4 +3,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI += " \
     file://docker-config-support-default-system-config.patch;patchdir=src/import \
     file://0001-cmd-copy-max-parallel-pulls-param.patch;patchdir=src/import \
+    file://0002-dont-store-signatures-if-none-is-present.patch;patchdir=src/import \
 "

--- a/meta-lmp-base/recipes-containers/skopeo/skopeo_git.bbappend
+++ b/meta-lmp-base/recipes-containers/skopeo/skopeo_git.bbappend
@@ -4,4 +4,5 @@ SRC_URI += " \
     file://docker-config-support-default-system-config.patch;patchdir=src/import \
     file://0001-cmd-copy-max-parallel-pulls-param.patch;patchdir=src/import \
     file://0002-dont-store-signatures-if-none-is-present.patch;patchdir=src/import \
+    file://0003-increase-tcp-dialer-timeouts.patch;patchdir=src/import \
 "


### PR DESCRIPTION
- Don't print "Storing signatures" and try to store signatures if they are missing.
- Increase the TCP dialer timeouts for connections to Registries.