### PR TITLE
lmp-el2go-auto-register: enable generic usage for subscriber secure objects

### DIFF
--- a/meta-lmp-base/recipes-support/lmp-el2go-auto-register/lmp-el2go-auto-register/lmp-el2go-auto-register
+++ b/meta-lmp-base/recipes-support/lmp-el2go-auto-register/lmp-el2go-auto-register/lmp-el2go-auto-register
@@ -66,25 +66,27 @@ class FioCli:
         ]
         run_quietly(args)
 
+    @classmethod
+    def import_key(cls, slot: str, label: str):
+        oid = label.replace("SE_", "0x")
+        args = [
+            "fio-se05x-cli",
+            "--token-label",
+            "aktualizr",
+            "--import-key",
+            oid,
+            "--pin",
+            PIN,
+            "--id",
+            slot,
+            "--key-type",
+            "EC:prime256v1",
+        ]
+        run_quietly(args)
+
 
 class Pkcs11:
     LIB = "/usr/lib/libckteec.so.0"
-
-    def import_crt(self, identifier: str, label: str):
-        FioCli.import_crt(identifier, label)
-
-    def import_key(self, slot: str, label: str):
-        args = [
-            "pkcs11-tool",
-            f"--module={self.LIB}",
-            f"--pin={PIN}",
-            "--keypairgen",
-            "--key-type=EC:prime256v1",
-            f"--id={slot}",
-            f"--label={label}",
-            "--token-label=aktualizr",
-        ]
-        run_quietly(args)
 
     def has_labels(self, labels: List[str]) -> bool:
         args = ["pkcs11-tool", f"--module={self.LIB}", f"--pin={PIN}", "--list-objects"]
@@ -150,8 +152,8 @@ class GenericKpHandler:
             log.info(f"Key {self.key_id} already provisioned")
             return
         log.info(f"Processing key {self.key_id}...")
-        pkcs11.import_key(f"{self.slot_num:02d}", key_label)
-        pkcs11.import_crt(f"{(self.slot_num+1):02d}", crt_label)
+        FioCli.import_key(f"{self.slot_num:02d}", key_label)
+        FioCli.import_crt(f"{(self.slot_num+1):02d}", crt_label)
 
 
 class AkliteKpHandler(NamedTuple):
@@ -180,8 +182,8 @@ class AkliteKpHandler(NamedTuple):
                 log.info("Aktualizr-lite keys in place")
         else:
             log.info("Processing keys for aktualizr-lite...")
-            pkcs11.import_key("01", key_label)
-            pkcs11.import_crt("03", crt_label)
+            FioCli.import_key("01", key_label)
+            FioCli.import_crt("03", crt_label)
 
         tag = self._get_tag()
         sota_toml = os.path.join(SOTA_DIR, "sota.toml")

--- a/meta-lmp-base/recipes-support/lmp-el2go-auto-register/lmp-el2go-auto-register/lmp-el2go-auto-register
+++ b/meta-lmp-base/recipes-support/lmp-el2go-auto-register/lmp-el2go-auto-register/lmp-el2go-auto-register
@@ -36,49 +36,50 @@ def run_quietly(args: List[str]):
         sys.exit(1)
 
 
+def SE_label(oid: int) -> str:
+    return f"SE_{oid:08x}"
+
 class FioCli:
     @classmethod
-    def _list_object(cls, oid: str) -> str:
-        args = ["fio-se05x-cli", "--list-objects", oid]
+    def _list_object(cls, oid: int) -> str:
+        args = ["fio-se05x-cli", "--list-objects", hex(oid)]
         process = subprocess.Popen(args, stdout=None, stderr=subprocess.PIPE)
         _, stderr = process.communicate()
         line = stderr.decode()
         return line
 
     @classmethod
-    def has_object(cls, oid: str) -> bool:
+    def has_object(cls, oid: int) -> bool:
         line = cls._list_object(oid)
         pattern = r"Key-Id:\s+(0x[0-9a-fA-F]+)"
         match = re.search(pattern, line)
         if match:
-            if match.group(1) == oid:
+            if int(match.group(1), 16) == oid:
                 return True
         return False
 
     @classmethod
