### PR TITLE
lmp-base: fio-se05x-cli: bump to 6fd9c93

### DIFF
--- a/meta-lmp-base/recipes-security/optee/fio-se05x-cli_git.bb
+++ b/meta-lmp-base/recipes-security/optee/fio-se05x-cli_git.bb
@@ -8,7 +8,7 @@ inherit pkgconfig
 DEPENDS = "optee-client openssl"
 
 SRC_URI = "git://github.com/foundriesio/fio-se05x-cli.git;protocol=https;branch=main"
-SRCREV = "7a87cce5900eb419669389dabf5c5942094f83a4"
+SRCREV = "6fd9c9329bb265b916c7fc14cb9447d198aceebf"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Relevant changes:
- 6fd9c93 getuid: display also in decimal
- 1ecbbba getuid: display the secure element unique identifier
- 0611906 Update README.rst