### PR TITLE
bsp: linux-lmp: stm32mp15-disco: add patch to auto enable i2c5 with s…

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp/0001-FIO-internal-arch-arm-dts-stm32mp157c-dk2-enable-I2C.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp/0001-FIO-internal-arch-arm-dts-stm32mp157c-dk2-enable-I2C.patch
@@ -1,0 +1,39 @@
+From d3cb58b4bd8ffdb6a47e1424960e37fc01e8c89f Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo@foundries.io>
+Date: Sun, 10 Dec 2023 22:51:23 -0300
+Subject: [PATCH] [FIO internal] arch: arm: dts: stm32mp157c-dk2: enable I2C5
+ bus
+
+Enable I2C5 bus to connect SE050.
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+---
+ arch/arm/boot/dts/stm32mp157c-dk2.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm/boot/dts/stm32mp157c-dk2.dts b/arch/arm/boot/dts/stm32mp157c-dk2.dts
+index dc6464c08f4a..d4794c10ecc8 100644
+--- a/arch/arm/boot/dts/stm32mp157c-dk2.dts
++++ b/arch/arm/boot/dts/stm32mp157c-dk2.dts
+@@ -22,6 +22,7 @@ aliases {
+ 		serial1 = &usart3;
+ 		serial2 = &uart7;
+ 		serial3 = &usart2;
++		i2c5 = &i2c5;
+ 	};
+ 
+ 	chosen {
+@@ -86,6 +87,10 @@ touchscreen@38 {
+ 	};
+ };
+ 
++&i2c5 {
++	status = "okay";
++};
++
+ &ltdc {
+ 	status = "okay";
+ 
+-- 
+2.34.1
+

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp_6.1.bbappend
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp_6.1.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:stm32mp15-disco = " \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'se05x', 'file://0001-FIO-internal-arch-arm-dts-stm32mp157c-dk2-enable-I2C.patch', '', d)} \
+"


### PR DESCRIPTION
…e05x

Automatically enable i2c5 when se05x is enabled via MACHINE_FEATURES, as done for other imx-based targets.