### PR TITLE
ncurses: fix CVE-2023-29491

### DIFF
--- a/meta-lmp-base/recipes-core/ncurses/files/0001-tic-hang.patch
+++ b/meta-lmp-base/recipes-core/ncurses/files/0001-tic-hang.patch
@@ -1,0 +1,43 @@
+From 168ba7a681be73ac024438e33e14fde1d5aea97d Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Fri, 30 Mar 2018 10:02:24 +0800
+Subject: [PATCH 1/2] tic hang
+
+Upstream-Status: Inappropriate [configuration]
+
+'tic' of some linux distributions (e.g. fedora 11) hang in an infinite
+loop when processing the original file.
+
+Signed-off-by: anonymous
+
+Rebase to 6.1
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ misc/terminfo.src | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/misc/terminfo.src b/misc/terminfo.src
+index 84f4810..6b385ec 100644
+--- a/misc/terminfo.src
++++ b/misc/terminfo.src
+@@ -5562,12 +5562,11 @@ konsole-xf3x|KDE console window with keyboard for XFree86 3.x xterm,
+ # The value for kbs (see konsole-vt100) reflects local customization rather
+ # than the settings used for XFree86 xterm.
+ konsole-xf4x|KDE console window with keyboard for XFree86 4.x xterm,
+-	kend=\EOF, khome=\EOH, use=konsole+pcfkeys,
+-	use=konsole-vt100,
+-
+-konsole+pcfkeys|konsole subset of xterm+pcfkeys,
+-	kcbt=\E[Z, use=xterm+pcc2, use=xterm+pcf0,
+-	use=xterm+pce2,
++	kend=\EOF, kf1=\EOP, kf13=\EO2P, kf14=\EO2Q, kf15=\EO2R,
++	kf16=\EO2S, kf17=\E[15;2~, kf18=\E[17;2~, kf19=\E[18;2~,
++	kf2=\EOQ, kf20=\E[19;2~, kf21=\E[20;2~, kf22=\E[21;2~,
++	kf23=\E[23;2~, kf24=\E[24;2~, kf3=\EOR, kf4=\EOS,
++	khome=\EOH, use=konsole-vt100,
+ 
+ # Obsolete: vt100.keymap
+ # KDE's "vt100" keyboard has no relationship to any terminal that DEC made, but
+-- 
+1.8.3.1
+

--- a/meta-lmp-base/recipes-core/ncurses/files/0001-tic-hang.patch
+++ b/meta-lmp-base/recipes-core/ncurses/files/0001-tic-hang.patch
@@ -1,7 +1,7 @@
-From 168ba7a681be73ac024438e33e14fde1d5aea97d Mon Sep 17 00:00:00 2001
+From 1d6efe2e27c5cb89d9f20c4fc4abdd72ce320076 Mon Sep 17 00:00:00 2001
 From: Hongxu Jia <hongxu.jia@windriver.com>
 Date: Fri, 30 Mar 2018 10:02:24 +0800
-Subject: [PATCH 1/2] tic hang
+Subject: [PATCH] tic hang
 
 Upstream-Status: Inappropriate [configuration]
 
@@ -12,15 +12,16 @@ Signed-off-by: anonymous
 
 Rebase to 6.1
 Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
 ---
  misc/terminfo.src | 11 +++++------
  1 file changed, 5 insertions(+), 6 deletions(-)
 
 diff --git a/misc/terminfo.src b/misc/terminfo.src
-index 84f4810..6b385ec 100644
+index c11f98f5..4689b62d 100644
 --- a/misc/terminfo.src
 +++ b/misc/terminfo.src
-@@ -5562,12 +5562,11 @@ konsole-xf3x|KDE console window with keyboard for XFree86 3.x xterm,
+@@ -6547,12 +6547,11 @@ konsole-xf3x|KDE console window with keyboard for XFree86 3.x xterm,
  # The value for kbs (see konsole-vt100) reflects local customization rather
  # than the settings used for XFree86 xterm.
  konsole-xf4x|KDE console window with keyboard for XFree86 4.x xterm,
@@ -38,6 +39,3 @@ index 84f4810..6b385ec 100644
  
  # Obsolete: vt100.keymap
  # KDE's "vt100" keyboard has no relationship to any terminal that DEC made, but
--- 
-1.8.3.1
-

--- a/meta-lmp-base/recipes-core/ncurses/files/0002-configure-reproducible.patch
+++ b/meta-lmp-base/recipes-core/ncurses/files/0002-configure-reproducible.patch
@@ -1,0 +1,33 @@
+From ec87e53066a9942e9aaba817d71268342f5e83b9 Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Wed, 16 Aug 2017 14:45:27 +0800
+Subject: [PATCH] configure: reproducible
+
+"configure" enforces -U for ar flags, breaking deterministic builds.
+The flag was added to fix some vaguely specified "recent POSIX binutil
+build problems" in 2015.
+
+Upstream-Status: Pending
+Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>
+
+Rebase to 6.1
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 421cf859..a1b7840d 100755
+--- a/configure
++++ b/configure
+@@ -5072,7 +5072,7 @@ else
+ 		;;
+ 	(*)
+ 		cf_cv_ar_flags=unknown
+-		for cf_ar_flags in -curvU -curv curv -crv crv -cqv cqv -rv rv
++		for cf_ar_flags in -curv curv -crv crv -cqv cqv -rv rv
+ 		do
+ 
+ 			# check if $ARFLAGS already contains this choice

--- a/meta-lmp-base/recipes-core/ncurses/files/0002-configure-reproducible.patch
+++ b/meta-lmp-base/recipes-core/ncurses/files/0002-configure-reproducible.patch
@@ -1,4 +1,4 @@
-From ec87e53066a9942e9aaba817d71268342f5e83b9 Mon Sep 17 00:00:00 2001
+From ae061d11ccf61a5da2a9a4ce3d0befd95aac25a8 Mon Sep 17 00:00:00 2001
 From: Hongxu Jia <hongxu.jia@windriver.com>
 Date: Wed, 16 Aug 2017 14:45:27 +0800
 Subject: [PATCH] configure: reproducible
@@ -19,10 +19,10 @@ Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/configure b/configure
-index 421cf859..a1b7840d 100755
+index 3b9179f8..c2462f7f 100755
 --- a/configure
 +++ b/configure
-@@ -5072,7 +5072,7 @@ else
+@@ -5125,7 +5125,7 @@ else
  		;;
  	(*)
  		cf_cv_ar_flags=unknown

--- a/meta-lmp-base/recipes-core/ncurses/files/0003-gen-pkgconfig.in-Do-not-include-LDFLAGS-in-generated.patch
+++ b/meta-lmp-base/recipes-core/ncurses/files/0003-gen-pkgconfig.in-Do-not-include-LDFLAGS-in-generated.patch
@@ -1,0 +1,30 @@
+From 10cd0c12a6e14fb4f0498c299c1dd32720b710da Mon Sep 17 00:00:00 2001
+From: Nathan Rossi <nathan@nathanrossi.com>
+Date: Mon, 14 Dec 2020 13:39:02 +1000
+Subject: [PATCH] gen-pkgconfig.in: Do not include LDFLAGS in generated pc
+ files
+
+Including the LDFLAGS in the pkgconfig output is problematic as OE
+includes build host specific paths and options (e.g. uninative and
+'-Wl,--dynamic-linker=').
+
+Upstream-Status: Inappropriate [OE Specific]
+Signed-off-by: Nathan Rossi <nathan@nathanrossi.com>
+
+---
+ misc/gen-pkgconfig.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/misc/gen-pkgconfig.in b/misc/gen-pkgconfig.in
+index a45dd54f..85273054 100644
+--- a/misc/gen-pkgconfig.in
++++ b/misc/gen-pkgconfig.in
+@@ -83,7 +83,7 @@ if [ "$includedir" != "/usr/include" ]; then
+ fi
+ 
+ lib_flags=
+-for opt in -L$libdir @EXTRA_PKG_LDFLAGS@ @LIBS@
++for opt in -L$libdir @LIBS@
+ do
+ 	case $opt in
+ 	-l*) # LIBS is handled specially below

--- a/meta-lmp-base/recipes-core/ncurses/files/0003-gen-pkgconfig.in-Do-not-include-LDFLAGS-in-generated.patch
+++ b/meta-lmp-base/recipes-core/ncurses/files/0003-gen-pkgconfig.in-Do-not-include-LDFLAGS-in-generated.patch
@@ -1,4 +1,4 @@
-From 10cd0c12a6e14fb4f0498c299c1dd32720b710da Mon Sep 17 00:00:00 2001
+From 4cb6a8a35cdc04e2215a0de342f48998890cfdfb Mon Sep 17 00:00:00 2001
 From: Nathan Rossi <nathan@nathanrossi.com>
 Date: Mon, 14 Dec 2020 13:39:02 +1000
 Subject: [PATCH] gen-pkgconfig.in: Do not include LDFLAGS in generated pc
@@ -16,7 +16,7 @@ Signed-off-by: Nathan Rossi <nathan@nathanrossi.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/misc/gen-pkgconfig.in b/misc/gen-pkgconfig.in
-index a45dd54f..85273054 100644
+index 89a5cd4a..07d94d17 100644
 --- a/misc/gen-pkgconfig.in
 +++ b/misc/gen-pkgconfig.in
 @@ -83,7 +83,7 @@ if [ "$includedir" != "/usr/include" ]; then

--- a/meta-lmp-base/recipes-core/ncurses/files/exit_prototype.patch
+++ b/meta-lmp-base/recipes-core/ncurses/files/exit_prototype.patch
@@ -1,0 +1,32 @@
+From 4a769a441d7e57a23017c3037cde3e53fb9f35fe Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 30 Aug 2022 15:58:32 -0700
+Subject: [PATCH] Add needed headers for including mbstate_t and exit()
+
+Upstream-Status: Inappropriate [Reconfigure will solve it]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+---
+ configure | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configure b/configure
+index f377f551..163f8899 100755
+--- a/configure
++++ b/configure
+@@ -3423,6 +3423,7 @@ rm -f "conftest.$ac_objext" "conftest.$ac_ext"
+   cat >"conftest.$ac_ext" <<_ACEOF
+ #line 3424 "configure"
+ #include "confdefs.h"
++#include <stdlib.h>
+ $ac_declaration
+ int
+ main (void)
+@@ -13111,6 +13112,7 @@ cat >"conftest.$ac_ext" <<_ACEOF
+ #include <stdlib.h>
+ #include <stdarg.h>
+ #include <stdio.h>
++#include <wchar.h>
+ #ifdef HAVE_LIBUTF8_H
+ #include <libutf8.h>
+ #endif

--- a/meta-lmp-base/recipes-core/ncurses/files/exit_prototype.patch
+++ b/meta-lmp-base/recipes-core/ncurses/files/exit_prototype.patch
@@ -1,4 +1,4 @@
-From 4a769a441d7e57a23017c3037cde3e53fb9f35fe Mon Sep 17 00:00:00 2001
+From 14aaa7b6ca11f9580e0a4b424716b265e292b35a Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Tue, 30 Aug 2022 15:58:32 -0700
 Subject: [PATCH] Add needed headers for including mbstate_t and exit()
@@ -11,18 +11,18 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/configure b/configure
-index f377f551..163f8899 100755
+index c2462f7f..33668cf0 100755
 --- a/configure
 +++ b/configure
-@@ -3423,6 +3423,7 @@ rm -f "conftest.$ac_objext" "conftest.$ac_ext"
+@@ -3458,6 +3458,7 @@ rm -f "conftest.$ac_objext" "conftest.$ac_ext"
    cat >"conftest.$ac_ext" <<_ACEOF
- #line 3424 "configure"
+ #line 3459 "configure"
  #include "confdefs.h"
 +#include <stdlib.h>
  $ac_declaration
  int
  main (void)
-@@ -13111,6 +13112,7 @@ cat >"conftest.$ac_ext" <<_ACEOF
+@@ -13526,6 +13527,7 @@ cat >"conftest.$ac_ext" <<_ACEOF
  #include <stdlib.h>
  #include <stdarg.h>
  #include <stdio.h>

--- a/meta-lmp-base/recipes-core/ncurses/ncurses_6.4.bb
+++ b/meta-lmp-base/recipes-core/ncurses/ncurses_6.4.bb
@@ -1,7 +1,7 @@
 # Use kirkstone upstream include file
 require recipes-core/ncurses/ncurses.inc
 # ...and fix variables to be compatible with ncurses-6.4
-LIC_FILES_CHKSUM = "file://COPYING;md5=c5a4600fdef86384c41ca33ecc70a4b8;endline=27"
+LIC_FILES_CHKSUM = "file://COPYING;md5=8f2e5b99d5b6c0e6ee7cb39b992733b6;endline=27"
 SRC_URI = "git://github.com/ThomasDickey/ncurses-snapshots.git;protocol=https;branch=master"
 
 
@@ -11,7 +11,7 @@ SRC_URI += "file://0001-tic-hang.patch \
            file://exit_prototype.patch \
            "
 # commit id corresponds to the revision in package version
-SRCREV = "1003914e200fd622a27237abca155ce6bf2e6030"
+SRCREV = "27feb33ffd0039a08de54ea9bbf9d1f435e447a9"
 S = "${WORKDIR}/git"
 EXTRA_OECONF += "--with-abi-version=5"
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d+(\.\d+)+)$"

--- a/meta-lmp-base/recipes-core/ncurses/ncurses_6.4.bb
+++ b/meta-lmp-base/recipes-core/ncurses/ncurses_6.4.bb
@@ -1,0 +1,20 @@
+# Use kirkstone upstream include file
+require recipes-core/ncurses/ncurses.inc
+# ...and fix variables to be compatible with ncurses-6.4
+LIC_FILES_CHKSUM = "file://COPYING;md5=c5a4600fdef86384c41ca33ecc70a4b8;endline=27"
+SRC_URI = "git://github.com/ThomasDickey/ncurses-snapshots.git;protocol=https;branch=master"
+
+
+SRC_URI += "file://0001-tic-hang.patch \
+           file://0002-configure-reproducible.patch \
+           file://0003-gen-pkgconfig.in-Do-not-include-LDFLAGS-in-generated.patch \
+           file://exit_prototype.patch \
+           "
+# commit id corresponds to the revision in package version
+SRCREV = "1003914e200fd622a27237abca155ce6bf2e6030"
+S = "${WORKDIR}/git"
+EXTRA_OECONF += "--with-abi-version=5"
+UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d+(\.\d+)+)$"
+
+# This is needed when using patchlevel versions like 6.1+20181013
+#CVE_VERSION = "${@d.getVar("PV").split('+')[0]}.${@d.getVar("PV").split('+')[1]}"

--- a/meta-lmp-base/recipes-core/ncurses/site_config/headers
+++ b/meta-lmp-base/recipes-core/ncurses/site_config/headers
@@ -1,0 +1,5 @@
+curses.h
+ncurses/curses.h
+ncurses.h
+ncurses/termcap.h
+


### PR DESCRIPTION
Switching to ncurses-6.4 later than 20230408 fixes the mentioned CVE.

The upstream version of this fix is in progress.
