### PR TITLE
base: u-boot-fio: imx-2023.04: bump to c9892f0ea8a

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2023.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2023.04.bb
@@ -1,6 +1,6 @@
 require u-boot-fio-common.inc
 
-SRCREV = "c621f7a30feb35db1c12ca786c1630c7f603e1f2"
+SRCREV = "c9892f0ea8ab0e528f46805e87b96b7d2dc16514"
 SRCBRANCH = "2023.04+lf-6.1.22-2.0.0-fio"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=2ca5f2c35c8cc335f0a19756634782f1"
 


### PR DESCRIPTION
Relevant changes:
- c9892f0ea8a [FIO toup] fastboot: fb_fsl: add support for imx8mp and imx8mn
- a36dfbf2250 [FIO internal] common: support bootfirmware info in spl
- 8a9f935ae6c [FIO toup] board: freescale: mx6ul_14x14_evk: make DM-base serial driver work in SPL
- 0f33abed90b [FIO toup] arm: dts: imx6ul-14x14-evk-u-boot: enable uart1 in SPL
- 1c58c47b282 [FIO toup] board: freescale: mx6ullevk: make DM-base serial driver work in SPL
- f8736e83164 [FIO toup] arm: dts: imx6ull-14x14-evk-u-boot: enable uart1 in SPL
- 5534200c799 [FIO toup] board: mx6ullevk: add early UART pinmux initialization