### PR TITLE
base: compose-apps-early-start: Add runtime dependency

### DIFF
--- a/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start.bb
+++ b/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start.bb
@@ -25,3 +25,4 @@ do_install() {
 }
 
 FILES:${PN} += "${systemd_system_unitdir}/*.service"
+RDEPENDS:${PN} += "aktualizr-lite-apps"


### PR DESCRIPTION
Add aktualizr-lite-apps as runtime dependency.
The compose-apps-early-start script relies on aklite-apps.