### PR TITLE
base: kmeta-linux-lmp-6.1.y: bump to 810864f0

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v6.1.y"
-KERNEL_META_COMMIT ?= "34f20e96d6bacb4e9c00ae96f3a588352f5b0480"
+KERNEL_META_COMMIT ?= "810864f0f4df773549f8624ecee92f01c86c775c"


### PR DESCRIPTION
Relevant changes:
- 810864f0 bsp: imx: imx8mm-evk: fix ethernet interface