### PR TITLE
bsp: lmp-machine-custom: remove sota override from UBOOT_SIGN_KEYDIR in k3

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -620,7 +620,7 @@ WKS_FILES:sota:versal = "sdimage-sota.wks"
 
 # TI Generic (BSP)
 UBOOT_SIGN_ENABLE:sota:k3 = "1"
-UBOOT_SIGN_KEYDIR:sota:k3 ?= "${TOPDIR}/conf/keys"
+UBOOT_SIGN_KEYDIR:k3 = "${TOPDIR}/conf/keys"
 FIT_HASH_ALG:sota:k3 ?= "sha256"
 FIT_SIGN_ALG:sota:k3 ?= "rsa2048"
 KERNEL_IMAGETYPE:sota:k3 = "fitImage"


### PR DESCRIPTION
The value defined on meta-ti prevails so we need to change this not only when sota is enabled but always.
    
This affects mfgtool-am62xx-evm after lmp-signing.bbclass was merged because teh keys defined in TI bsp not found:
    
```
ERROR: /lmp/build-lmp-mfgtool-am62xx-evm-initrd-rebuild-container/conf/../../layers/meta-lmp/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx-xeno4_git.bb: SIGNING_UBOOT_SIGN_KEY=${TI_SECURE_DEV_PKG}/keys/ubootdev.key is not a file.
ERROR: /lmp/build-lmp-mfgtool-am62xx-evm-initrd-rebuild-container/conf/../../layers/meta-ti/meta-ti-bsp/recipes-kernel/linux/linux-ti-staging-systest_5.10.bb: SIGNING_UBOOT_SIGN_KEY=${TI_SECURE_DEV_PKG}/keys/ubootdev.key is not a file.
ERROR: /lmp/build-lmp-mfgtool-am62xx-evm-initrd-rebuild-container/conf/../../layers/meta-ti/meta-ti-bsp/recipes-kernel/linux/linux-ti-staging-systest_6.1.bb: SIGNING_UBOOT_SIGN_KEY=/lmp/build-lmp-mfgtool-am62xx-evm-initrd-rebuild-container/tmp-lmp_mfgtool/work/am62xx_evm-lmp-linux/linux-ti-staging-systest/6.1.33+gitAUTOINC+8f7f371be2-r0b/recipe-sysroot-native/usr/share/ti/ti-k3-secdev/keys/ubootdev.key is not a file.
```