### PR TITLE
chore(fioconfig): Revert back when ommitting tag

### DIFF
--- a/meta-lmp-base/recipes-support/fioconfig/fioconfig_git.bb
+++ b/meta-lmp-base/recipes-support/fioconfig/fioconfig_git.bb
@@ -11,7 +11,7 @@ SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO};branch=main \
 	file://fioconfig.path \
 	file://fioconfig-extract.service \
 "
-SRCREV = "c9469923f88cec496a9abce194d698fda0f3573d"
+SRCREV = "63231cd77d984e125a867c0bdcbc626b4802af7d"
 
 UPSTREAM_CHECK_COMMITS = "1"
 


### PR DESCRIPTION
Just update the reference for `fioconfig` to make it so that when you remove overrides from `z-50-fioctl.toml` it will relinquish control back to whatever is in `/var/sota/sota.toml`.

@rsalveti can you verify all is in order?