### PR TITLE
base: lmp-staging: lmp_sstate_checkhashes: remove multiple spaces

### DIFF
--- a/meta-lmp-base/classes/lmp-staging.bbclass
+++ b/meta-lmp-base/classes/lmp-staging.bbclass
@@ -38,6 +38,7 @@ def lmp_sstate_checkhashes(sq_data, d, **kwargs):
     if 'summary' not in kwargs or kwargs.get('summary'):
         mirrors = d.getVar("SSTATE_MIRRORS")
         if mirrors:
+            mirrors = " ".join(mirrors.split())
             bb.plain("SState mirrors: %s" % mirrors)
     return sstate_checkhashes(sq_data, d, **kwargs)
 


### PR DESCRIPTION
When we have more than one mirror it will be good to remove extra spaces and tabs.