### PR TITLE
base: import ntp 4.2.8p17 from meta-oe master d2a38a5ec5

### DIFF
--- a/meta-lmp-base/recipes-support/ntp/ntp/0001-libntp-Do-not-use-PTHREAD_STACK_MIN-on-glibc.patch
+++ b/meta-lmp-base/recipes-support/ntp/ntp/0001-libntp-Do-not-use-PTHREAD_STACK_MIN-on-glibc.patch
@@ -1,0 +1,33 @@
+From 082a504cfcc046c3d8adaae1164268bc94e5108a Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 31 Jul 2021 10:51:41 -0700
+Subject: [PATCH] libntp: Do not use PTHREAD_STACK_MIN on glibc
+
+In glibc 2.34+ PTHREAD_STACK_MIN is not a compile-time constant which
+could mean different stack sizes at runtime on different architectures
+and it also causes compile failure. Default glibc thread stack size
+or 64Kb set by ntp should be good in glibc these days.
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Wang Mingyu <wangmy@fujitsu.com>
+---
+ libntp/work_thread.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libntp/work_thread.c b/libntp/work_thread.c
+index c1fe5c2..21db4a0 100644
+--- a/libntp/work_thread.c
++++ b/libntp/work_thread.c
+@@ -598,7 +598,7 @@ start_blocking_thread_internal(
+ 		/* now clamp on lower stack limit. */
+ 		if (nstacksize < THREAD_MINSTACKSIZE)
+ 			nstacksize = THREAD_MINSTACKSIZE;
+-#            ifdef PTHREAD_STACK_MIN
++#            ifdef PTHREAD_STACK_MIN && !defined(__GLIBC__)
+ 		if (nstacksize < PTHREAD_STACK_MIN)
+ 			nstacksize = PTHREAD_STACK_MIN;
+ #            endif
+-- 
+2.34.1
+

--- a/meta-lmp-base/recipes-support/ntp/ntp/0001-sntp-Fix-types-in-check-for-pthread_detach.patch
+++ b/meta-lmp-base/recipes-support/ntp/ntp/0001-sntp-Fix-types-in-check-for-pthread_detach.patch
@@ -1,0 +1,33 @@
+From 864f43ae09d18b1114d5c894e836698743e4e44c Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 6 Sep 2022 21:36:35 -0700
+Subject: [PATCH] sntp: Fix types in check for pthread_detach
+
+New compilers are stricter and flag assigning NULL to pthread_t as error
+therefore using a pthread_t variable constructed from -1
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ sntp/m4/openldap-thread-check.m4 | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/sntp/m4/openldap-thread-check.m4 b/sntp/m4/openldap-thread-check.m4
+index 7768a5c..b9e54ad 100644
+--- a/sntp/m4/openldap-thread-check.m4
++++ b/sntp/m4/openldap-thread-check.m4
+@@ -262,10 +262,7 @@ pthread_rwlock_t rwlock;
+ 				dnl save the flags
+ 				AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+ #include <pthread.h>
+-#ifndef NULL
+-#define NULL (void*)0
+-#endif
+-]], [[pthread_detach(NULL);]])],[ol_cv_func_pthread_detach=yes],[ol_cv_func_pthread_detach=no])
++]], [[pthread_detach((pthread_t)-1);]])],[ol_cv_func_pthread_detach=yes],[ol_cv_func_pthread_detach=no])
+ 			])
+ 
+ 			if test $ol_cv_func_pthread_detach = no ; then
+-- 
+2.37.3
+

