### PR TITLE
base: non-clangable: add optee-examples

### DIFF
--- a/meta-lmp-base/conf/distro/include/non-clangable.inc
+++ b/meta-lmp-base/conf/distro/include/non-clangable.inc
@@ -140,6 +140,7 @@ TOOLCHAIN:pn-optee-os-tadevkit = "gcc"
 TOOLCHAIN:pn-optee-test = "gcc"
 TOOLCHAIN:pn-optee-client = "gcc"
 TOOLCHAIN:pn-optee-sks = "gcc"
+TOOLCHAIN:pn-optee-examples = "gcc"
 
 # qemuarm64
 ## clang only works with debug mode (not release)


### PR DESCRIPTION
Add optee-examples to the list of optee related recipes which should all be aligned with gcc.