### PR TITLE
base: rs: aktualizr: Bump aklite ver to 2afacef

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "a8d0bfe81f70ef2af3e6f7ceb19d0a98eca3b31a"
+SRCREV:lmp = "2afacef575719f83da3b99bf4c3f7226bd09a89d"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
Relevant changes:
- b38db4c offline: Don't allow downgrade by default
- df9aa8f offline: Fix --log-level option
- d1cfcb4 offline: Add sub-command to check update source dir
- 1efffdc offline: Add "current" subcommand