### PR TITLE
k3: u-boot: place root of trust keys outside the source repository

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging/k3-accept-filesystem-path-to-the-RoT-key.patch
+++ b/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging/k3-accept-filesystem-path-to-the-RoT-key.patch
@@ -1,0 +1,74 @@
+From 7afececd745b26a68822fe6c37addb0492356714 Mon Sep 17 00:00:00 2001
+From: Jorge Ramirez-Ortiz <jorge@foundries.io>
+Date: Wed, 28 Jun 2023 10:09:03 +0200
+Subject: [PATCH] k3: accept filesystem path to the RoT key
+
+Upstream-Status: Pending
+
+Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
+---
+ arch/arm/dts/Makefile       | 10 ++++++++--
+ arch/arm/dts/k3-binman.dtsi |  4 ++--
+ board/ti/common/Kconfig     |  7 +++++++
+ 3 files changed, 17 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 1b9c5f04c3..01b5ae36fe 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -1375,8 +1375,14 @@ targets += $(dtb-y)
+ # Add any required device tree compiler flags here
+ DTC_FLAGS += -a 0x8
+ 
+-PHONY += dtbs
+-dtbs: $(addprefix $(obj)/, $(dtb-y))
++PHONY += update_sign_keys dtbs
++
++update_sign_keys:
++ifeq ($(CONFIG_ARCH_K3),y)
++	${shell sed -i "s|TI_KEYS|$(CONFIG_SIGN_KEY_PATH)|g" $(srctree)/arch/arm/dts/k3-binman.dtsi}
++endif
++
++dtbs: update_sign_keys $(addprefix $(obj)/, $(dtb-y))
+ 	@:
+ 
+ clean-files := *.dtb *.dtbo *_HS
+diff --git a/arch/arm/dts/k3-binman.dtsi b/arch/arm/dts/k3-binman.dtsi
+index 97a3573bdb..c595203e9b 100644
+--- a/arch/arm/dts/k3-binman.dtsi
++++ b/arch/arm/dts/k3-binman.dtsi
+@@ -13,14 +13,14 @@
+ 	custMpk {
+ 		filename = "custMpk.pem";
+ 		blob-ext {
+-			filename = "../keys/custMpk.pem";
++			filename = "TI_KEYS/custMpk.pem";
+ 		};
+ 	};
+ 
+ 	ti-degenerate-key {
+ 		filename = "ti-degenerate-key.pem";
+ 		blob-ext {
+-			filename = "../keys/ti-degenerate-key.pem";
++			filename = "TI_KEYS/ti-degenerate-key.pem";
+ 		};
+ 	};
+ };
+diff --git a/board/ti/common/Kconfig b/board/ti/common/Kconfig
+index 49edd98014..4ff12d6c5b 100644
+--- a/board/ti/common/Kconfig
++++ b/board/ti/common/Kconfig
+@@ -49,3 +49,10 @@ config TI_COMMON_CMD_OPTIONS
+ 	imply CMD_SPI
+ 	imply CMD_TIME
+ 	imply CMD_USB if USB
++
++config SIGN_KEY_PATH
++       string "Path to the sign key"
++       depends on ARCH_K3
++       default "../keys"
++       help
++         Path to the folder containing the sign keys
+-- 
+2.34.1
+

--- a/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
@@ -5,6 +5,7 @@ include recipes-bsp/u-boot/u-boot-lmp-common.inc
 SRC_URI:append = " \
     ${@bb.utils.contains('MACHINE_FEATURES', 'jailhouse', 'file://0003-HACK-lib-lmb-Allow-re-reserving-post-relocation-U-Bo.patch', '', d)} \
     file://lib-zlib-Fix-a-bug-when-getting-a-gzip-header-extra-field.patch \
+    file://k3-accept-filesystem-path-to-the-RoT-key.patch \
 "
 
 SRC_URI:append:am64xx-evm = " \

--- a/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
@@ -27,3 +27,7 @@ python() {
     # we need to set the DEPENDS as well to produce valid SPDX documents
     fix_deployed_depends('do_install', d)
 }
+
+# Root of Trust Key directory
+K3_ROT_KEYS ?= "CONFIG_SIGN_KEY_PATH=${TOPDIR}/conf/keys"
+EXTRA_OEMAKE += "$K3_ROT_KEYS"


### PR DESCRIPTION
Allow u-boot's binman to read the signing keys from anywhere in the filesystem.
i.e: specifying the following config option in uboot:

`CONFIG_SIGN_KEY_PATH="/tmp/`