### PR TITLE
base: docker-credential-helper: Handle leading spaces

### DIFF
--- a/meta-lmp-base/recipes-support/docker-credential-helper-fio/files/docker-credential-fio-helper
+++ b/meta-lmp-base/recipes-support/docker-credential-helper-fio/files/docker-credential-fio-helper
@@ -15,7 +15,7 @@ if [ "$1" = "get" ] ; then
 		echo "ERROR: Device does not appear to be registered under $SOTA_DIR"
 		exit 1
 	fi
-	server=$(grep -m1 ^server ${SOTA_DIR}/sota.toml | cut -d\" -f2)
+	server=$(grep -m1 '^[[:space:]]*server' ${SOTA_DIR}/sota.toml | cut -d\" -f2)
 	if [ -z $server ] ; then
 		server="https://ota-lite.foundries.io:8443"
 	fi


### PR DESCRIPTION
Normally `/var/sota/sota.toml` has had TOML with no indentation. eg: 
```
[section]
key=val
```

There are situations where /var/sota/sota.toml can be indented:
```
[section]
  key=val
```
This changes our regular expression to handle either one. Discovered while testing meds.