### PR TITLE
tpm2-tss: fix Upstream-Status of patch

### DIFF
--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-tss/tpm2-tss/fixup_hosttools.patch
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-tss/tpm2-tss/fixup_hosttools.patch
@@ -2,7 +2,7 @@ revert configure: add checks for all tools used by make install
 
 Not appropriate for cross build env.
 
-Upstream-Status: OE [inappropriate]
+Upstream-Status: Inappropriate [OE Specific]
 Signed-off-by: Armin Kuster <akuster808@gmail.com>
 
 Index: tpm2-tss-4.0.1/configure.ac


### PR DESCRIPTION
Quiet a warning in Layer Index update check:
WARNING: Invalid upstream status in /opt/workdir/https___github_com_foundriesio_meta-lmp/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-tss/tpm2-tss/fixup_hosttools.patch: Upstream-Status: OE [inappropriate]

https://docs.yoctoproject.org/contributor-guide/recipe-style-guide.html#patch-upstream-status