### PR TITLE
Lmp disable gplv3 init install efi

### DIFF
--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-module-install-efi_%.bbappend
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-module-install-efi_%.bbappend
@@ -1,3 +1,5 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-RDEPENDS:${PN} += "efibootmgr"
+# Prefer gptfdisk instead of parted
+RDEPENDS:${PN}:remove = "parted dosfstools"
+RDEPENDS:${PN} += "efibootmgr gptfdisk"


### PR DESCRIPTION
Use [1] to test.
I created one commit with the changes of the install script only to make it easier to review what the script was and how it is changed. The goal is to have this squashed before the merge.

Also, I created a new recipe and a new package name to make sure we can switch in the class file, however, there might be other better ways, I thought it is only simpler.

[1] https://docs.foundries.io/latest/reference-manual/linux/linux-wic-installer.html#testing-wic-image-installer-with-qemu-x86