### PR TITLE
mfgtool-files: Use compressed image for the full_image script

### DIFF
--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx6ulevk/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx6ulevk/full_image.uuu.in
@@ -9,7 +9,7 @@ SDPV: jump
 FB: ucmd if mmc dev 0; then setenv flash_dev 0; setenv emmc_partconf "mmc partconf ${flash_dev} ${emmc_ack} 1 0"; else setenv flash_dev 1; setenv emmc_partconf "true"; fi;
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd mmc dev ${flash_dev}
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
 FB: ucmd mmc dev ${flash_dev} 1; mmc erase 2 0x1FFE
 FB: flash bootloader ../SPL-@@MACHINE@@
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx6ullevk/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx6ullevk/full_image.uuu.in
@@ -9,7 +9,7 @@ SDPV: jump
 FB: ucmd if mmc dev 0; then setenv flash_dev 0; setenv emmc_partconf "mmc partconf ${flash_dev} ${emmc_ack} 1 0"; else setenv flash_dev 1; setenv emmc_partconf "true"; fi;
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd mmc dev ${flash_dev}
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
 FB: ucmd mmc dev ${flash_dev} 1; mmc erase 2 0x1FFE
 FB: flash bootloader ../SPL-@@MACHINE@@
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mm-lpddr4-evk-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mm-lpddr4-evk-sec/full_image.uuu.in
@@ -21,7 +21,7 @@ FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb delete_pvalue bootfirm
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue debug 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue is_secondary_boot 0; else true; fi
 
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
 FB: flash bootloader ../imx-boot-@@MACHINE@@.signed
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
 FB: flash bootloader_s ../imx-boot-@@MACHINE@@.signed

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mm-lpddr4-evk/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mm-lpddr4-evk/full_image.uuu.in
@@ -9,7 +9,7 @@ SDPV: jump
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd setenv mmcdev ${emmc_dev}
 FB: ucmd mmc dev ${emmc_dev} 1; mmc erase 0 0x2000
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
 FB: flash bootloader ../imx-boot-@@MACHINE@@
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
 FB: flash bootloader_s ../imx-boot-@@MACHINE@@

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mn-ddr4-evk-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mn-ddr4-evk-sec/full_image.uuu.in
@@ -17,7 +17,7 @@ FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb delete_pvalue bootfirm
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue debug 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue is_secondary_boot 0; else true; fi
 
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
 FB: flash bootloader ../imx-boot-@@MACHINE@@.signed
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
 FB: flash bootloader_s ../imx-boot-@@MACHINE@@.signed

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mn-ddr4-evk/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mn-ddr4-evk/full_image.uuu.in
@@ -5,7 +5,7 @@ SDPS: boot -f imx-boot-mfgtool
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd setenv mmcdev ${emmc_dev}
 FB: ucmd mmc dev ${emmc_dev} 1; mmc erase 0 0x2000
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
 FB: flash bootloader ../imx-boot-@@MACHINE@@
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
 FB: flash bootloader_s ../imx-boot-@@MACHINE@@

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mn-lpddr4-evk-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mn-lpddr4-evk-sec/full_image.uuu.in
@@ -17,7 +17,7 @@ FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb delete_pvalue bootfirm
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue debug 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue is_secondary_boot 0; else true; fi
 
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
 FB: flash bootloader ../imx-boot-@@MACHINE@@.signed
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
 FB: flash bootloader_s ../imx-boot-@@MACHINE@@.signed

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mn-lpddr4-evk/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mn-lpddr4-evk/full_image.uuu.in
@@ -5,7 +5,7 @@ SDPS: boot -f imx-boot-mfgtool
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd setenv mmcdev ${emmc_dev}
 FB: ucmd mmc dev ${emmc_dev} 1; mmc erase 0 0x2000
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
 FB: flash bootloader ../imx-boot-@@MACHINE@@
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
 FB: flash bootloader_s ../imx-boot-@@MACHINE@@

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mp-lpddr4-evk-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mp-lpddr4-evk-sec/full_image.uuu.in
@@ -21,7 +21,7 @@ FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb delete_pvalue bootfirm
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue debug 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue is_secondary_boot 0; else true; fi
 
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
 FB: flash bootloader ../imx-boot-@@MACHINE@@.signed
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
 FB: flash bootloader_s ../imx-boot-@@MACHINE@@.signed

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mp-lpddr4-evk/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mp-lpddr4-evk/full_image.uuu.in
@@ -9,7 +9,7 @@ SDPV: jump
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd setenv mmcdev ${emmc_dev}
 FB: ucmd mmc dev ${emmc_dev} 1; mmc erase 0 0x2000
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
 FB: flash bootloader ../imx-boot-@@MACHINE@@
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
 FB: flash bootloader_s ../imx-boot-@@MACHINE@@

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mq-evk/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8mq-evk/full_image.uuu.in
@@ -16,7 +16,7 @@ SDPV: jump
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd setenv mmcdev ${emmc_dev}
 FB: ucmd mmc dev ${mmcdev} 1; mmc erase 0 0x2000
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
 FB: flash bootloader ../imx-boot-@@MACHINE@@
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
 # secondary boot image should not contain HDMI FW

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek-sec/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek-sec/full_image.uuu.in
@@ -37,5 +37,5 @@ FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb delete_pvalue bootfirm
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue debug 0; else true; fi
 FB[-t 50000]: ucmd if test -n "${fiovb_rpmb}"; then fiovb write_pvalue is_secondary_boot 0; else true; fi
 
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
 FB: done

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek/full_image.uuu.in
@@ -17,7 +17,7 @@ SDPV: jump
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd setenv mmcdev 0
 FB: ucmd mmc dev ${mmcdev} 1; mmc erase 0 0x3FFE
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
 FB: flash bootloader ../imx-boot-@@MACHINE@@
 FB: flash bootloader_s ../imx-boot-@@MACHINE@@
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8ulp-lpddr4-evk/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8ulp-lpddr4-evk/full_image.uuu.in
@@ -5,7 +5,7 @@ SDPS: boot -f imx-boot-mfgtool
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd setenv mmcdev 0
 FB: ucmd mmc dev ${mmcdev} 1; mmc erase 0 0x3C00
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
 FB: flash bootloader ../imx-boot-@@MACHINE@@
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
 FB: flash bootloader_s ../imx-boot-@@MACHINE@@

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx93-11x11-lpddr4x-evk/full_image.uuu.in
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx93-11x11-lpddr4x-evk/full_image.uuu.in
@@ -5,7 +5,7 @@ SDPS: boot -f imx-boot-mfgtool
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd setenv mmcdev 0
 FB: ucmd mmc dev ${mmcdev} 1; mmc erase 0 0x3C00
-FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic
+FB: flash -raw2sparse all ../@@MFGTOOL_FLASH_IMAGE@@-@@MACHINE@@.wic.gz/*
 FB: flash bootloader ../imx-boot-@@MACHINE@@
 FB: flash bootloader2 ../u-boot-@@MACHINE@@.itb
 FB: flash bootloader_s ../imx-boot-@@MACHINE@@


### PR DESCRIPTION
Use the compressed image. It reduces one step for the flashing process and makes the flashing time a little quicker.
