### PR TITLE
base: rs: aktualizr: bump version to 2575118

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "e66327c0e93233e1da08bf28b3d92d38290879ae"
+SRCREV:lmp = "257511849d48e9d771653b21e28ac8eaa7721aba"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
Relevant changes:
- 99a91d2: cmake: Add build param to turn ON/OFF aklite-apps
- 0bcd548: apps: Calculate App update size precisely
- 80e3e5d: yaml2json: Throw exception with meaningful message
- 193cdf4: restorableapps: Verify already extracted compose file
- cc741b2: restorableapps: Check and store compose file safely
- f24e129: ostree: Exit fetch retry loop if no space while pulling deltas
- def33c2: Print msg if expected error occurs while importing root meta
- c861cf7: liteclient: Set request headers properly at init time
- af0df67: liteclient: Update ostree hash header
- 3c4b924: liteclient: Update info about current target on successful update
- ce6e38d: liteclient: Refresh the status headers on successful update