### PR TITLE
base/bsp: lmp-image-common: tegra: increase IMAGE_OVERHEAD_FACTOR to 2.3

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -21,6 +21,7 @@ IMAGE_OVERHEAD_FACTOR:qemuriscv64 ?= "2.3"
 IMAGE_OVERHEAD_FACTOR:qemuarm64 ?= "2.3"
 IMAGE_OVERHEAD_FACTOR:qemuarm ?= "2.3"
 IMAGE_OVERHEAD_FACTOR:intel-corei7-64 ?= "2.3"
+IMAGE_OVERHEAD_FACTOR:tegra ?= "2.3"
 
 # let's make sure we have a good image..
 REQUIRED_DISTRO_FEATURES = "pam systemd"


### PR DESCRIPTION
Commit b49ed7f5c sets IMAGE_ROOTFS_SIZE to 65536, which forces the image size to be basically enough for the rootfs, without a lot of extra space (which is then extended by resize-helper). This might cause issues due lack of disk space depending on the situation, so extend IMAGE_ROOTFS_SIZE to 2.3 on tegra, to make sure by default it has enough for a full rootfs OTA.