### PR TITLE
lmp-el2go-auto-register: allow to disable "composeapp"

### DIFF
--- a/meta-lmp-base/recipes-support/lmp-el2go-auto-register/lmp-el2go-auto-register/lmp-el2go-auto-register
+++ b/meta-lmp-base/recipes-support/lmp-el2go-auto-register/lmp-el2go-auto-register/lmp-el2go-auto-register
@@ -19,6 +19,7 @@ PIN = os.environ.get("PKCS11_PIN", "87654321")
 SO_PIN = os.environ.get("PKCS11_SOPIN", "12345678")
 SOTA_DIR = os.environ.get("SOTA_DIR", "/var/sota")
 HANDLERS = os.environ.get("HANDLERS", "aws-iot,aktualizr-lite")
+PACMAN_TYPE = os.environ.get("PACMAN_TYPE", "ostree+compose_apps")
 
 REPO_ID = os.environ["REPOID"]
 
@@ -196,7 +197,7 @@ repo_server = "https://{REPO_ID}.ota-lite.foundries.io:8443/repo"
 key_source = "file"
 
 [pacman]
-type = "ostree+compose_apps"
+type = "{PACMAN_TYPE}"
 ostree_server = "https://{REPO_ID}.ostree.foundries.io:8443/ostree"
 packages_file = "/usr/package.manifest"
 tags = "{tag}"


### PR DESCRIPTION
On a device running a dockerless LmP with EdgeLock 2GO [1], the "aktualizr-lite" was failing and exiting with an error message:

  `aktualizr-lite[991]: boost::filesystem::canonical: No such file or directory [generic:2]: "/usr/bin/docker"`

We could trace the error in "`aktualizr-lite`": it happens only when "`aktualizr-lite`" tried to upgrade the "compose apps" on a dockerless system. But "`aktualizr-lite`" can work: while our device is dockerless, we could register it manually with "`lmp-device-register`" and upgrade the firmware with "`aktualizr-lite`".

The difference between the successfull "`aktualizr-lite`" when manually registering the device and the error mentioned above is the use of EdgeLock 2GO (el2go). The "`lmp-el2go-auto-register`" script [2] starts the EdgeLock 2GO agent and creates a "`/var/sota/sota.toml`" configuration file for "`aktualizr-lite`". That configuration file does not support dockerless systems because it forces the package manager in "`ostree+compose_apps`" mode:
```
  [...]
  [pacman]
  type = "ostree+compose_apps"
  ostree_server = "https://{REPO_ID}.ostree.foundries.io:8443/ostree"
  packages_file = "/usr/package.manifest"
  [...]
```

On a dockerless system, the package manager should be in "`ostree`" mode, i.e. not trying to upgrade the docker containers. The config file speaks about "pacman `type`".

Fixed: made the package manager type an option that depends on the "`PACMAN_TYPE`" environment variable, and be "`ostree+compose_apps`" by default, for backward compatibility. Dockerless systems can set the "`PACMAN_TYPE`" variable to "`ostree`" in the script environment.

References:
- [1] "_Creating an LmP Build With EdgeLock 2GO_" <https://docs.foundries.io/91/user-guide/el2g.html#creating-an-lmp-build-with-edgelock-2go>
- [2] "_lmp-el2go-auto-register_" <https://github.com/foundriesio/meta-lmp/blob/main/meta-lmp-base/recipes-support/lmp-el2go-auto-register/lmp-el2go-auto-register/lmp-el2go-auto-register#L199>