### PR TITLE
base: non-clangable: add qoriq-atf

### DIFF
--- a/meta-lmp-base/conf/distro/include/non-clangable.inc
+++ b/meta-lmp-base/conf/distro/include/non-clangable.inc
@@ -160,6 +160,7 @@ TOOLCHAIN:pn-optee-os-fio-mfgtool = "gcc"
 
 # imx targets (not reproducible)
 TOOLCHAIN:pn-imx-atf = "gcc"
+TOOLCHAIN:pn-qoriq-atf = "gcc"
 
 # kv260
 # vck190-versal


### PR DESCRIPTION
Similar to imx-atf (named differently due SoC differences but same source).