### PR TITLE
base: kmeta-linux-lmp-6.1.y: bump to 63f34a75

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v6.1.y"
-KERNEL_META_COMMIT ?= "cc5d0ac12ad5c7b307fc92447494bb347c612afa"
+KERNEL_META_COMMIT ?= "63f34a75536289e4b13513f1238932f80a975f3f"


### PR DESCRIPTION
Relevant changes:
- 63f34a75 bsp: beaglebone: clean up config warnings