### PR TITLE
base: uboot-fitimage: fix getting TEST_BASE address

### DIFF
--- a/meta-lmp-base/classes/uboot-fitimage.bbclass
+++ b/meta-lmp-base/classes/uboot-fitimage.bbclass
@@ -293,7 +293,8 @@ do_deploy:prepend() {
 				type_idx=$(expr $type_idx + 1);
 				if [ $type_idx -eq $machine_idx ]; then
 					cd ${B}/${config}
-					UBOOT_LOAD_ADDR=`grep 'define CONFIG_SYS_TEXT_BASE' u-boot.cfg | cut -d' ' -f 3`
+					# TODO: Rewrite getting UBOOT_LOAD_ADDR in more reliable manner
+					UBOOT_LOAD_ADDR=`grep -E 'define CONFIG_(SYS_)?TEXT_BASE' u-boot.cfg | cut -d' ' -f 3`
 					uboot_fitimage_assemble "${UBOOT_ITB_BINARY}" "${UBOOT_LOAD_ADDR}" "${OPTEE_LOAD_ADDR}" "${ATF_LOAD_ADDR}" "${SPL_FPGA_LOAD_ADDR}" "${BOOTSCR_LOAD_ADDR}"
 					uboot_fitimage_sign ${UBOOT_ITB_BINARY}
 					# Make SPL to generate a board-compatible binary via mkimage
@@ -326,7 +327,8 @@ do_deploy:prepend() {
 		unset machine_idx
 	else
 		cd ${B}
-		UBOOT_LOAD_ADDR=`grep 'define CONFIG_SYS_TEXT_BASE' u-boot.cfg | cut -d' ' -f 3`
+		# TODO: Rewrite getting UBOOT_LOAD_ADDR in more reliable manner
+		UBOOT_LOAD_ADDR=`grep -E 'define CONFIG_(SYS_)?TEXT_BASE' u-boot.cfg | cut -d' ' -f 3`
 		uboot_fitimage_assemble "${UBOOT_ITB_BINARY}" "${UBOOT_LOAD_ADDR}" "${OPTEE_LOAD_ADDR}" "${ATF_LOAD_ADDR}" "${SPL_FPGA_LOAD_ADDR}" "${BOOTSCR_LOAD_ADDR}"
 		uboot_fitimage_sign ${UBOOT_ITB_BINARY}
 		# Make SPL to generate a board-compatible binary via mkimage


### PR DESCRIPTION
The SYS_TEXT_BASE is renamed to TEXT_BASE. Improve a grep regex to cover both legacy and new name. This fixes the bug [1] in u-boot.itb that leads to load u-boot over the SPL and causes a crash [2].

[1]
...
 Image 0 (uboot)
  Description:  U-Boot no-dtb
  ...
  Load Address: 0x00000000
  Entry Point:  0x00000000
...

[2]
U-Boot SPL 2023.04+fio+g3ffd209fa1 (Sep 27 2023 - 13:31:56 +0000) ...
"Error" handler, esr 0xbf000002
elr: 00000000007ed498 lr : 00000000007e48b0
x 0: 0000000000000000 x 1: 00000000400ac090
x 2: 00000000000aa360 x 3: 0000000000000008
x 4: 0000000040200000 x 5: 00000000000aa4b4
x 6: 0000000000000002 x 7: 0000000000187a4c
x 8: 00000000400abfc0 x 9: 0000000000000002
x10: 00000000000aa4b8 x11: 0000000000187a6c
x12: 00000000400abfc0 x13: 00000000400abfc0
x14: 000000004e577609 x15: 00000000bef9a3f7
x16: 00000000007efffc x17: 00000000b9b85ae8
x18: 0000000000187e50 x19: 0000000000187c68
x20: 0000000000000064 x21: 00000000400abfc0
x22: 0000000000187c80 x23: 0000000000000000
x24: 00000000400ac090 x25: 0000000000187d28
x26: 0000000040400000 x27: 00000000007f9f11
x28: 00000000000000f0 x29: 0000000000187b80
...