### PR TITLE
recipes-support: make early-start only run to completion once

### DIFF
--- a/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start.service
+++ b/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start.service
@@ -12,6 +12,7 @@ Type=oneshot
 RemainAfterExit=true
 ExecStart=/usr/bin/compose-apps-early-start
 Restart=on-failure
+ExecStartPost=/usr/bin/systemctl disable compose-apps-early-start.service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The way customers use this feature means that it can be several reboots before the device is registered. The early-start was running on every boot which causes delays in startup. This makes it so it only runs once and on all subsequent reboots dockerd will start the containers.