### PR TITLE
base: u-boot: remove unused recipes

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-mfgtool_2021.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-mfgtool_2021.04.bb
@@ -1,8 +1,0 @@
-SUMMARY = "Produces a Manufacturing Tool compatible U-Boot"
-DESCRIPTION = "U-Boot recipe that produces a Manufacturing Tool compatible \
-binary to be used in updater environment"
-
-require recipes-bsp/u-boot/u-boot-fio_2021.04.bb
-
-# Environment config is not required for mfgtool
-SRC_URI:remove = "file://fw_env.config"

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2021.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2021.04.bb
@@ -1,5 +1,0 @@
-require u-boot-fio-common.inc
-
-SRCREV = "d5976b6253dcae875fb42fbef68e1d05e7de5141"
-SRCBRANCH = "2021.04+imx_5.10.35-2.0.0-fio"
-LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2021.07.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_2021.07.bb
@@ -1,5 +1,0 @@
-require u-boot-fio-common.inc
-
-SRCREV = "068e9ff69182799b1933883d08e25f3f96c9e807"
-SRCBRANCH = "2021.07+fio"
-LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"


### PR DESCRIPTION
U-boot 2021.04 and 2021.07 are not used in LmP anymore. Remove obsolete recipes.