### PR TITLE
base: lmp: clang: disable -mbranch-protection=standard

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -18,6 +18,9 @@ require conf/distro/include/non-clangable.inc
 require conf/distro/include/security_flags.inc
 require conf/distro/include/yocto-uninative.inc
 
+# Disable branch-protection=standard from clang until properly validated (causes issues on aktualizr)
+TUNE_CCARGS:remove:toolchain-clang = "${@bb.utils.contains('TUNE_FEATURES', 'aarch64', '-mbranch-protection=standard', '', d)}"
+
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-lmp"
 PREFERRED_PROVIDER_virtual/optee-os ?= "optee-os-fio"
 PREFERRED_PROVIDER_u-boot-fw-utils ?= "libubootenv"


### PR DESCRIPTION
Added as a side effect of the oe-core a1119750e commit, and causes unexpected side effects on aktualizr-lite, such as:

aktualizr-lite[993]: libc++abi: terminating with uncaught exception of
type offline::MetaFetcher::NotFoundException: Metadata hasn't been
found; role: root; ve5

Disable while the behavior is properly investigated on a more recent clang release.