### PR TITLE
base: kmeta-linux-lmp-6.1.y.inc: bump to 3261dba

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v6.1.y"
-KERNEL_META_COMMIT ?= "63f34a75536289e4b13513f1238932f80a975f3f"
+KERNEL_META_COMMIT ?= "3261dbac62f5720f6536d26f8f4e7f316fae5019"


### PR DESCRIPTION
Relevant changes:
 - ktypes: xeno4: fix evl configuration