### PR TITLE
meta-lmp-base: lmp-device-auto-register: add support for tags

### DIFF
--- a/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register/lmp-device-auto-register
+++ b/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register/lmp-device-auto-register
@@ -1,6 +1,15 @@
 #!/bin/sh -e
 
 TOKEN_FILE=${TOKEN_FILE-/etc/lmp-device-register-token}
+TAG=""
+
+if [ -f /etc/sota/tag ] ; then
+	# tag file should contain only one tag
+	# FoundriesFactory backend supports only
+	# single tag for device registration
+	TAG=$(</etc/sota/tag)
+	TAG="-t ${TAG}"
+fi
 
 if [ ! -f ${TOKEN_FILE} ] ; then
 	echo "$0: ERROR: Missing token file ${TOKEN_FILE}"
@@ -29,4 +38,4 @@ else
 	echo "$0: Registering with all available apps"
 fi
 
-/usr/bin/lmp-device-register -T ${TOKEN} ${APPS}
+/usr/bin/lmp-device-register -T ${TOKEN} ${TAG} ${APPS}


### PR DESCRIPTION
Add support for auto registration with tags. Tags should be defined in the /etc/sota/tags file. This file should contain one line with comma separated list of tags.