### PR TITLE
bsp: base-files: fstab: enable file system check on boot

### DIFF
--- a/meta-lmp-bsp/recipes-core/base-files/base-files/am62xx-evm/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/am62xx-evm/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-LABEL=boot           /mnt/boot            vfat       noatime,sync          0  0
+LABEL=boot           /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/am64xx-evm/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/am64xx-evm/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-LABEL=boot           /mnt/boot            vfat       noatime,sync          0  0
+LABEL=boot           /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/beaglebone-yocto/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/beaglebone-yocto/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-LABEL=boot           /mnt/boot            vfat       noatime,sync          0  0
+LABEL=boot           /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/beagleplay/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/beagleplay/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-LABEL=boot           /mnt/boot            vfat       noatime,sync          0  0
+LABEL=boot           /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/imx6ulevk/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/imx6ulevk/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-LABEL=boot           /mnt/boot            vfat       noatime,sync          0  0
+LABEL=boot           /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/imx6ullevk/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/imx6ullevk/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-LABEL=boot           /mnt/boot            vfat       noatime,sync          0  0
+LABEL=boot           /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/imx7ulpea-ucom/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/imx7ulpea-ucom/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-/dev/mmcblk0p1       /mnt/boot            vfat       noatime,sync          0  0
+/dev/mmcblk0p1       /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/imx8mm-lpddr4-evk/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/imx8mm-lpddr4-evk/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-/dev/mmcblk2p1       /mnt/boot            vfat       noatime,sync          0  0
+/dev/mmcblk2p1       /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/imx8mn-ddr4-evk/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/imx8mn-ddr4-evk/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-/dev/mmcblk2p1       /mnt/boot            vfat       noatime,sync          0  0
+/dev/mmcblk2p1       /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/imx8mn-lpddr4-evk/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/imx8mn-lpddr4-evk/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-/dev/mmcblk2p1       /mnt/boot            vfat       noatime,sync          0  0
+/dev/mmcblk2p1       /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/imx8mp-lpddr4-evk/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/imx8mp-lpddr4-evk/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-/dev/mmcblk2p1       /mnt/boot            vfat       noatime,sync          0  0
+/dev/mmcblk2p1       /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/imx8mq-evk/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/imx8mq-evk/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-/dev/mmcblk0p1       /mnt/boot            vfat       noatime,sync          0  0
+/dev/mmcblk0p1       /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/imx8qm-mek/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/imx8qm-mek/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-LABEL=boot           /mnt/boot            vfat       noatime,sync          0  0
+LABEL=boot           /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/imx8ulp-lpddr4-evk/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/imx8ulp-lpddr4-evk/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-/dev/mmcblk0p1       /mnt/boot            vfat       noatime,sync          0  0
+/dev/mmcblk0p1       /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/imx93-11x11-lpddr4x-evk/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/imx93-11x11-lpddr4x-evk/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-/dev/mmcblk0p1       /mnt/boot            vfat       noatime,sync          0  0
+/dev/mmcblk0p1       /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/k26/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/k26/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-LABEL=boot           /mnt/boot            vfat       noatime,sync          0  0
+LABEL=boot           /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/qemuarm/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/qemuarm/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-/dev/vda1            /mnt/boot            vfat       noatime,sync          0  0
+/dev/vda1            /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/qemuarm64/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/qemuarm64/fstab
@@ -5,6 +5,6 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # vfat boot partition
-/dev/vda1            /mnt/boot            vfat       noatime,sync          0  0
+/dev/vda1            /mnt/boot            vfat       noatime,sync          0  2
 # ostree boot partition
-/dev/vda2            /boot                ext4       defaults              0  1
+/dev/vda2            /boot                ext4       defaults              0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/qemuriscv64/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/qemuriscv64/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-/dev/vda1            /mnt/boot            vfat       noatime,sync          0  0
+/dev/vda1            /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/rpi/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/rpi/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-/dev/mmcblk0p1       /mnt/boot            vfat       noatime,sync          0  0
+/dev/mmcblk0p1       /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/sun8i/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/sun8i/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-/dev/mmcblk0p1       /mnt/boot            vfat       noatime,sync          0  0
+/dev/mmcblk0p1       /mnt/boot            vfat       noatime,sync          0  2

--- a/meta-lmp-bsp/recipes-core/base-files/base-files/uz/fstab
+++ b/meta-lmp-bsp/recipes-core/base-files/base-files/uz/fstab
@@ -5,4 +5,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # boot partition
-LABEL=boot           /mnt/boot            vfat       noatime,sync          0  0
+LABEL=boot           /mnt/boot            vfat       noatime,sync          0  2


### PR DESCRIPTION
Enable file system check on boot mounts by default to avoid corrupted vfat partitions that can later block the boot process.