--- a/meta-lmp-base/recipes-support/ntp/ntp/0001-test-Fix-build-with-new-compiler-defaults-to-fno-com.patch
+++ b/meta-lmp-base/recipes-support/ntp/ntp/0001-test-Fix-build-with-new-compiler-defaults-to-fno-com.patch
@@ -1,0 +1,56 @@
+From 778f3cddc20930185a917fa3f8ffe1ef2b0b0ea0 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 31 Jul 2021 13:27:16 -0700
+Subject: [PATCH] test: Fix build with new compiler defaults to -fno-common
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Wang Mingyu <wangmy@fujitsu.com>
+---
+ sntp/tests/run-packetHandling.c | 2 +-
+ sntp/tests/run-t-log.c          | 2 +-
+ sntp/tests/run-utilities.c      | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/sntp/tests/run-packetHandling.c b/sntp/tests/run-packetHandling.c
+index 7790b20..c58380c 100644
+--- a/sntp/tests/run-packetHandling.c
++++ b/sntp/tests/run-packetHandling.c
+@@ -64,7 +64,7 @@ void resetTest(void)
+   setUp();
+ }
+ 
+-char const *progname;
++extern char const *progname;
+ 
+ 
+ //=======MAIN=====
+diff --git a/sntp/tests/run-t-log.c b/sntp/tests/run-t-log.c
+index 268bf41..cd835bc 100644
+--- a/sntp/tests/run-t-log.c
++++ b/sntp/tests/run-t-log.c
+@@ -50,7 +50,7 @@ void resetTest(void)
+   setUp();
+ }
+ 
+-char const *progname;
++extern char const *progname;
+ 
+ 
+ //=======MAIN=====
+diff --git a/sntp/tests/run-utilities.c b/sntp/tests/run-utilities.c
+index f717882..98d9bf1 100644
+--- a/sntp/tests/run-utilities.c
++++ b/sntp/tests/run-utilities.c
+@@ -58,7 +58,7 @@ void resetTest(void)
+   setUp();
+ }
+ 
+-char const *progname;
++extern char const *progname;
+ 
+ 
+ //=======MAIN=====
+-- 
+2.34.1
+

--- a/meta-lmp-base/recipes-support/ntp/ntp/ntp-4.2.4_p6-nano.patch
+++ b/meta-lmp-base/recipes-support/ntp/ntp/ntp-4.2.4_p6-nano.patch
@@ -1,0 +1,27 @@
+From 2310898533f059d875dcffd26ab6cf1b280292fd Mon Sep 17 00:00:00 2001
+From: Koen Kooi <koen@dominion.thruhere.net>
+Date: Wed, 12 Jan 2011 21:38:46 +0100
+
+---
+ include/ntp_syscall.h | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/include/ntp_syscall.h b/include/ntp_syscall.h
+index d1ce03e..9e18432 100644
+--- a/include/ntp_syscall.h
++++ b/include/ntp_syscall.h
+@@ -10,6 +10,14 @@
+ # include <sys/timex.h>
+ #endif
+ 
++#if defined(ADJ_NANO) && !defined(MOD_NANO)
++#define MOD_NANO ADJ_NANO
++#endif
++
++#if defined(ADJ_TAI) && !defined(MOD_TAI)
++#define MOD_TAI ADJ_TAI
++#endif
++
+ #ifndef NTP_SYSCALLS_LIBC
+ # ifdef NTP_SYSCALLS_STD
+ #  define ntp_adjtime(t)	syscall(SYS_ntp_adjtime, (t))

--- a/meta-lmp-base/recipes-support/ntp/ntp/ntp.conf
+++ b/meta-lmp-base/recipes-support/ntp/ntp/ntp.conf
@@ -1,0 +1,21 @@
+# This is the most basic ntp configuration file
+# The driftfile must remain in a place specific to this
+# machine - it records the machine specific clock error
+driftfile /var/lib/ntp/drift
+# This should be a server that is close (in IP terms)
+# to the machine.  Add other servers as required.
+# Unless you un-comment the line below ntpd will sync
+# only against the local system clock.
+#
+# server time.server.example.com
+#
+# Using local hardware clock as fallback
+# Disable this when using ntpd -q -g -x as ntpdate or it will sync to itself
+server 127.127.1.0
+fudge 127.127.1.0 stratum 14
+# Defining a default security setting
+restrict -4 default notrap nomodify nopeer noquery
+restrict -6 default notrap nomodify nopeer noquery
+
+restrict 127.0.0.1    # allow local host
+restrict ::1          # allow local host

