### PR TITLE
base: lmp-device-register: bump to ced5f1c

### DIFF
--- a/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
+++ b/meta-lmp-base/recipes-sota/lmp-device-register/lmp-device-register_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
 
 DEPENDS = "boost curl glib-2.0 libp11 openssl"
 
-SRCREV = "3c871e757b20d7400e76a90dea469722299a8c72"
+SRCREV = "e3be3296f60aa03f1c0010a58f0896d3eea28882"
 
 SRC_URI = "git://github.com/foundriesio/lmp-device-register.git;protocol=https;branch=main"
 


### PR DESCRIPTION
Relevant changes:
- ced5f1c options: fix regression on UUID validation