### PR TITLE
base: kmeta-linux-lmp-6.1.y: bump to cc5d0ac1

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v6.1.y"
-KERNEL_META_COMMIT ?= "810864f0f4df773549f8624ecee92f01c86c775c"
+KERNEL_META_COMMIT ?= "cc5d0ac12ad5c7b307fc92447494bb347c612afa"


### PR DESCRIPTION
Relevant changes:
- cc5d0ac1 bsp: imx: rename CONFIG_IMX_LCDIF_CORE to CONFIG_IMX8MM_LCDIF_CORE
- a7573368 bsp: imx8mmevk: add CONFIG_NVMEM_SNVS_LPGPR
- 55523612 bsp: imx8mmevk: add MXC_GPU_VIV