-    def import_crt(self, identifier: str, label: str):
-        oid = label.replace("SE_", "0x")
+    def import_crt(self, identifier: str, oid: int):
         args = [
             "fio-se05x-cli",
             "--token-label",
             "aktualizr",
             "--import-cert",
-            oid,
+            f"0x{oid:08x}",
             "--id",
             identifier,
             "--label",
-            label,
+            SE_label(oid),
         ]
         run_quietly(args)
 
     @classmethod
-    def import_key(cls, slot: str, label: str):
-        oid = label.replace("SE_", "0x")
+    def import_key(cls, slot: str, oid: int):
         line = cls._list_object(oid)
         pattern = r"Key-Id:\s+(0x[0-9a-fA-F]+)\s+([A-Z_]+)\s+\[\s*([0-9]+) bits\]"
         match = re.search(pattern, line)
-        if not match or match.group(1) != oid:
-            log.error(f"Key {label} not found, not importing")
+        if not match or int(match.group(1), 16) != oid:
+            log.error(f"Key 0x{oid:08x} not found, not importing")
             return
         key_class = match.group(2)
         key_length = match.group(3)
@@ -92,13 +93,13 @@ class FioCli:
                 "521": "secp521r1",
             }
             if key_length not in ec_subtypes:
-                log.error(f"Unsupported key length {key_length} for EC key {label}")
+                log.error(f"Unsupported key length {key_length} for EC key 0x{oid:08x}")
                 return
             key_type = f"EC:{ec_subtypes[key_length]}"
         elif key_class == "RSA_KEY_PAIR_CRT":
             key_type = f"RSA:{key_length}"
         else:
