### PR TITLE
base: u-boot-ostree-scr-fit: add var for enabling rb protection

### DIFF
--- a/meta-lmp-base/conf/distro/lmp.conf
+++ b/meta-lmp-base/conf/distro/lmp.conf
@@ -58,3 +58,6 @@ OSTREE_WKS_BOOT_SIZE ?= "--size 200M --overhead-factor 1"
 # This is needed to move fontcache for all installed packages
 # from /var/cache/fontconfig to /usr/lib/fontconfig/cache
 FONTCONFIG_CACHE_DIR = "${libdir}/fontconfig/cache"
+
+# Boot firmware rollback protection
+LMP_ROLLBACK_PROTECTION_ENABLE ??= "0"

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit.bb
@@ -43,6 +43,7 @@ do_compile() {
 			boot.cmd.in
 	sed -e 's/@@FIT_NODE_SEPARATOR@@/${FIT_NODE_SEPARATOR}/g' \
 	    -e 's/@@OSTREE_SPLIT_BOOT@@/${OSTREE_SPLIT_BOOT}/g' \
+	    -e 's/@@LMP_ROLLBACK_PROTECTION_ENABLE@@/${LMP_ROLLBACK_PROTECTION_ENABLE}/g' \
 	    -e 's/@@OSTREE_DEPLOY_USR_OSTREE_BOOT@@/${OSTREE_DEPLOY_USR_OSTREE_BOOT}/g' \
 			boot.cmd.in > boot.cmd
 	sed -e 's/@@FIT_HASH_ALG@@/${FIT_HASH_ALG}/' \

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-header.cmd.in
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-ostree-scr-fit/boot-header.cmd.in
@@ -86,6 +86,20 @@ else
 	setenv fiovb.debug "${debug}"
 fi
 
+# Add a line that force enables rollback protection if
+# LMP_ROLLBACK_PROTECTION_ENABLE flag was set.
+setenv rollback_force_protection_enable "@@LMP_ROLLBACK_PROTECTION_ENABLE@@"
+
+if test "${rollback_force_protection_enable}" = "1" && test "${fiovb.rollback_protection}" = "0"; then
+	setenv fiovb.rollback_protection "1"
+	# we also enable it in ubootenv/fiovb, so userland knows it's enabled
+	if test -n "${fiovb_rpmb}"; then
+		fiovb write_pvalue rollback_protection 1;
+	else
+		setenv rollback_protection 1;
+	fi
+fi
+
 if test "${fiovb.debug}" = "1"; then
 	echo "${fio_msg} ################ Debug info ###############"
 	echo "${fio_msg} State machine variables:"


### PR DESCRIPTION
Add LMP_ROLLBACK_PROTECTION_ENABLE variable for enabling rollback protection during build time.
If it is set U-Boot boot.cmd script will automatically force enable rollback protection during first run.