### PR TITLE
base: u-boot-fio-common: change config include order

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-common.inc
@@ -17,8 +17,8 @@ SRC_URI = "${UBOOT_REPO};protocol=https;branch=${SRCBRANCH} \
 # Handle lmp / lmp-mfgtool distro configs set
 SRC_URI:append = " \
     ${@bb.utils.contains('MACHINE_FEATURES', 'ebbr', 'file://lmp-ebbr-common.cfg', 'file://lmp-common.cfg', d)} \
-    ${@bb.utils.contains('MACHINE_FEATURES', 'ebbr', 'file://lmp-ebbr.cfg', 'file://lmp.cfg', d)} \
     ${@bb.utils.contains('UBOOT_SIGN_ENABLE', '1', '', 'file://lmp-common-nosec.cfg', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'ebbr', 'file://lmp-ebbr.cfg', 'file://lmp.cfg', d)} \
 "
 
 # LMP base requires different u-boot configuration fragments


### PR DESCRIPTION
Make the machine specific configuration fragment (lmp-ebbr or lmp.cfg) be the last one in the fragments list so it can have higher priority.

This allows the machine specific config to replace any option that is set in another fragment that is parsed before it.