### PR TITLE
bsp: lmp-machine-custom: UBOOT_SIGN_KEYDIR for TI k3 should be weak assinged

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -641,7 +641,7 @@ WKS_FILES:sota:versal = "sdimage-sota.wks"
 
 # TI Generic (BSP)
 UBOOT_SIGN_ENABLE:sota:k3 = "1"
-UBOOT_SIGN_KEYDIR:k3 = "${TOPDIR}/conf/keys"
+UBOOT_SIGN_KEYDIR:k3 ?= "${TOPDIR}/conf/keys"
 FIT_HASH_ALG:sota:k3 ?= "sha256"
 FIT_SIGN_ALG:sota:k3 ?= "rsa2048"
 KERNEL_IMAGETYPE:sota:k3 = "fitImage"


### PR DESCRIPTION
The commit cb51e303 removes the sota override but also inadvertently the weak assinged.
Restore the weak assinged so that is possible to use the '=' to override this defenitions on the factory.
