### PR TITLE
bsp: linux-lmp-fslc-imx: imx8mm-evk: fix compatible node on evka

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-FIO-extras-arm64-dts-imx8mm-evk-use-imx8mm-evkb-for-.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-FIO-extras-arm64-dts-imx8mm-evk-use-imx8mm-evkb-for-.patch
@@ -1,4 +1,4 @@
-From a11faaaf345da8f047129744c6e5b17e417addf7 Mon Sep 17 00:00:00 2001
+From a47f2cef1ce51c81e238622d5a3c6b20353f56d0 Mon Sep 17 00:00:00 2001
 From: Ricardo Salveti <ricardo@foundries.io>
 Date: Fri, 14 May 2021 13:36:10 -0300
 Subject: [PATCH] [FIO extras] arm64: dts: imx8mm-evk: use imx8mm-evkb for the
@@ -8,6 +8,8 @@ Allow older EVKs to be transitioned properly by using a new dtb for the
 EVKB variant.
 
 Main difference is the pmic used (bd71847 -> pca9450).
+
+Upstream-Status: Inappropriate [configuration]
 
 Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
 Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
@@ -22,20 +24,20 @@ Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
  .../freescale/imx8mm-evk-iqaudio-dacpro.dts   |  69 ++++++++-
  .../boot/dts/freescale/imx8mm-evk-lk.dts      |   2 +-
  .../boot/dts/freescale/imx8mm-evk-pcie-ep.dts |   2 +-
- .../dts/freescale/imx8mm-evk-qca-wifi.dts     |   2 +-
+ .../dts/freescale/imx8mm-evk-qca-wifi.dts     |   3 +-
  .../boot/dts/freescale/imx8mm-evk-rm67191.dts |   2 +-
  .../boot/dts/freescale/imx8mm-evk-root.dts    |   2 +-
  .../boot/dts/freescale/imx8mm-evk-rpmsg.dts   |   2 +-
  .../dts/freescale/imx8mm-evk-usd-wifi.dts     |   2 +-
  arch/arm64/boot/dts/freescale/imx8mm-evk.dts  | 139 +----------------
  arch/arm64/boot/dts/freescale/imx8mm-evkb.dts | 142 ++++++++++++++++++
- 17 files changed, 226 insertions(+), 152 deletions(-)
+ 17 files changed, 227 insertions(+), 152 deletions(-)
  mode change 100755 => 100644 arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts
  mode change 100755 => 100644 arch/arm64/boot/dts/freescale/imx8mm-evk.dts
  create mode 100644 arch/arm64/boot/dts/freescale/imx8mm-evkb.dts
 
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-8mic-revE.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-8mic-revE.dts
-index ba397b00a033..bd08a6f4f335 100644
+index 5facaecc733f..36d70369af08 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-8mic-revE.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-8mic-revE.dts
 @@ -3,7 +3,7 @@
@@ -48,7 +50,7 @@ index ba397b00a033..bd08a6f4f335 100644
  / {
  	mic_leds {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-ak4497.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-ak4497.dts
-index 18aacba546f6..e2611cc23a28 100644
+index ca8e5d7b35d8..4cf5b10b55a6 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-ak4497.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-ak4497.dts
 @@ -3,7 +3,7 @@
@@ -74,7 +76,7 @@ index 4d3da8e33688..149b5cf67ce7 100644
  / {
  	sound-ak5558 {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-dpdk.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-dpdk.dts
-index 3b5503933a35..ff497006ca07 100644
+index e600a7208c1f..08a4c3232ccf 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-dpdk.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-dpdk.dts
 @@ -3,7 +3,7 @@
@@ -84,8 +86,8 @@ index 3b5503933a35..ff497006ca07 100644
 -#include "imx8mm-evk.dts"
 +#include "imx8mm-evkb.dts"
  
- &fec1 {
- 	compatible = "fsl,imx8mm-fec-uio";
+ &ethphy0 {
+ 	/delete-property/ reset-assert-us;
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-ecspi-slave.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-ecspi-slave.dts
 index e06dbc00d9dc..b0670f2cde37 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-ecspi-slave.dts
@@ -237,10 +239,10 @@ index 2f96420e3230..61202cae7f3b 100644
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts
 old mode 100755
 new mode 100644
-index aa1a25f00f55..b5cbf6882e5e
+index aa1a25f00f55..b5cbd103880d
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts
-@@ -5,7 +5,7 @@
+@@ -5,10 +5,11 @@
  
  /dts-v1/;
  
@@ -249,6 +251,10 @@ index aa1a25f00f55..b5cbf6882e5e
  
  / {
  	model = "FSL i.MX8MM LPDDR4 EVK with QCA WIFI revC board ";
++	compatible = "fsl,imx8mm-evk", "fsl,imx8mm";
+ };
+ 
+ /delete-node/&pmic_nxp;
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-rm67191.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-rm67191.dts
 index 958912c409b2..d6563b7a41da 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-rm67191.dts
@@ -276,7 +282,7 @@ index 426b0adc31ce..3986daaec096 100644
  / {
  	interrupt-parent = <&gic>;
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-rpmsg.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-rpmsg.dts
-index dc3e2ef9347d..0b74c2efea1c 100644
+index 2a477c74b634..46e817739e9f 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-rpmsg.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-rpmsg.dts
 @@ -5,7 +5,7 @@


### PR DESCRIPTION
Upstream dts changes caused the evkb model to also be included in the evka dts file, causing a bug at userspace when trying to identify if hciattach should be executed or not (as it depends on evkb).