### PR TITLE
base: non-clangable: tegra: force gcc on container tools and gcc

### DIFF
--- a/meta-lmp-base/conf/distro/include/non-clangable.inc
+++ b/meta-lmp-base/conf/distro/include/non-clangable.inc
@@ -174,6 +174,11 @@ TOOLCHAIN:pn-trusted-firmware-a = "gcc"
 TOOLCHAIN:pn-nvdisp-init = "gcc"
 # edk2-tegra/edk2/MdeModulePkg/Include/Guid/ExtendedFirmwarePerformance.h:137:50: error: field Guid1 within 'FPDT_DUAL_GUID_STRING_EVENT_RECORD' is less aligned than 'EFI_GUID' (aka 'GUID') and is usually due to 'FPDT_DUAL_GUID_STRING_EVENT_RECORD' being packed, which can lead to unaligned accesses [-Werror,-Wunaligned-access]
 TOOLCHAIN:pn-edk2-firmware-tegra = "gcc"
+# libnvidia-container-tools: unknown argument: '-fplan9-extensions'
+TOOLCHAIN:pn-libnvidia-container-tools = "gcc"
+# configure: error: unrecognized option: `-flto'
+TOOLCHAIN:pn-libgcc-8 = "gcc"
+TOOLCHAIN:pn-gcc-8-runtime = "gcc"
 
 # stm32mp1
 TOOLCHAIN:pn-tf-a-stm32mp = "gcc"


### PR DESCRIPTION
Tools and recipes required for cuda and nvidia container runtime.