### PR TITLE
base: rs: custom-sota-client: Add User to Unit file

### DIFF
--- a/meta-lmp-base/recipes-sota/custom-sota-client/files/systemd.service
+++ b/meta-lmp-base/recipes-sota/custom-sota-client/files/systemd.service
@@ -5,6 +5,7 @@ Requires=boot-complete.target
 ConditionPathExists=|/var/sota/sota.toml
 
 [Service]
+User=root
 RestartSec=180
 Restart=always
 ExecStartPre=/usr/bin/mkdir -p /run/aktualizr


### PR DESCRIPTION
In order for the `docker compose` commands to be executed correctly from within the custom sota client the `$HOME` environment variable needs to be present.
This can be done in two ways, either we add the HOME environment variable to the already existing `Environment=` settings or we set the `User`.