### PR TITLE
bsp: u-boot-fio: imx8mp-lpddr4-evk-ebbr: reduce image size

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/imx8mp-lpddr4-evk/lmp-ebbr.cfg
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio/imx8mp-lpddr4-evk/lmp-ebbr.cfg
@@ -47,6 +47,8 @@ CONFIG_CMD_SECONDARY_BOOT=y
 # CONFIG_SUPPORT_EMMC_RPMB is not set
 CONFIG_SUPPORT_EMMC_BOOT=y
 # CONFIG_ENV_IS_IN_MMC is not set
+# CONFIG_ENV_IS_NOWHERE is not set
+# CONFIG_ENV_IS_IN_SPI_FLASH is not set
 CONFIG_ENV_IS_IN_FAT=y
 CONFIG_ENV_FAT_INTERFACE="mmc"
 CONFIG_ENV_FAT_DEVICE_AND_PART="2:1"
@@ -73,6 +75,10 @@ CONFIG_CMD_SAVEENV=y
 # CONFIG_CHIMP_OPTEE is not set
 # CONFIG_DM_VIDEO is not set
 # CONFIG_VIDEO_IMX_SEC_DSI is not set
+# CONFIG_PHY_IMX8MQ_USB is not set
+# CONFIG_CMD_ERASEENV is not set
+# CONFIG_LED is not set
+# CONFIG_LED_GPIO is not set
 
 CONFIG_BOOTCOMMAND="load mmc 2:1 ${fdt_addr_r} dtb/${fdtfile}; run distro_bootcmd"
 


### PR DESCRIPTION
Tested OK:
- flash
- boot
- network
- register

Reduce image size to fix flashing error [1].

[1]
3:9      6/ 9 [image too large for partition         ] FB: flash bootloader2 ../u-boot-imx8mp-lpddr4-evk-ebbr.itb