### PR TITLE
base: connectivity: introduce docker-network-ref implementation

### DIFF
--- a/meta-lmp-base/recipes-connectivity/docker-network-ref/docker-network-ref/create-docker-ref-network.sh.in
+++ b/meta-lmp-base/recipes-connectivity/docker-network-ref/docker-network-ref/create-docker-ref-network.sh.in
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# Run this script as root to prepare docker-network-ref bridge network for docker
+#
+
+if [ -z "`docker network list -q -f name=@@DOCKER_NETWORK_NAME@@`" ]; then
+	docker network create @@DOCKER_NETWORK_NAME@@
+fi

--- a/meta-lmp-base/recipes-connectivity/docker-network-ref/docker-network-ref/docker-network-ref.service
+++ b/meta-lmp-base/recipes-connectivity/docker-network-ref/docker-network-ref/docker-network-ref.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Create docker-network-ref docker bridge network
+After=boot-complete.target
+Before=aktualizr-lite.service
+Requires=boot-complete.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/create-docker-ref-network.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-lmp-base/recipes-connectivity/docker-network-ref/docker-network-ref_1.0.bb
+++ b/meta-lmp-base/recipes-connectivity/docker-network-ref/docker-network-ref_1.0.bb
@@ -1,0 +1,34 @@
+SUMMARY = "Auto creation of the `docker-network-ref` docker bridge network"
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-2-Clause;md5=cb641bc04cda31daea161b1bc15da69f"
+
+inherit systemd
+
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE:${PN} = "docker-network-ref.service"
+
+SRC_URI = " \
+    file://create-docker-ref-network.sh.in \
+    file://docker-network-ref.service \
+"
+
+S = "${WORKDIR}"
+
+DOCKER_NETWORK_NAME ?= "docker-network-ref"
+
+do_compile() {
+    sed -e 's|@@DOCKER_NETWORK_NAME@@|${DOCKER_NETWORK_NAME}|g' \
+        ${WORKDIR}/create-docker-ref-network.sh.in > ${WORKDIR}/create-docker-ref-network.sh
+}
+
+do_install() {
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${S}/docker-network-ref.service ${D}${systemd_unitdir}/system
+    install -d ${D}${sbindir}
+    install -m 0755 ${S}/create-docker-ref-network.sh ${D}${sbindir}/
+}
+
+FILES:${PN} = " \
+    ${systemd_unitdir}/system/docker-network-ref.service \
+    ${sbindir}/create-docker-ref-network.sh \
+"


### PR DESCRIPTION
docker-network-ref brings a reference implementation for a docker bridge network that compose apps can connect to.

This avoids issues found when a network is defined in a compose app, which prevents bringing these apps and network down.