### PR TITLE
base: rs: aktualizr: bump version to e981256

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "c429dda95874cb932be08d45a8d7723210255f25"
+SRCREV:lmp = "e9812564058a84c70d9e4a8be8bf8cca47d12a71"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
Relevant changes:
- ac91224 liteclient: Enable TLS connections sharing
- 1ce7782 aktualizr: Bump version to 2023.09+fio
- e666637 apps: Assume stateless app is pulled when running it
- 54040f3 rfsmgr: Don't pull ostree if no available storage
- eb3a3ff sysroot: Remove redundant conf param
- a46a634 Apply usage stat to apps
- de69ee4 Use usage stat to control pull attempts
- 03c6b14 Unify and improve free space verification
- f676ad3 Apply the new storage watermark parameter to both the delta and non-delta use-cases
- 6efbe43 Delta stat usage fixes
- 70aa49e Delta stat application: check update size before fetching update data
- e20362d Improvements and cleanup related to the static delta use-case