### PR TITLE
bsp: u-boot-ti-staging: move default keys

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
@@ -35,5 +35,5 @@ python() {
 }
 
 # Root of Trust Key directory
-K3_ROT_KEYS ?= "CONFIG_SIGN_KEY_PATH=${TOPDIR}/conf/keys"
+K3_ROT_KEYS ?= "CONFIG_SIGN_KEY_PATH=${TOPDIR}/conf/keys/platform/ti"
 EXTRA_OEMAKE += "$K3_ROT_KEYS"


### PR DESCRIPTION
Move the default keys to a platform specific directory