### PR TITLE
base: rs: Bump aklite version to e66327c

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "0d8c0e3749629e18c4f998c2a863b5e5935c2a2d"
+SRCREV:lmp = "e66327c0e93233e1da08bf28b3d92d38290879ae"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
Relevant changes:
 - 50e2db3 restorableapps: Cleanup skopeo's tmp files
 - 82a2a25 restorableapps: Try tmp file removal if not enough space
 - b771ee0 offline: Use absolute path to source dir
 - 7050db9 offline: Don't install or register Apps if already running
 - f5a810b and d8a59bb cli: The API-based CLI implementation (update/finalize)
 - 5885f8a rootfsmanager: Move the finalization fix to libaktualizr