### PR TITLE
bsp: linux-lmp-ti-staging: update to 09.00.00.007

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-ti-staging_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-ti-staging_git.bb
@@ -5,7 +5,7 @@ include recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
 
 LINUX_VERSION ?= "6.1.33"
 KBRANCH = "ti-linux-6.1.y"
-SRCREV_machine = "40c32565ca0e213fb653570cc618408ee8e9c6cf"
+SRCREV_machine = "8f7f371be250809e9c4af879cfa31d5f1839257d"
 SRCREV_meta = "${KERNEL_META_COMMIT}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"


### PR DESCRIPTION
Relevant changes:
- 8f7f371be25080 HACK: arm64: dts: ti: k3-am68-sk-base-board: Disable DSI
- 02fc6e18c300af HACK: arm64: dts: ti: k3-j784s4-evm: Disable DSI
- 72ad1c84e47332 HACK: arm64: dts: ti: k3-j721s2-common-proc-board: Disable DSI
- 995670442f4b47 arm64: dts: ti: k3-am69-sk-rpi-hdr-ehrpwm: Set the updated pinmux for gpio0
- 772e8f4ac9d62e arm64: dts: ti: k3-j721e-main: Add dts nodes for EHRPWMs
- 439c0dff56266e arm64: dts: ti: k3-j721s2-main: Add dts nodes for EHRPWMs
- a430178d12c87a arm64: dts: ti: k3-j721e-sk-*: Add DTB overlay to enable EHRPWMs
- 6aad0284013ee2 TEMP: media: img: vxe-vxd: decoder: Disable CMA for capture buffers
- de1228f628054a arm64: dts: ti: k3-j721e-beagleboneai64: Fixup reference to phandles array
- a6741f1de15a35 arm64: dts: ti: k3-j721e-beagleboneai64: Move eeprom WP gpio pinctrl to eeprom node
- 520bbd84c50929 arm64: dts: ti: k3-j721e-beagleboneai64: Move camera gpio pinctrl to gpio node
- 54d89e2de8ef48 arm64: dts: ti: k3-j721e: Enable MDIO nodes at the board level
- 5fd05c19462bdd arm64: dts: ti: k3-j721e: Enable PCIe nodes at the board level
- cd7cb452d74130 arm64: dts: ti: k3-j721e: Remove PCIe endpoint nodes
- 12a1a3808296b0 arm64: dts: ti: k3-j721e-beagleboneai64: Fix mailbox node status
- 65a81dd716f5b1 arm64: dts: ti: Add k3-j721e-beagleboneai64
- b9d82dcf9fceae drm/tidss: Set OLDI clock to bypass-25MHz during probe
- 05222ef1f8edd5 mtd: spi-nor: sfdp: Update params->hwcaps.mask at xSPI profile 1.0 table parse
- 9208d5f9d49ef7 Revert "drm/bridge: ti-sn65dsi86: Use drm_connector_init with helper funcs"
- 9f92016d9bbff5 scsi: ufs: TI UFS host controller expose device tree aliases