### PR TITLE
base: lmp: meta-ti-extras: mask jailhouse

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -117,9 +117,10 @@ BBMASK += " \
     /meta-st-stm32mp/recipes-graphics/drm/libdrm_2.4.113.bbappend \
     /meta-st-stm32mp/recipes-bsp/trusted-firmware-a/tf-a-stm32mp_2.6.bb \
 "
-# meta-ti-bsp: mask optee related recipes as they are provided by lmp
+# meta-ti-bsp: mask optee and jailhouse related recipes as they are provided by lmp
 BBMASK += " \
     /meta-ti/meta-ti-bsp/recipes-security/optee \
+    /meta-ti/meta-ti-extras/recipes-ti/jailhouse \
 "
 
 # disable xsct tarball by default (xilinx)


### PR DESCRIPTION
Prefer the recipe provided by LmP, which includes AM62 support.

This is to allow us enabling meta-ti-extras without conflicts.