### PR TITLE
bsp: linux-lmp-fslc-imx-rt: update kernel to the 6.1-2.0.x-imx branch

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx-rt_6.1.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx-rt_6.1.bb
@@ -3,8 +3,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/linux-lmp-fslc-imx:"
 include linux-lmp-fslc-imx_${PV}.bb
 
 KERNEL_REPO = "git://github.com/foundriesio/linux.git"
-LINUX_VERSION = "6.1.26"
-KERNEL_BRANCH = "6.1-1.0.x-imx-rt"
+LINUX_VERSION = "6.1.38"
+KERNEL_BRANCH = "6.1-2.0.x-imx-rt"
 
-SRCREV_machine = "b0d53b2f48c3626b7df546617f87fc8bf70232de"
+SRCREV_machine = "c2ea24ccb87b8fd6dc075e784eb00d229e320b85"
 LINUX_KERNEL_TYPE = "preempt-rt"


### PR DESCRIPTION
Based on 6.1-2.0.x-imx + v6.1.38-rt12-rebase.