### PR TITLE
bsp: support: mfgtool-files: imx8qm-mek: replace "reboot" command

### DIFF
--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek-sec/close.uuu
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek-sec/close.uuu
@@ -34,6 +34,6 @@ FB: ucmd setenv srk_14 0x6E0B791C
 FB: ucmd setenv srk_15 0x6A558134
 
 FB[-t 1000]: ucmd if fiohab_close; then echo Platform Secured; else echo Error, Can Not Secure the Platform; sleep 2; fi
-FB: acmd reboot
+FB: acmd reset
 
 FB: done

--- a/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek-sec/fuse.uuu
+++ b/meta-lmp-bsp/recipes-support/mfgtool-files/mfgtool-files/imx8qm-mek-sec/fuse.uuu
@@ -31,5 +31,5 @@ FB: ucmd fuse prog -y 0 735 0x8273EBD2
 FB: ucmd fuse prog -y 0 736 0x6E0B791C
 FB: ucmd fuse prog -y 0 737 0x6A558134
 
-FB: acmd reboot
+FB: acmd reset
 fb: done


### PR DESCRIPTION
"reboot" command is not available for apalis-imx8 u-boot,
so replace it with "reset".