-            log.error(f"Unsupported key type {key_class} for key {label}")
+            log.error(f"Unsupported key type {key_class} for key 0x{oid:08x}")
             return
 
         args = [
@@ -106,7 +107,7 @@ class FioCli:
             "--token-label",
             "aktualizr",
             "--import-key",
-            oid,
+            f"0x{oid:08x}",
             "--pin",
             PIN,
             "--id",
@@ -171,26 +172,22 @@ def run_agent() -> bool:
 
 class GenericKpHandler:
     def __init__(self, key_id: str, slot_num: int):
-        key_id_int = int(key_id, 16)
-        crt_id_int = key_id_int + 1
-        self.key_id = f"0x{key_id_int:x}"
-        self.crt_id = f"0x{crt_id_int:x}"
+        self.key_id = int(key_id, 16)
+        self.crt_id = self.key_id + 1
         self.slot_num = slot_num
 
     def process(self, pkcs11: Pkcs11):
-        key_label = self.key_id.replace("0x", "SE_")
-        crt_label = self.crt_id.replace("0x", "SE_")
-        if pkcs11.has_labels([key_label, crt_label]):
-            log.info(f"Key {self.key_id} already provisioned")
+        if pkcs11.has_labels([SE_label(self.key_id), SE_label(self.crt_id)]):
+            log.info(f"Key {self.key_id:08x} already provisioned")
             return
-        log.info(f"Processing key {self.key_id}...")
-        FioCli.import_key(f"{self.slot_num:02d}", key_label)
-        FioCli.import_crt(f"{(self.slot_num+1):02d}", crt_label)
+        log.info(f"Processing key {self.key_id:08x}...")
+        FioCli.import_key(f"{self.slot_num:02d}", self.key_id)
+        FioCli.import_crt(f"{(self.slot_num+1):02d}", self.crt_id)
 
 
 class AkliteKpHandler(NamedTuple):
-    key_id: str = "0x83000042"
-    crt_id: str = "0x83000043"
+    key_id = 0x83000042
+    crt_id = 0x83000043
 
     @staticmethod
     def _get_tag():
@@ -203,10 +200,7 @@ class AkliteKpHandler(NamedTuple):
         sys.exit("Unable to parse LMP_MACHINE and LMP_TAG from /etc/os-release")
 
     def process(self, pkcs11: Pkcs11):
-        key_label = self.key_id.replace("0x", "SE_")
-        crt_label = self.crt_id.replace("0x", "SE_")
-
-        if pkcs11.has_labels([key_label, crt_label]):
+        if pkcs11.has_labels([SE_label(self.key_id), SE_label(self.crt_id)]):
             if os.path.exists(os.path.join(SOTA_DIR, "sql.db")):
                 log.info("Aktualizr-lite already provisioned")
                 return
@@ -214,8 +208,8 @@ class AkliteKpHandler(NamedTuple):
                 log.info("Aktualizr-lite keys in place")
         else:
             log.info("Processing keys for aktualizr-lite...")
-            FioCli.import_key("01", key_label)
-            FioCli.import_crt("03", crt_label)
+            FioCli.import_key("01", self.key_id)
+            FioCli.import_crt("03", self.crt_id)
 
         tag = self._get_tag()
         sota_toml = os.path.join(SOTA_DIR, "sota.toml")

--- a/meta-lmp-base/recipes-support/lmp-el2go-auto-register/lmp-el2go-auto-register/lmp-el2go-auto-register
+++ b/meta-lmp-base/recipes-support/lmp-el2go-auto-register/lmp-el2go-auto-register/lmp-el2go-auto-register
@@ -18,7 +18,6 @@ DAEMON_INTERVAL = os.environ.get("DAEMON_INTERVAL", "300")
 PIN = os.environ.get("PKCS11_PIN", "87654321")
 SO_PIN = os.environ.get("PKCS11_SOPIN", "12345678")
 SOTA_DIR = os.environ.get("SOTA_DIR", "/var/sota")
-HANDLERS = os.environ.get("HANDLERS", "aws-iot,aktualizr-lite")
 PACMAN_TYPE = os.environ.get("PACMAN_TYPE", "ostree+compose_apps")
 
 REPO_ID = os.environ["REPOID"]
@@ -223,19 +222,17 @@ tls_clientcert_id = "03"
 
 
 def main():
-    handlers = {
-        "aws-iot": AwsKpHandler(),
-        "aktualizr-lite": AkliteKpHandler(),
-    }
-    handler_names = [x.strip() for x in HANDLERS.split(",") if x]
+    handlers = [
+        AwsKpHandler(),
+        AkliteKpHandler(),
+    ]
 
     interval = int(DAEMON_INTERVAL)
     pkcs11 = Pkcs11.get_initialized()
 
     while True:
         if run_agent():
-            for name in handler_names:
-                handler = handlers[name]
+            for handler in handlers:
                 if FioCli.has_object(handler.key_id):
                     if FioCli.has_object(handler.crt_id):
                         handler.process(pkcs11)

--- a/meta-lmp-base/recipes-support/lmp-el2go-auto-register/lmp-el2go-auto-register/lmp-el2go-auto-register
+++ b/meta-lmp-base/recipes-support/lmp-el2go-auto-register/lmp-el2go-auto-register/lmp-el2go-auto-register
@@ -18,6 +18,7 @@ DAEMON_INTERVAL = os.environ.get("DAEMON_INTERVAL", "300")
 PIN = os.environ.get("PKCS11_PIN", "87654321")
 SO_PIN = os.environ.get("PKCS11_SOPIN", "12345678")
 SOTA_DIR = os.environ.get("SOTA_DIR", "/var/sota")
+GENERIC_KEYPAIRS = os.environ.get("GENERIC_KEYPAIRS", "0X83000044")
 PACMAN_TYPE = os.environ.get("PACMAN_TYPE", "ostree+compose_apps")
 
 REPO_ID = os.environ["REPOID"]
@@ -134,19 +135,23 @@ def run_agent() -> bool:
     return True
 
 
-class AwsKpHandler(NamedTuple):
-    key_id: str = "0x83000044"
-    crt_id: str = "0x83000045"
+class GenericKpHandler:
+    def __init__(self, key_id: str, slot_num: int):
+        key_id_int = int(key_id, 16)
+        crt_id_int = key_id_int + 1
+        self.key_id = f"0x{key_id_int:x}"
+        self.crt_id = f"0x{crt_id_int:x}"
+        self.slot_num = slot_num
 
     def process(self, pkcs11: Pkcs11):
         key_label = self.key_id.replace("0x", "SE_")
         crt_label = self.crt_id.replace("0x", "SE_")
         if pkcs11.has_labels([key_label, crt_label]):
-            log.info("aws-iot already provisioned")
+            log.info(f"Key {self.key_id} already provisioned")
             return
-        log.info("Processing keys for aws-iot...")
-        pkcs11.import_key("04", key_label)
-        pkcs11.import_crt("05", crt_label)
+        log.info(f"Processing key {self.key_id}...")
+        pkcs11.import_key(f"{self.slot_num:02d}", key_label)
+        pkcs11.import_crt(f"{(self.slot_num+1):02d}", crt_label)
 
 
 class AkliteKpHandler(NamedTuple):
@@ -222,10 +227,16 @@ tls_clientcert_id = "03"
 
 
 def main():
-    handlers = [
-        AwsKpHandler(),
-        AkliteKpHandler(),
-    ]
+    generic_keypairs = GENERIC_KEYPAIRS.split(",")
+    handlers = []
+    # slot_num starts at 4 because 1 and 3 are used by aktualizr.
+    # It increments with 2 (one for key, one for cert), so we count half slot_num
+    for half_slot_num, key_id in enumerate(generic_keypairs, 2):
+        try:
+            handlers.append(GenericKpHandler(key_id, 2*half_slot_num))
+        except ValueError:
+            log.error(f"Invalid generic keypair {key_id} - should be formatted as 0X....")
+    handlers.append(AkliteKpHandler())
 
     interval = int(DAEMON_INTERVAL)
     pkcs11 = Pkcs11.get_initialized()

--- a/meta-lmp-base/recipes-support/lmp-el2go-auto-register/lmp-el2go-auto-register/lmp-el2go-auto-register
+++ b/meta-lmp-base/recipes-support/lmp-el2go-auto-register/lmp-el2go-auto-register/lmp-el2go-auto-register
@@ -38,11 +38,16 @@ def run_quietly(args: List[str]):
 
 class FioCli:
     @classmethod
-    def has_object(self, oid: str) -> bool:
+    def _list_object(cls, oid: str) -> str:
         args = ["fio-se05x-cli", "--list-objects", oid]
         process = subprocess.Popen(args, stdout=None, stderr=subprocess.PIPE)
         _, stderr = process.communicate()
         line = stderr.decode()
+        return line
+
+    @classmethod
+    def has_object(cls, oid: str) -> bool:
+        line = cls._list_object(oid)
         pattern = r"Key-Id:\s+(0x[0-9a-fA-F]+)"
         match = re.search(pattern, line)
         if match:
@@ -69,6 +74,33 @@ class FioCli:
     @classmethod
     def import_key(cls, slot: str, label: str):
         oid = label.replace("SE_", "0x")
+        line = cls._list_object(oid)
+        pattern = r"Key-Id:\s+(0x[0-9a-fA-F]+)\s+([A-Z_]+)\s+\[\s*([0-9]+) bits\]"
+        match = re.search(pattern, line)
+        if not match or match.group(1) != oid:
+            log.error(f"Key {label} not found, not importing")
+            return
+        key_class = match.group(2)
+        key_length = match.group(3)
+        if key_class == "EC_KEY_PAIR":
+            # OpenSSL has different EC key types depending on length
+            ec_subtypes = {
+                "192": "prime192v1",
+                "224": "secp224r1",
+                "256": "prime256v1",
+                "384": "secp384r1",
+                "521": "secp521r1",
+            }
+            if key_length not in ec_subtypes:
+                log.error(f"Unsupported key length {key_length} for EC key {label}")
+                return
+            key_type = f"EC:{ec_subtypes[key_length]}"
+        elif key_class == "RSA_KEY_PAIR_CRT":
+            key_type = f"RSA:{key_length}"
+        else:
+            log.error(f"Unsupported key type {key_class} for key {label}")
+            return
+
         args = [
             "fio-se05x-cli",
             "--token-label",
@@ -80,7 +112,7 @@ class FioCli:
             "--id",
             slot,
             "--key-type",
-            "EC:prime256v1",
+            key_type,
         ]
         run_quietly(args)
 


### PR DESCRIPTION
This PR makes various improvements to lmp-el2go-auto-register. The main goal is to make it more useful for a subscriber who wants to use EdgeLock 2GO to manage their own secure objects.

Currently only two secure objects are handled: Foundries and AWS IoT. The mechanism used for AWS IoT can however easily be applied more generically to any keypair and certificate that a subscriber wants to provision through EdgeLock 2GO. 

Subscriber keypairs may use an algorithm other than P-256, so support for that is added as well. However, this part is largely untested - in the end we used P-256 after all, so I didn't get around to test all the others, and our SE050 variant doesn't support P-384 and P-521.

We happen to use OID 0x5010 in our tests, and it turns out that the processing of labels didn't work correctly with smaller OIDs. The final patch fixes that bug.

The other patches are cleanups and enablers.

The documentation is updated accordingly: https://github.com/foundriesio/docs/pull/611