### PR TITLE
base: kmeta-linux-lmp-5-15.y: bump to 613da241

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-5.15.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v5.15.y"
-KERNEL_META_COMMIT ?= "8e6ac16ef2bc7875b0173b84b97669e59a936638"
+KERNEL_META_COMMIT ?= "613da241353acf42c6c7b3a653e1ff9eef824151"


### PR DESCRIPTION
Relevant changes:
- 613da241 bsp: rpi3: add missing usb phy and regulator fixed
- aea810f0 bsp: rpi: remove config warnings