### PR TITLE
base: jool: update to 4.1.10

### DIFF
--- a/meta-lmp-base/recipes-kernel/jool/jool_git.bb
+++ b/meta-lmp-base/recipes-kernel/jool/jool_git.bb
@@ -7,8 +7,8 @@ LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRC_URI = "git://github.com/NICMx/Jool.git;protocol=https;branch=main"
 
-PV = "4.0.4"
-SRCREV = "4c3e99d00242cf54832985fbe5374225512de3d5"
+PV = "4.1.10"
+SRCREV = "47334c9124b7a2e3253fb279e6c33acb9c2b09a6"
 
 S = "${WORKDIR}/git"
 
@@ -16,22 +16,19 @@ inherit module
 
 EXTRA_OEMAKE += 'ARCH="${ARCH}" CROSS_COMPILE="${TARGET_PREFIX}" \
     KERNEL_DIR="${STAGING_KERNEL_DIR}" KERNEL_VERSION="${KERNEL_VERSION}" \
-    KBUILD_EXTRA_SYMBOLS="${KBUILD_EXTRA_SYMBOLS}" \
 '
 
 do_compile() {
-    # Only build the kernel modules
-    unset CFLAGS CPPFLAGS CXXFLAGS LDFLAGS
-    oe_runmake -C "${S}/src/mod/nat64" CC="${KERNEL_CC}" LD="${KERNEL_LD}" \
+    for module in common nat64 siit; do
+        oe_runmake -C "${S}/src/mod/${module}" CC="${KERNEL_CC}" LD="${KERNEL_LD}" \
             AR="${KERNEL_AR}" O=${STAGING_KERNEL_BUILDDIR}
-    oe_runmake -C "${S}/src/mod/siit" CC="${KERNEL_CC}" LD="${KERNEL_LD}" \
-            AR="${KERNEL_AR}" O=${STAGING_KERNEL_BUILDDIR}
+    done
 }
 
 do_install() {
-    install -d ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/jool
-    install -m 0755 ${S}/src/mod/nat64/jool.ko \
-            ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/jool/
-    install -m 0755 ${S}/src/mod/siit/jool_siit.ko \
-            ${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/jool/
+    for module in common nat64 siit; do
+        oe_runmake DEPMOD=echo MODLIB="${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}" \
+            -C "${S}/src/mod/${module}" CC="${KERNEL_CC}" LD="${KERNEL_LD}" \
+            AR="${KERNEL_AR}" O=${STAGING_KERNEL_BUILDDIR} modules_install
+    done
 }


### PR DESCRIPTION
A new kernel module is part of this release, which requires the usage of an internal KBUILD_EXTRA_SYMBOLS settings, and why it is also removed from the recipe.

Install updated to use modules_install in order to have signed modules as part of the install process.

Relevant changes:
- 47334c91 Protocolary updates for release 4.1.10
- 469c2c22 Add support for kernel 6.2 and 6.3
- cbaf33dc Clean up skb->tstamp on translation
- 4509b34a Patch the kernel module's JNLAT_PORT parser
- bf4c7e36 Docs: Clarify the source of the NBT's ping
- dad6837d Patch Netlink request error propagation logic
- 490ddb09 Modernize the iptables shared object exports
- d5e64957 Userspace half of #347
- 7831ff3f Protocolary updates for release 4.1.9
- 0b5952e8 F1x #378
- c2962a73 Netlink: Allow some backward compatibility
- 6dfa2f69 Allow < 128 ICMP extension'd packets
- c95e211f Remove traces of the master branch from the documentation
- c1b64e9e Move content of the LICENSE file to the README
- aeedd340 Add support for RHEL 8.6, 8.7, 9.0 and 9.1
- 226b37e3 Update openwrt.md
- 48c3d44f Add pool4 validation to atomic config BIBs
- bb49c60b Fix the example configuration for NAT64
- 78c50395 Doc: Highlight that xlat ping doesn't work from xlator namespace
- 61e67648 DKMS: Fix RHEL kernel version checks on 9.99 / 5.17
- 5604a61f Remove all references to jool.mx
- abe9a9ec Add sustainability survey to the site
- 6822bdee Protocolary updates for release 4.1.8
- 4af409cf Revert 21b97b1e4fd29676ae3dd6800dc3286c70dd0690
- 344b058e 4.1.8 release review
- c48cf90a RFC7915: Update the GRO comments I could find
- e95308fe 6to4: Remove ptk_len()
- b87b6c66 7915: Fix checksums on Slow Path
- 454b83f8 GRO: Slow Path review; remove pkt_len() usage
- ebb5f7e1 Documentation: Update sample atomic files
- 89f3218e Create CNAME
- 1c1267f2 Protocolary updates for release 4.1.7
- 04ef98dd xtables: print enabled status on startup
- 81d6ad1d Autotools: Add --with-xtables
- a036f08a Makefile: Remove JOOL_FLAGS
- 23fcde67 iptables: Make optional
- e9e5c582 Protocolary updates for release 4.1.6
- 8d23b996 Add support for kernels 5.12-5.15, RHEL 7.9, 8.4 and 8.5
- 555d61a0 Netfilter: Remove hardcoded array length
- 88339465 Documentation: Update OpenWRT install instructions
- c6897c57 Documentation: Add contact pointer to Matrix
- 458d7887 rbtree: Replace obsolete foreach function with kernel's macro
- a1d2d1a5 Documentation: Add map-t-type to the MAP-T tutorial
- a72e9554 README: Update Github IPv6 availability status
- 40022698 Update of configuration flag: --handle-rst-during-fin-rcv
- 725b0e12 ICMP: Do not rely on flowi to translate internal type and error
- cd1c03f9 Address xlat: Change ::1 verdict from DROP to ACCEPT
- 2323a135 EAMT: Fix #363 properly
- 3a0da31c Radix Trie: Purge RCU waits
- 6f3ad879 joold: Add NLA_F_NESTED to joold add requests
- 5dc6ae4f Documentation: OpenWRT review
- 3c4c71cc Documentation: Update Privacy Notice
- 673f89a7 Documentation: Add "does't follow Jool's protocol" FAQ entry
- a08c1784 Documentation: Update Privacy Notice
- 3a873911 Documentation: Downgrade recommendation priority of 4.0.9
- 34ffbf56 Protocolary updates for release 4.1.5
- ff8f8bdb Merge branch 'issue352'
- 978190a9 Documentation: Update year
- ebe4abbb Documentation: Fix DNS64 tutorial 2
- e7141a10 Documentation: Fix DNS64 tutorial
- dc7b39b7 issue352: Add debugging information
- 8dd0b9fb Define the netlink header magic string in the preprocessor.
- 58bf14e0 joold: Properly initalize the Jool header
- ba85afbf joold: Patch Netlink callback mess
- d3208d8c Documentation: Update with 4.2.0-rc1
- 73dc38c2 Hairpinning: Reinforce state object initialization on SIIT
- 5ad9b702 Netlink: Remove CAP_NET_ADMIN validation on stats display handler
- aec9f25f Add a timeseries stats section - Explain about the new jool-exporter being available - Keep generic + link to projects README - State that it's not maintained by Jool core developers
- fb731d99 Documentation: Update MAP-T usage, add prototype Cheat Sheet
- 705c5adf MAP-T: Documentation review
- 705e86cb MAP-T: Mirror documentation from the mapt branch
- b782646d Documentation: Review
- 4df5a8e3 Documentation: Review
- 23464e25 Documentation: Address the rest of the #345 feedback
- b0c3284d Documentation: Address some feedback from #345
- b09c4903 Protocolary updates for release 4.1.4
- 026d45c2 Merge branch 'issue341'
- 9b2614ef documentation: Current agreed changes for #345
- 525ee6da denylist4: Rename from blacklist4
- 79bd450d documentation: Update the intro to xlat
- 972c2de0 documentation: Update instance flag's pool4 examples
- c3620137 generic denylist: allow /32 addresses
- 9b628265 Protocolary updates for release 4.1.3
- 35267a38 Issue #338: Bump version number
- bd974032 siit: apply generic blacklist to dst address
- 163b9f4d Protocolary updates for release 4.1.2
- 07279bfd iptables: Remove `static` from `_init()`.
- 661e4960 Merge debug and trace configuration options
- c9a3d2d2 Patch unit tests
- f647e14f Patch compilation on CentOS 8
- c4f38e82 Turn debug into a runtime switch
- bdab9612 Patch a bunch of compile bugs reported by Fatih USTA
- fc1a6877 Protocolary updates for release 4.1.1
- 212acb49 GRO: Patch GRO in the IPv4 to IPv6 direction
- eba6df14 pool4: patch port management in stateful NAT64.
- b8c20a35 GRO: Patch GRO in the IPv6 to IPv4 direction
- b00265df Documentation: Patch release leftover noise
- b5f4cb55 graybox: Test addendums inspired by release protocol
- c3a482b6 Patch empty pool4 bug
- 1118be57 Protocolary updates for release 4.1.0 (unfinished)
- 539a65e1 Purge `force-slow-path-46`
- b17353d7 Add `lowest-ipv6-mtu` documentation
- 1db50109 graybox: NAT64 test suite review, part 3
- 04076bac graybox: NAT64 test suite review, part 2
- c439fc4c graybox: NAT64 test suite review, part 1
- 7848ad4f graybox: SIIT test suite review
- 2a8d0adc Merge branch 'master' into issue136
- c188c1b7 graybox: Big cleanup and refactor
- 1849b01e Design and implement tests jb* and jc*
- 7f72f85d Design and implement graybox test ja
- 3e1e8fd1 Protocolary updates for release 4.0.9
- b846a194 Testing
- 388e2dda autotools: Convert all shared libs to convenience libraries
- fad9dc98 netlink: Update API usage again
- a16b5274 graybox: Redesign and implement all id tests
- caf6285d Implement graybox tests ic5, ic6, id1, id2 and id3
- 2deb5efb Implement graybox tests ic1, ic2, ic3 and ic4
- 088bbff4 Patch graybox tests
- a0cfa6f2 Merge branch 'issue136'
- 1a4eaac7 Protocolary updates for release 4.0.8
- 2a3e0991 Code review and testing
- d41e3dc4 Code review and testing
- b541c4cc Code review
- 9e9a636b Restore successful compilation on all supported kernels
- a687860b Code review
- f144ae51 netlink: add joold
- 277e7ed3 Patch compilation on all supported kernels
- 286fe5a9 netlink: add atomic configuration
- c3dd25a5 Complete rewrite of the Netlink code
- 6cd661f7 Implement translation of ICMP Extensions (IE)
- b970c7cd Complete RFC 7915 graybox tests
- de9f3701 Look at all these bugfixes
- 47271479 Optimized further
- 24027071 Patch submodule deinitialization order
- 54b9aaa7 Still testing and thinking
- fde105c1 Bunch of testing
- 07a9c951 Documentation: Add Arch Linux dependencies
- 50a4920a Improve documentation based on latest feedback
- be53fe41 Merge branch 'master' into issue136
- 76c12343 Improve trace based on latest feedback
- 0fada0fc Add the `trace` global configuration option
- 1aaf79e4 Update the logging documentation
- 866779a2 Add uninstallation steps for source-compiled binaries
- 4ff45fc1 Protocolary updates for release 4.0.7
- 78d5424a Kbuild: s/SUBDIRS/M/
- ef48ec3b Merge branch 'issue221'
- da67695e WIP
- 535d83d1 Add --lowest-ipv6-mtu
- cfa601aa Print iptables-save properly
- 61a8bb49 Fix kern/usr communication protocol structure sizes
- d39e1d53 Fix kern/usr communication protocol structure sizes
- 553d16f9 Add survey for 2020 development
- 79406a56 joold: Remind users that logging is sent to syslog
- 0343b851 RFC6791 test implementations da, db and ga
- 0a1b2c8e RFC6791 test implementations ce through fa, except da and db
- 9981795f RFC6791 test implementations aa through cd
- ca59bb18 Doc: Update binary list, commit random stashes
- 6d6aede1 Update Debian packages documentation again
- 8dd80381 Update Debian packages documentation
- df40aea4 Add documentation for Alpine Linux
- 3862ecfd Add design of future RFC 6791 graybox tests
- 89227b09 RFC 7915 review
- 90033801 Patch some documentation links
- 98c56b4b Protocolary updates for release 4.0.6
- 5367a688 More testing; patch more bugs
- 1442ea4d More testing; patch more bugs
- ae166170 Reduce stack usage
- f3476c2b Testing the jool_common refactor; patch bugs
- 60f832de Merge branch 'issue114v2' into issue297
- 23af85ca Update iptables documentation
- de8895ed Merge branch 'issue297'
- 7ce47989 add build dependency "libtool" for build from git repository
- fc1cbd88 Create jool_common kernel module
- 43f88597 Mirror Netfilter packet return mechanism on iptables mode
- f949e77d follow iptables rule option format convention
- de8d79ce Add support for kernel 5.4, RHEL 7.7 and RHEL 8
- 0f1c1ba2 properly print rule options with leading space
- 1b9efd40 Unit and graybox test the previous commit
- 1acae4cc Convert log_err from macro to function
- 8e10bc1a Patch build bugs found by Rosen Penev
- 95054a39 Merge branch 'genofire'
- f4472619 Patch some installation instruction bugs
- 629c9e0a fix(doc): siit-dc - kernel forwarding
- 0e78a11b updates for release 4.0.5
- a1f2f7c6 Patch previous commit
- e5fb78a1 Attempt to patch #289 and #279
- 6247edcb Document public key and signature status
- 48f35ffd Patch DKMS installation
- 0ac33a38 Enhance eamt query operation