--- a/meta-lmp-base/recipes-support/ntp/ntp/ntpd
+++ b/meta-lmp-base/recipes-support/ntp/ntp/ntpd
@@ -1,0 +1,84 @@
+#! /bin/sh
+
+### BEGIN INIT INFO
+# Provides:        ntp
+# Required-Start:  $network $remote_fs $syslog
+# Required-Stop:   $network $remote_fs $syslog
+# Default-Start:   2 3 4 5
+# Default-Stop:
+# Short-Description: Start NTP daemon
+### END INIT INFO
+
+PATH=/sbin:/bin:/usr/bin:/usr/sbin
+
+DAEMON=/usr/sbin/ntpd
+PIDFILE=/var/run/ntpd.pid
+
+# ntpd	init.d script for ntpdc from ntp.isc.org
+test -x $DAEMON -a -r /etc/ntp.conf || exit 0
+
+# rcS contains TICKADJ
+test -r /etc/default/rcS && . /etc/default/rcS
+
+# Source function library.
+. /etc/init.d/functions
+
+# Functions to do individual actions
+settick(){
+  	# If TICKADJ is set we *must* adjust it before we start, because the
+	# driftfile relies on the correct setting
+	test -n "$TICKADJ" -a -x /usr/sbin/tickadj && {
+		echo -n "Setting tick to $TICKADJ: "
+		/usr/sbin/tickadj "$TICKADJ"
+		echo "done"
+	}
+}
+startdaemon(){
+	# The -g option allows ntpd to step the time to correct it just
+	# once.  The daemon will exit if the clock drifts too much after
+	# this.  If ntpd seems to disappear after a while assume TICKADJ
+	# above is set to a totally incorrect value.
+	echo -n "Starting ntpd: "
+	start-stop-daemon --start --quiet --oknodo --pidfile $PIDFILE --startas $DAEMON -- -u ntp:ntp -p $PIDFILE "$@"
+	echo "done"
+}
+stopdaemon(){
+	echo -n "Stopping ntpd: "
+	start-stop-daemon --stop --quiet --oknodo -p $PIDFILE
+	echo "done"
+}
+
+case "$1" in
+  start)
+  	settick
+	startdaemon -g
+	;;
+  stop)
+  	stopdaemon
+	;;
+  force-reload)
+  	stopdaemon
+  	settick
+	startdaemon -g
+	;;
+  restart)
+  	# Don't reset the tick here
+	stopdaemon
+	startdaemon -g
+	;;
+  reload)
+  	# Must do this by hand, but don't do -g
+	stopdaemon
+	startdaemon
+	;;
+  status)
+	status /usr/sbin/ntpd;
+	exit $?
+	;;
+  *)
+	echo "Usage: ntpd { start | stop | status | restart | reload }" >&2
+	exit 1
+	;;
+esac
+
+exit 0

--- a/meta-lmp-base/recipes-support/ntp/ntp/ntpd.list
+++ b/meta-lmp-base/recipes-support/ntp/ntp/ntpd.list
@@ -1,0 +1,1 @@
+ntpd.service

