### PR TITLE
base: u-boot-fio: imx-2022.04: bump to 605d0aa5c0

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
@@ -1,6 +1,6 @@
 require u-boot-fio-common.inc
 
-SRCREV = "d7db7d85cdae692ddda43c4b8b06910c9d610919"
+SRCREV = "605d0aa5c016915058c7b19051f76d592e103b32"
 SRCBRANCH = "2022.04+lf-6.1.1-1.0.0-fio"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 


### PR DESCRIPTION
Relevant changes:
- 605d0aa5c0 [FIO toup] fastboot: fb_fsl: add support for imx8mp and imx8mn
- bb09b00e62 [FIO internal] common: support bootfirmware info in spl