### PR TITLE
base: lmp-device-register: bump to 3c871e7

### DIFF
--- a/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl glib-2.0 libp11 openssl"
 
-SRCREV = "0e65a282f11bf5fac5744c0ba149edf8a5e958bf"
+SRCREV = "3c871e757b20d7400e76a90dea469722299a8c72"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https;branch=main"
 


### PR DESCRIPTION
Relevant changes:
- 3c871e7 options: validate the UUID input parameter