### PR TITLE
base: u-boot-fio: add recipe for imx-2023.04

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-mfgtool_imx-2023.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-mfgtool_imx-2023.04.bb
@@ -1,0 +1,10 @@
+SUMMARY = "Produces a Manufacturing Tool compatible U-Boot"
+DESCRIPTION = "U-Boot recipe that produces a Manufacturing Tool compatible \
+binary to be used in updater environment"
+
+require recipes-bsp/u-boot/u-boot-fio_imx-2023.04.bb
+
+# Environment config is not required for mfgtool
+SRC_URI:remove = "file://fw_env.config"
+
+DEFAULT_PREFERENCE = "-1"

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2023.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2023.04.bb
@@ -1,0 +1,7 @@
+require u-boot-fio-common.inc
+
+SRCREV = "c621f7a30feb35db1c12ca786c1630c7f603e1f2"
+SRCBRANCH = "2023.04+lf-6.1.22-2.0.0-fio"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=2ca5f2c35c8cc335f0a19756634782f1"
+
+DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
Introduce FIO-specific recipes based on the NXP u-boot release lf-6.1.22-2.0.0.