### PR TITLE
base: lmp-image-common: intel: also create wic.qcow2

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -3,8 +3,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/configs:"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-# Always create vmdk and vdi images for the compatible targets
-IMAGE_FSTYPES:append:intel-corei7-64 = " wic.vmdk wic.vdi"
+# Always create vmdk, vdi and qcow2 images for the compatible targets
+IMAGE_FSTYPES:append:intel-corei7-64 = " wic.vmdk wic.vdi wic.qcow2"
 
 inherit core-image features_check extrausers
 


### PR DESCRIPTION
Useful for users consuming the intel image with qemu.