--- a/meta-lmp-base/recipes-support/ntp/ntp/ntpd.service
+++ b/meta-lmp-base/recipes-support/ntp/ntp/ntpd.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Network Time Service
+After=network.target
+
+[Service]
+Type=forking
+PIDFile=/run/ntpd.pid
+ExecStart=/usr/sbin/ntpd -u ntp:ntp -p /run/ntpd.pid -g
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-lmp-base/recipes-support/ntp/ntp/reproducibility-fixed-path-to-posix-shell.patch
+++ b/meta-lmp-base/recipes-support/ntp/ntp/reproducibility-fixed-path-to-posix-shell.patch
@@ -1,0 +1,26 @@
+reproducibility fixed path to posixshell
+---
+ sntp/libopts/m4/libopts.m4 | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/sntp/libopts/m4/libopts.m4 b/sntp/libopts/m4/libopts.m4
+index 23738ca..4e18187 100644
+--- a/sntp/libopts/m4/libopts.m4
++++ b/sntp/libopts/m4/libopts.m4
+@@ -107,13 +107,6 @@ AC_DEFUN([INVOKE_LIBOPTS_MACROS_FIRST],[
+   AC_PROG_SED
+   [while :
+   do
+-      test -x "$POSIX_SHELL" && break
+-      POSIX_SHELL=`which bash`
+-      test -x "$POSIX_SHELL" && break
+-      POSIX_SHELL=`which dash`
+-      test -x "$POSIX_SHELL" && break
+-      POSIX_SHELL=/usr/xpg4/bin/sh
+-      test -x "$POSIX_SHELL" && break
+       POSIX_SHELL=`/bin/sh -c '
+           exec 2>/dev/null
+           if ! true ; then exit 1 ; fi
+-- 
+2.34.1
+

--- a/meta-lmp-base/recipes-support/ntp/ntp/sntp
+++ b/meta-lmp-base/recipes-support/ntp/ntp/sntp
@@ -1,0 +1,1 @@
+NTPSERVER="ntpserver.example.org"

--- a/meta-lmp-base/recipes-support/ntp/ntp/sntp.service
+++ b/meta-lmp-base/recipes-support/ntp/ntp/sntp.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Simple Network Time Service Client
+After=network.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/default/sntp
+ExecStart=/usr/sbin/sntp -s $NTPSERVER
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-lmp-base/recipes-support/ntp/ntp_4.2.8p17.bb
+++ b/meta-lmp-base/recipes-support/ntp/ntp_4.2.8p17.bb
@@ -1,0 +1,179 @@
+SUMMARY = "Network Time Protocol daemon and utilities"
+DESCRIPTION = "The Network Time Protocol (NTP) is used to \
+synchronize the time of a computer client or server to \
+another server or reference time source, such as a radio \
+or satellite receiver or modem."
+HOMEPAGE = "http://support.ntp.org"
+SECTION = "net"
+LICENSE = "NTP"
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=3a8ffebbcad335abf2c39fec38671eec"
+
+DEPENDS = "libevent"
+
+SRC_URI = "http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/ntp-${PV}.tar.gz \
+           file://ntp-4.2.4_p6-nano.patch \
+           file://reproducibility-fixed-path-to-posix-shell.patch \
+           file://0001-libntp-Do-not-use-PTHREAD_STACK_MIN-on-glibc.patch \
+           file://0001-test-Fix-build-with-new-compiler-defaults-to-fno-com.patch \
+           file://0001-sntp-Fix-types-in-check-for-pthread_detach.patch \
+           file://ntpd \
+           file://ntp.conf \
+           file://ntpd.service \
+           file://sntp.service \
+           file://sntp \
+           file://ntpd.list \
+"
+
+SRC_URI[sha256sum] = "103dd272e6a66c5b8df07dce5e9a02555fcd6f1397bdfb782237328e89d3a866"
+
+# CVE-2016-9312 is only for windows.
+# CVE-2019-11331 is inherent to RFC 5905 and cannot be fixed without breaking compatibility
+# The other CVEs are not correctly identified because cve-check
+# is not able to check the version correctly (it only checks for 4.2.8 omitting p15 that makes the difference)
+CVE_CHECK_IGNORE += "\
+    CVE-2016-9312 \
+    CVE-2015-5146 \
+    CVE-2015-5300 \
+    CVE-2015-7975 \
+    CVE-2015-7976 \
+    CVE-2015-7977 \
+    CVE-2015-7978 \
+    CVE-2015-7979 \
+    CVE-2015-8138 \
+    CVE-2015-8139 \
+    CVE-2015-8140 \
+    CVE-2015-8158 \
+    CVE-2016-1547 \
+    CVE-2016-2516 \
+    CVE-2016-2517 \
+    CVE-2016-2519 \
+    CVE-2016-7429 \
+    CVE-2016-7433 \
+    CVE-2016-9310 \
+    CVE-2016-9311 \
+    CVE-2019-11331 \
+"
+
+
+inherit autotools update-rc.d useradd systemd pkgconfig
+
+# The ac_cv_header_readline_history is to stop ntpdc depending on either
+# readline or curses
+EXTRA_OECONF += "--with-net-snmp-config=no \
+                 --without-ntpsnmpd \
+                 ac_cv_header_readline_history_h=no \
+                 --with-yielding_select=yes \
+                 --with-locfile=redhat \
+                 --without-rpath \
+                 "
+CFLAGS:append = " -DPTYS_ARE_GETPT -DPTYS_ARE_SEARCHED"
+
+USERADD_PACKAGES = "${PN}"
+NTP_USER_HOME ?= "/var/lib/ntp"
+USERADD_PARAM:${PN} = "--system --home-dir ${NTP_USER_HOME} \
+                       --no-create-home \
+                       --shell /bin/false --user-group ntp"
+
+# NB: debug is default-enabled by NTP; keep it default-enabled here.
+PACKAGECONFIG ??= "cap debug refclocks openssl \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'ipv6', d)} \
+"
+PACKAGECONFIG[openssl] = "--with-openssl-libdir=${STAGING_LIBDIR} \
+                          --with-openssl-incdir=${STAGING_INCDIR} \
+                          --with-crypto, \
+                          --without-openssl --without-crypto, \
+                          openssl"
+PACKAGECONFIG[cap] = "--enable-linuxcaps,--disable-linuxcaps,libcap"
+PACKAGECONFIG[readline] = "--with-lineeditlibs,--without-lineeditlibs,readline"
+PACKAGECONFIG[refclocks] = "--enable-all-clocks,--disable-all-clocks,pps-tools"
+PACKAGECONFIG[debug] = "--enable-debugging,--disable-debugging"
+PACKAGECONFIG[mdns] = "ac_cv_header_dns_sd_h=yes,ac_cv_header_dns_sd_h=no,mdns"
+PACKAGECONFIG[ipv6] = "--enable-ipv6,--disable-ipv6,"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/init.d
+    install -m 644 ${WORKDIR}/ntp.conf ${D}${sysconfdir}
+    install -m 755 ${WORKDIR}/ntpd ${D}${sysconfdir}/init.d
+
+    install -m 755 -d ${D}${NTP_USER_HOME}
+    chown ntp:ntp ${D}${NTP_USER_HOME}
+
+    # Fix hardcoded paths in scripts
+    sed -i 's!/usr/sbin/!${sbindir}/!g' ${D}${sysconfdir}/init.d/ntpd
+    sed -i 's!/usr/bin/!${bindir}/!g' ${D}${sysconfdir}/init.d/ntpd
+    sed -i 's!/etc/!${sysconfdir}/!g' ${D}${sysconfdir}/init.d/ntpd
+    sed -i 's!/var/!${localstatedir}/!g' ${D}${sysconfdir}/init.d/ntpd
+    sed -i '1s,#!.*perl -w,#! ${bindir}/env perl,' ${D}${sbindir}/ntptrace
+    sed -i '/use/i use warnings;' ${D}${sbindir}/ntptrace
+    sed -i '1s,#!.*perl,#! ${bindir}/env perl,' ${D}${sbindir}/ntp-wait
+    sed -i '/use/i use warnings;' ${D}${sbindir}/ntp-wait
+    sed -i '1s,#!.*perl -w,#! ${bindir}/env perl,' ${D}${sbindir}/calc_tickadj
+    sed -i '/use/i use warnings;' ${D}${sbindir}/calc_tickadj
+
+    install -d ${D}/${sysconfdir}/default
+    install -m 0644 ${WORKDIR}/sntp ${D}${sysconfdir}/default/
+
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/ntpd.service ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/sntp.service ${D}${systemd_unitdir}/system/
+
+    install -d ${D}${systemd_unitdir}/ntp-units.d
+    install -m 0644 ${WORKDIR}/ntpd.list ${D}${systemd_unitdir}/ntp-units.d/60-ntpd.list
+
+    # Remove the empty libexecdir and bindir.
+    rmdir --ignore-fail-on-non-empty ${D}${libexecdir}
+    rmdir --ignore-fail-on-non-empty ${D}${bindir}
+}
+
+PACKAGES += "sntp ntpdc ntpq ${PN}-tickadj ${PN}-utils"
+
+# ntp originally includes tickadj. It's split off for inclusion in small firmware images on platforms
+# with wonky clocks (e.g. OpenSlug)
+RDEPENDS:${PN} = "${PN}-tickadj"
+# ntpd & sntp require libgcc for execution due to phtread_cancel/pthread_exit calls
+RDEPENDS:${PN} += "libgcc"
+RDEPENDS:sntp += "libgcc"
+# Handle move from bin to utils package
+RPROVIDES:${PN}-utils = "${PN}-bin"
+RREPLACES:${PN}-utils = "${PN}-bin"
+RCONFLICTS:${PN}-utils = "${PN}-bin"
+# ntpdc and ntpq were split out of ntp-utils
+RDEPENDS:${PN}-utils = "ntpdc ntpq"
+
+SYSTEMD_PACKAGES = "${PN} sntp"
+SYSTEMD_SERVICE:${PN} = "ntpd.service"
+SYSTEMD_SERVICE:sntp = "sntp.service"
+SYSTEMD_AUTO_ENABLE:sntp = "disable"
+
+RPROVIDES:${PN} += "${PN}-systemd"
+RREPLACES:${PN} += "${PN}-systemd"
+RCONFLICTS:${PN} += "${PN}-systemd"
+
+RSUGGESTS:${PN} = "iana-etc"
+
+FILES:${PN} = "${sbindir}/ntpd.ntp ${sysconfdir}/ntp.conf ${sysconfdir}/init.d/ntpd \
+    ${NTP_USER_HOME} \
+    ${systemd_unitdir}/ntp-units.d/60-ntpd.list \
+"
+FILES:${PN}-tickadj = "${sbindir}/tickadj"
+FILES:${PN}-utils = "${sbindir} ${datadir}/ntp/lib"
+RDEPENDS:${PN}-utils += "perl"
+FILES:sntp = "${sbindir}/sntp \
+              ${sysconfdir}/default/sntp \
+              ${systemd_unitdir}/system/sntp.service \
+             "
+FILES:ntpdc = "${sbindir}/ntpdc"
+FILES:ntpq = "${sbindir}/ntpq"
+
+CONFFILES:${PN} = "${sysconfdir}/ntp.conf"
+
+INITSCRIPT_NAME = "ntpd"
+# No dependencies, so just go in at the standard level (20)
+INITSCRIPT_PARAMS = "defaults"
+
+inherit update-alternatives
+
+ALTERNATIVE_PRIORITY = "100"
+
+ALTERNATIVE:${PN} = "ntpd"
+ALTERNATIVE_LINK_NAME[ntpd] = "${sbindir}/ntpd"


### PR DESCRIPTION
The ntp version available in meta-oe kirkstone has several CVEs and important bugs, but we cannot easily backport in meta-oe since the newer version also brings general improvements (not suitable for LTS).

Since the general improvements done as part of the release 4.2.8p16 are not of a concern for LmP, backport latest version from meta-oe master in order to fix the several CVEs associated with the older revisions.

CVEs fixed:
- CVE-2023-26551
- CVE-2023-26552
- CVE-2023-26553
- CVE-2023-26554
- CVE-2023-26555