### PR TITLE
base: rc: Patch docker to load image optimally

### DIFF
--- a/meta-lmp-base/recipes-containers/docker/docker-ce_%.bbappend
+++ b/meta-lmp-base/recipes-containers/docker/docker-ce_%.bbappend
@@ -7,6 +7,7 @@ SRC_URI:append = " \
     file://0001-registry-increase-TLS-and-connection-timeouts.patch;patchdir=src/import \
     file://0001-daemon-overlay2-write-layer-metadata-atomically.patch;patchdir=src/import \
     file://0001-layer-ensure-layer-files-are-synced-to-disk.patch;patchdir=src/import \
+    file://0001-tarexport-optimize-image-loading-on-local-host.patch;patchdir=src/import \
     file://daemon.json.in \
     file://docker.service \
 "

--- a/meta-lmp-base/recipes-containers/docker/files/0001-tarexport-optimize-image-loading-on-local-host.patch
+++ b/meta-lmp-base/recipes-containers/docker/files/0001-tarexport-optimize-image-loading-on-local-host.patch
@@ -1,0 +1,180 @@
+From d737cd24d2922c0bde11be945e19a0febbec42cb Mon Sep 17 00:00:00 2001
+From: Mike Sul <mike.sul@foundries.io>
+Date: Fri, 22 Sep 2023 12:49:07 +0200
+Subject: [PATCH] tarexport: Optimize image loading on local host
+
+This commit augments the image load manifest by introducing
+an additional field that allows specifying the image layer root
+directory on a local host.
+
+When this root directory is provided in the manifest, the Docker image
+loading process will read layer data directly from that location,
+optimizing the operation.
+
+In cases where the layer root directory is not specified in
+the manifest, the default behavior remains intact. The image layers
+will be transferred via the input TAR stream, temporarily stored in
+the temporary directory (`/var/lib/docker/tmp/docker-import-*`), and
+subsequently read from the temporary location during the layer loading
+process into the Docker store.
+
+Also, this change enables setting the digest reference to an image in
+addition to the tag one, as well as it corrects the reference printing
+of a loaded image.
+
+Upstream-Status: Inappropriate [lmp specific]
+
+Signed-off-by: Mike <mike.sul@foundries.io>
+---
+ image/tarexport/load.go      | 59 ++++++++++++++++++++++--------------
+ image/tarexport/tarexport.go |  1 +
+ 2 files changed, 38 insertions(+), 22 deletions(-)
+
+diff --git a/image/tarexport/load.go b/image/tarexport/load.go
+index d9f3873081..312dd78b52 100644
+--- a/image/tarexport/load.go
++++ b/image/tarexport/load.go
+@@ -8,6 +8,7 @@ import (
+ 	"os"
+ 	"path/filepath"
+ 	"runtime"
++	"strings"
+ 
+ 	"github.com/docker/distribution"
+ 	"github.com/docker/distribution/reference"
+@@ -66,11 +67,9 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
+ 	}
+ 
+ 	var parentLinks []parentLink
+-	var imageIDsStr string
+-	var imageRefCount int
+ 
+ 	for _, m := range manifest {
+-		configPath, err := safePath(tmpDir, m.Config)
++		configPath, err := safePathWithTmp(m.LayersRoot, tmpDir, m.Config)
+ 		if err != nil {
+ 			return err
+ 		}
+@@ -93,7 +92,7 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
+ 		}
+ 
+ 		for i, diffID := range img.RootFS.DiffIDs {
+-			layerPath, err := safePath(tmpDir, m.Layers[i])
++			layerPath, err := safePathWithTmp(m.LayersRoot, tmpDir, m.Layers[i])
+ 			if err != nil {
+ 				return err
+ 			}
+@@ -117,25 +116,30 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
+ 		if err != nil {
+ 			return err
+ 		}
+-		imageIDsStr += fmt.Sprintf("Loaded image ID: %s\n", imgID)
+-
+-		imageRefCount = 0
++		var imageRefs []string
+ 		for _, repoTag := range m.RepoTags {
+ 			named, err := reference.ParseNormalizedNamed(repoTag)
+ 			if err != nil {
+-				return err
++				return fmt.Errorf("invalid image reference: %s", repoTag)
+ 			}
+-			ref, ok := named.(reference.NamedTagged)
+-			if !ok {
+-				return fmt.Errorf("invalid tag %q", repoTag)
++			if refSetErr := l.setLoadedNamedRef(named, imgID.Digest(), outStream); refSetErr == nil {
++				imageRefs = append(imageRefs, reference.FamiliarString(named))
++			} else {
++				logrus.Warnf("failed to set loaded image reference: %s", refSetErr.Error())
+ 			}
+-			l.setLoadedTag(ref, imgID.Digest(), outStream)
+-			outStream.Write([]byte(fmt.Sprintf("Loaded image: %s\n", reference.FamiliarString(ref))))
+-			imageRefCount++
+ 		}
+ 
+ 		parentLinks = append(parentLinks, parentLink{imgID, m.Parent})
+ 		l.loggerImgEvent.LogImageEvent(imgID.String(), imgID.String(), "load")
++		var imageIDsStr string
++		if len(imageRefs) > 0 {
++			imageIDsStr = fmt.Sprintf("Image loaded; refs: %s", strings.Join(imageRefs, ", "))
++		} else {
++			imageIDsStr = fmt.Sprintf("Image loaded; ID: %s", imgID)
++		}
++		if _, writeErr := outStream.Write([]byte(imageIDsStr)); writeErr != nil {
++			logrus.Warnf("failed to output loaded image IDs: %s", writeErr.Error())
++		}
+ 	}
+ 
+ 	for _, p := range validatedParentLinks(parentLinks) {
+@@ -146,10 +150,6 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
+ 		}
+ 	}
+ 
+-	if imageRefCount == 0 {
+-		outStream.Write([]byte(imageIDsStr))
+-	}
+-
+ 	return nil
+ }
+ 
+@@ -203,12 +203,19 @@ func (l *tarexporter) loadLayer(filename string, rootFS image.RootFS, id string,
+ 	return l.lss.Register(inflatedLayerData, rootFS.ChainID())
+ }
+ 
+-func (l *tarexporter) setLoadedTag(ref reference.Named, imgID digest.Digest, outStream io.Writer) error {
++func (l *tarexporter) setLoadedNamedRef(ref reference.Named, imgID digest.Digest, outStream io.Writer) error {
+ 	if prevID, err := l.rs.Get(ref); err == nil && prevID != imgID {
+ 		fmt.Fprintf(outStream, "The image %s already exists, renaming the old one with ID %s to empty string\n", reference.FamiliarString(ref), string(prevID)) // todo: this message is wrong in case of multiple tags
+ 	}
+-
+-	return l.rs.AddTag(ref, imgID, true)
++	switch specificRef := ref.(type) {
++	case reference.NamedTagged:
++		l.rs.AddTag(specificRef, imgID, true)
++	case reference.Canonical:
++		l.rs.AddDigest(specificRef, imgID, true)
++	default:
++		return fmt.Errorf("unsupported image reference type: %s", ref.String())
++	}
++	return nil
+ }
+ 
+ func (l *tarexporter) legacyLoad(tmpDir string, outStream io.Writer, progressOutput progress.Output) error {
+@@ -262,7 +269,7 @@ func (l *tarexporter) legacyLoad(tmpDir string, outStream io.Writer, progressOut
+ 			if err != nil {
+ 				return err
+ 			}
+-			l.setLoadedTag(ref, imgID.Digest(), outStream)
++			l.setLoadedNamedRef(ref, imgID.Digest(), outStream)
+ 		}
+ 	}
+ 
+@@ -371,6 +378,14 @@ func safePath(base, path string) (string, error) {
+ 	return symlink.FollowSymlinkInScope(filepath.Join(base, path), base)
+ }
+ 
++func safePathWithTmp(rootDir, tmp, path string) (string, error) {
++	root := rootDir
++	if len(root) == 0 {
++		root = tmp
++	}
++	return symlink.FollowSymlinkInScope(filepath.Join(root, path), root)
++}
++
+ type parentLink struct {
+ 	id, parentID image.ID
+ }
+diff --git a/image/tarexport/tarexport.go b/image/tarexport/tarexport.go
+index 5bcad2265c..b8ec6872f9 100644
+--- a/image/tarexport/tarexport.go
++++ b/image/tarexport/tarexport.go
+@@ -21,6 +21,7 @@ type manifestItem struct {
+ 	Layers       []string
+ 	Parent       image.ID                                 `json:",omitempty"`
+ 	LayerSources map[layer.DiffID]distribution.Descriptor `json:",omitempty"`
++	LayersRoot   string                                   `json:",omitempty"`
+ }
+ 
+ type tarexporter struct {
+-- 
+2.40.1
+


### PR DESCRIPTION
This patch helps to improve the image loading process that occurs at the App installation step. Specifically, image layers are not copied from the skopeo/OCI store to the docker temporal directory before their extraction to the docker store.
Instead, image layers are read directly from the skopeo store.

Also, this patch fixes a few minor issues the loader/tarexporter implementation.

To leverage the patch [this change to aklite](https://github.com/foundriesio/aktualizr-lite/pull/273. should be utilized.