### PR TITLE
base: lmp: ota-esp is only needed when sota is enabled

### DIFF
--- a/meta-lmp-base/classes/lmp.bbclass
+++ b/meta-lmp-base/classes/lmp.bbclass
@@ -3,7 +3,9 @@ FIO_PUSH_CMD ?= "fiopush"
 FIO_CHECK_CMD ?= "fiocheck"
 SOTA_TUF_ROOT_DIR ?= "usr/lib/sota/tuf"
 
-IMAGE_FSTYPES += "${@bb.utils.contains('EFI_PROVIDER', 'systemd-boot', 'ota-esp', ' ', d)}"
+IMAGE_FSTYPES_OTA ?= ""
+IMAGE_FSTYPES_OTA:sota = "${@bb.utils.contains('EFI_PROVIDER', 'systemd-boot', 'ota-esp', '', d)}"
+IMAGE_FSTYPES += "${IMAGE_FSTYPES_OTA}"
 
 # Provided by meta-lmp-bsp or any other compatible BSP layer
 include conf/machine/include/lmp-machine-custom.inc


### PR DESCRIPTION
Without this change lmp-base distro fails to build and other without sota DISTRO_FEATURES will still fail the same way.