### PR TITLE
base: clang-layer: fix building llvm with GCC13

### DIFF
--- a/meta-lmp-base/conf/layer.conf
+++ b/meta-lmp-base/conf/layer.conf
@@ -30,6 +30,8 @@ BBFILES_DYNAMIC += " \
     parsec-layer:${LAYERDIR}/dynamic-layers/parsec-layer/*/*/*.bbappend \
     tpm-layer:${LAYERDIR}/dynamic-layers/tpm-layer/*/*/*.bb \
     tpm-layer:${LAYERDIR}/dynamic-layers/tpm-layer/*/*/*.bbappend \
+    clang-layer:${LAYERDIR}/dynamic-layers/clang-layer/*/*/*.bb \
+    clang-layer:${LAYERDIR}/dynamic-layers/clang-layer/*/*/*.bbappend \
 "
 
 # A list of recipes that are completely stable and will never change.

--- a/meta-lmp-base/dynamic-layers/clang-layer/recipes-devtools/clang/files/Add-missing-cstdint.patch
+++ b/meta-lmp-base/dynamic-layers/clang-layer/recipes-devtools/clang/files/Add-missing-cstdint.patch
@@ -1,0 +1,31 @@
+From ff1681ddb303223973653f7f5f3f3435b48a1983 Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Mon, 23 May 2022 08:03:23 +0100
+Subject: [PATCH] [Support] Add missing <cstdint> header to Signals.h
+
+Without the change llvm build fails on this week's gcc-13 snapshot as:
+
+    [  0%] Building CXX object lib/Support/CMakeFiles/LLVMSupport.dir/Signals.cpp.o
+    In file included from llvm/lib/Support/Signals.cpp:14:
+    llvm/include/llvm/Support/Signals.h:119:8: error: variable or field 'CleanupOnSignal' declared void
+      119 |   void CleanupOnSignal(uintptr_t Context);
+          |        ^~~~~~~~~~~~~~~
+
+Upstream-Status: Backport [llvmorg-15.0.0-rc1]
+
+---
+ llvm/include/llvm/Support/Signals.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/include/llvm/Support/Signals.h b/llvm/include/llvm/Support/Signals.h
+index 44f5a750ff5cb..937e0572d4a72 100644
+--- a/llvm/include/llvm/Support/Signals.h
++++ b/llvm/include/llvm/Support/Signals.h
+@@ -14,6 +14,7 @@
+ #ifndef LLVM_SUPPORT_SIGNALS_H
+ #define LLVM_SUPPORT_SIGNALS_H
+ 
++#include <cstdint>
+ #include <string>
+ 
+ namespace llvm {

--- a/meta-lmp-base/dynamic-layers/clang-layer/recipes-devtools/clang/llvm-project-source.bbappend
+++ b/meta-lmp-base/dynamic-layers/clang-layer/recipes-devtools/clang/llvm-project-source.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append = " file://Add-missing-cstdint.patch "


### PR DESCRIPTION
Clang 14.0.3 fails to build with GCC 13.1.x with the error [1]. Apply an upstream fix for this issue.

[1]
| In file included from llvm/lib/Support/Signals.cpp:14: | llvm/include/llvm/Support/Signals.h:119:8: error: variable or field 'CleanupOnSignal' declared void
|   119 |   void CleanupOnSignal(uintptr_t Context);
|       |        ^~~~~~~~~~~~~~~
| llvm/include/llvm/Support/Signals.h:119:24: error: 'uintptr_t' was not declared in this scope

Upstream-Status: Pending [meta-clang]