### PR TITLE
base: lmp: remove ptest from distro feauture

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -40,7 +40,7 @@ PREFERRED_VERSION_gcc-arm-none-eabi-native ?= "10.3-2021.10"
 INIT_MANAGER = "systemd"
 DISTRO_FEATURES_DEFAULT = "acl argp bluetooth ext2 ipv4 ipv6 largefile usbgadget usbhost wifi xattr zeroconf pci vfat modsign efi security tpm integrity seccomp"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "pulseaudio ldconfig"
-DISTRO_FEATURES:append = " pam usrmerge virtualization ptest alsa"
+DISTRO_FEATURES:append = " pam usrmerge virtualization alsa"
 
 # Default IMA policy (tcb)
 IMA_POLICY ?= "ima-policy-tcb"


### PR DESCRIPTION
It will be better to dropping this as it build a lot of stuff used only in testing, when we decide to run on the target the unit test produced with ptest we can enable it again.