### PR TITLE
bsp: u-boot-fio/scr-fit: stm32mp15: define used addr vars

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/stm32mp15-disco/lmp.cfg
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/stm32mp15-disco/lmp.cfg
@@ -1,4 +1,4 @@
-CONFIG_BOOTCOMMAND="setenv verify 1; source ${scriptaddr}; reset"
+CONFIG_BOOTCOMMAND="setenv verify 1; source 0xc4100000; reset"
 CONFIG_DEFAULT_DEVICE_TREE="stm32mp157c-dk2"
 CONFIG_ENV_SIZE=0x4000
 CONFIG_ENV_OFFSET=0x800000

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/stm32mp15-eval-sec/lmp.cfg
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/stm32mp15-eval-sec/lmp.cfg
@@ -1,4 +1,4 @@
-CONFIG_BOOTCOMMAND="setenv verify 1; source ${scriptaddr}; reset;"
+CONFIG_BOOTCOMMAND="setenv verify 1; source 0xc4100000; reset;"
 CONFIG_DEFAULT_DEVICE_TREE="stm32mp157c-ev1"
 CONFIG_TEE=y
 CONFIG_OPTEE=y

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/stm32mp15-eval/lmp.cfg
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/stm32mp15-eval/lmp.cfg
@@ -1,4 +1,4 @@
-CONFIG_BOOTCOMMAND="if test ${boot_device} = serial || test ${boot_device} = usb; then stm32prog ${boot_device} ${boot_instance}; else; setenv verify 1; source ${scriptaddr}; reset; fi;"
+CONFIG_BOOTCOMMAND="if test ${boot_device} = serial || test ${boot_device} = usb; then stm32prog ${boot_device} ${boot_instance}; else; setenv verify 1; source 0xc4100000; reset; fi;"
 CONFIG_DEFAULT_DEVICE_TREE="stm32mp157c-ev1"
 CONFIG_ENV_SIZE=0x4000
 CONFIG_ENV_OFFSET=0x80000

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/stm32mp15-disco/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/stm32mp15-disco/boot.cmd
@@ -7,12 +7,12 @@ setenv bootlimit 3
 setenv devtype ${boot_device}
 setenv devnum ${boot_instance}
 setenv rootpart 6
-setenv fit_addr ${ramdisk_addr_r}
+setenv fit_addr 0xc4400000
 setenv fdt_file_final ${fdtfile}
-setenv fdt_addr ${fdt_addr_r}
+setenv fdt_addr 0xc4000000
 setenv optee_ovl_addr 0xc4300000
 
-setenv loadaddr ${ramdisk_addr_r}
+setenv loadaddr 0xc4400000
 setenv do_reboot "reset"
 setenv check_board_closed 'if test "${boot_auth}" = "2"; then setenv board_is_closed 1; else setenv board_is_closed; fi;'
 setenv check_secondary_boot 'if test "${boot_part}" = "2"; then setenv fiovb.is_secondary_boot 1; else setenv fiovb.is_secondary_boot 0; fi;'

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/stm32mp15-eval/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/stm32mp15-eval/boot.cmd
@@ -7,12 +7,12 @@ setenv bootlimit 3
 setenv devtype ${boot_device}
 setenv devnum ${boot_instance}
 setenv rootpart 2
-setenv fit_addr ${ramdisk_addr_r}
+setenv fit_addr 0xc4400000
 setenv fdt_file_final ${fdtfile}
-setenv fdt_addr ${fdt_addr_r}
+setenv fdt_addr 0xc4000000
 setenv optee_ovl_addr 0xc4300000
 
-setenv loadaddr ${ramdisk_addr_r}
+setenv loadaddr 0xc4400000
 setenv do_reboot "reset"
 setenv check_board_closed 'if test "${boot_auth}" = "2"; then setenv board_is_closed 1; else setenv board_is_closed; fi;'
 setenv check_secondary_boot 'if test "${boot_part}" = "2"; then setenv fiovb.is_secondary_boot 1; else setenv fiovb.is_secondary_boot 0; fi;'


### PR DESCRIPTION
The required addr variables are all depending on CONFIG_DISTRO_DEFAULTS, which got disabled as a consequence of the lmp-common work, causing the boot to fail.

Manually define the required addr variables in order for lmp to be fully functional with and without CONFIG_DISTRO_DEFAULTS.