### PR TITLE
fix(aktualizr): Add User to Unit file

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr/aktualizr-lite.service.in
@@ -9,6 +9,7 @@ StartLimitBurst=3
 StartLimitAction=reboot
 
 [Service]
+User=root
 RestartSec=180
 Restart=always
 ExecStartPre=/usr/bin/mkdir -p /run/aktualizr


### PR DESCRIPTION
In order for the `docker compose` commands to be executed correctly from within `aktualizr` the `$HOME` environment variable needs to be present. This can be done in two ways, either we add the HOME environment variable to the already existing `Environment=` settings or we set the `User`. 

All code in golang, so far as I have seemed to determine, uses the `$HOME` to determine the user home directory through methods like `UserHomeDir`. 

There are two other ways to get the data, one is through `os.user.Lookup`/`os.user.LookupId` and the other is `user.Current()`. Meaning we could also patch the `docker compose` code in order to use this particular method rather than setting a hardcoded user. 