### PR TITLE
bsp: dynamic-layers: imx-atf: adjust power off logic

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-atf/imx-atf/0001-Revert-MA-20141-imx8m-enable-alarm-when-shutdown.patch
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-atf/imx-atf/0001-Revert-MA-20141-imx8m-enable-alarm-when-shutdown.patch
@@ -1,0 +1,83 @@
+From 3872bf195615db39fab6ba2532b18c09055abf7e Mon Sep 17 00:00:00 2001
+From: Igor Opaniuk <igor.opaniuk@foundries.io>
+Date: Wed, 6 Dec 2023 14:35:24 +0100
+Subject: [PATCH] Revert "MA-20141 imx8m: enable alarm when shutdown"
+
+This reverts commit 4fe65a006b2b0a95f3f1d17e782a92732932325f.
+---
+ plat/imx/imx8m/imx8m_psci_common.c           | 3 +--
+ plat/imx/imx8m/imx8mm/include/platform_def.h | 2 --
+ plat/imx/imx8m/imx8mn/include/platform_def.h | 2 --
+ plat/imx/imx8m/imx8mp/include/platform_def.h | 2 --
+ plat/imx/imx8m/imx8mq/include/platform_def.h | 2 --
+ 5 files changed, 1 insertion(+), 10 deletions(-)
+
+diff --git a/plat/imx/imx8m/imx8m_psci_common.c b/plat/imx/imx8m/imx8m_psci_common.c
+index 4a7255657..925e63ae5 100644
+--- a/plat/imx/imx8m/imx8m_psci_common.c
++++ b/plat/imx/imx8m/imx8m_psci_common.c
+@@ -251,8 +251,7 @@ void __dead2 imx_system_off(void)
+ 	uint32_t val;
+ 
+ 	val = mmio_read_32(IMX_SNVS_BASE + SNVS_LPCR);
+-	val |= SNVS_LPCR_SRTC_ENV | SNVS_LPCR_DP_EN | SNVS_LPCR_TOP |
+-		SNVS_LPCR_LPTA_EN | SNVS_LPCR_LPWUI_EN;
++	val |= SNVS_LPCR_SRTC_ENV | SNVS_LPCR_DP_EN | SNVS_LPCR_TOP;
+ 	mmio_write_32(IMX_SNVS_BASE + SNVS_LPCR, val);
+ 
+ 	while (1)
+diff --git a/plat/imx/imx8m/imx8mm/include/platform_def.h b/plat/imx/imx8m/imx8mm/include/platform_def.h
+index 430164d2c..b3a008f6a 100644
+--- a/plat/imx/imx8m/imx8mm/include/platform_def.h
++++ b/plat/imx/imx8m/imx8mm/include/platform_def.h
+@@ -160,8 +160,6 @@
+ 
+ #define SNVS_LPCR			U(0x38)
+ #define SNVS_LPCR_SRTC_ENV		BIT(0)
+-#define SNVS_LPCR_LPTA_EN		BIT(1)
+-#define SNVS_LPCR_LPWUI_EN		BIT(3)
+ #define SNVS_LPCR_DP_EN			BIT(5)
+ #define SNVS_LPCR_TOP			BIT(6)
+ 
+diff --git a/plat/imx/imx8m/imx8mn/include/platform_def.h b/plat/imx/imx8m/imx8mn/include/platform_def.h
+index 5147dfea8..90f9175e7 100644
+--- a/plat/imx/imx8m/imx8mn/include/platform_def.h
++++ b/plat/imx/imx8m/imx8mn/include/platform_def.h
+@@ -135,8 +135,6 @@
+ 
+ #define SNVS_LPCR			U(0x38)
+ #define SNVS_LPCR_SRTC_ENV		BIT(0)
+-#define SNVS_LPCR_LPTA_EN		BIT(1)
+-#define SNVS_LPCR_LPWUI_EN		BIT(3)
+ #define SNVS_LPCR_DP_EN			BIT(5)
+ #define SNVS_LPCR_TOP			BIT(6)
+ 
+diff --git a/plat/imx/imx8m/imx8mp/include/platform_def.h b/plat/imx/imx8m/imx8mp/include/platform_def.h
+index 46862f732..4b3713d11 100644
+--- a/plat/imx/imx8m/imx8mp/include/platform_def.h
++++ b/plat/imx/imx8m/imx8mp/include/platform_def.h
+@@ -174,8 +174,6 @@
+ 
+ #define SNVS_LPCR			U(0x38)
+ #define SNVS_LPCR_SRTC_ENV		BIT(0)
+-#define SNVS_LPCR_LPTA_EN		BIT(1)
+-#define SNVS_LPCR_LPWUI_EN		BIT(3)
+ #define SNVS_LPCR_DP_EN			BIT(5)
+ #define SNVS_LPCR_TOP			BIT(6)
+ 
+diff --git a/plat/imx/imx8m/imx8mq/include/platform_def.h b/plat/imx/imx8m/imx8mq/include/platform_def.h
+index 95837ea55..288988f0f 100644
+--- a/plat/imx/imx8m/imx8mq/include/platform_def.h
++++ b/plat/imx/imx8m/imx8mq/include/platform_def.h
+@@ -127,8 +127,6 @@
+ 
+ #define SNVS_LPCR			U(0x38)
+ #define SNVS_LPCR_SRTC_ENV		BIT(0)
+-#define SNVS_LPCR_LPTA_EN		BIT(1)
+-#define SNVS_LPCR_LPWUI_EN		BIT(3)
+ #define SNVS_LPCR_DP_EN			BIT(5)
+ #define SNVS_LPCR_TOP			BIT(6)
+ 
+-- 
+2.34.1
+

--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-atf/imx-atf_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/imx-atf/imx-atf_%.bbappend
@@ -5,6 +5,7 @@ RPROVIDES:${PN} += "virtual/trusted-firmware-a"
 
 SRC_URI:append = " \
     file://0001-plat-imx8m-obtain-boot-set-from-bootrom-even-log.patch \
+    file://0001-Revert-MA-20141-imx8m-enable-alarm-when-shutdown.patch \
 "
 
 SRC_URI:append:toradex = " \


### PR DESCRIPTION
Current logic in imx-atf configures SNVS_LP Control Register to generate a wakeup alarm after power-down, so poweroff works the same as reboot.

Revert the patch 4fe65a006b2 ("MA-20141 imx8m: enable alarm when shutdown") in imx-atf that introduces this behavior.