### PR TITLE
base: layer.conf: exclude os-release siggen dependencie on the mfgtool-initramfs

### DIFF
--- a/meta-lmp-base/conf/layer.conf
+++ b/meta-lmp-base/conf/layer.conf
@@ -40,6 +40,7 @@ SIGGEN_EXCLUDERECIPES_ABISAFE += "os-release"
 SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += " \
     initramfs-ostree-lmp-image->os-release \
     core-image-minimal-initramfs->os-release \
+    fsl-image-mfgtool-initramfs->os-release \
 "
 
 # Override for external layers


### PR DESCRIPTION
This patch is a follow-up of 24d1016e, the fsl-image-mfgtool-initramfs is used on the distro lmp-mfgtool and without this patch the initramfs is rebuilded which consequently triggers a kernel rebuild.