### PR TITLE
systemd: build coredump

### DIFF
--- a/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
@@ -12,6 +12,7 @@ PACKAGECONFIG ?= " \
     binfmt \
     cryptsetup \
     cryptsetup-plugins \
+    coredump \
     gshadow \
     hibernate \
     hostnamed \


### PR DESCRIPTION
The `systemd-coredump` is needed to collect possible coredumps and `coredumpctl` to analize the collect data.