### PR TITLE
base: kmeta-linux-lmp-6.1.y.inc: bump to d461d570

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v6.1.y"
-KERNEL_META_COMMIT ?= "3261dbac62f5720f6536d26f8f4e7f316fae5019"
+KERNEL_META_COMMIT ?= "d461d5701c8e0320b048d7866faecd69fd164782"


### PR DESCRIPTION
Relevant changes:
- d461d570 bsp: imx: enable support for the new btnxpuart driver
- 33df0da3 bsp: imx93-11x11-lpddr4x-evk: set CONFIG_NXP_C45_TJA11XX_PHY
- e6b43089 bsp: imx: apalis-imx8: remove toradex support
- 74a6c1a4 bsp: imx: apalis-imx6: remove toradex support
- 5f4ab2d1 bsp: stm32: disable stm32-rng in favor of optee-rng