### PR TITLE
bsp: tf-a-fio: st: remove old signed binary before signing

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/trusted-firmware-a/tf-a-fio-st.inc
+++ b/meta-lmp-bsp/recipes-bsp/trusted-firmware-a/tf-a-fio-st.inc
@@ -47,6 +47,9 @@ sign_binaries() {
                 if [ "${file_type}" = "bl2" ]; then
                     # Install TF-A binary
                     if [ -f "${B}/${config}${soc_suffix}/${tfa_basename}-${dt}-${config}.${TF_A_SUFFIX}" ]; then
+                        if [ -f "${B}/${config}${soc_suffix}/${tfa_basename}-${dt}-${config}_Signed.${TF_A_SUFFIX}" ]; then
+			    rm -f "${B}/${config}${soc_suffix}/${tfa_basename}-${dt}-${config}_Signed.${TF_A_SUFFIX}"
+                        fi
                         bbnote "Signing STM32 TF-A binary with ROT key: ${B}/${config}${soc_suffix}/${tfa_basename}-${dt}-${config}.${TF_A_SUFFIX}"
                         ${STM32_CUBE_PATH}/bin/STM32MP_SigningTool_CLI -bin "${B}/${config}${soc_suffix}/${tfa_basename}-${dt}-${config}.${TF_A_SUFFIX}" \
                                                                        -pubk ${STM32_ROT_KEY_PATH}/publicKey.pem -prvk ${STM32_ROT_KEY_PATH}/privateKey.pem \


### PR DESCRIPTION
```
The ft-a-fio deploy task does optionally sign the tf-a using the
ST STM32MP Signing Tool. However, if it is invoked due to some
other dependent recipe change when the previous signed files already
exist, it reports that the destination file already exists and asks
for confirmation:

Do you want to replace this file: .../tf-a-stm32mp157c-dk2-sdcard_Signed.stm32 ? (y/n)

This keeps to be generated until all memory is exhausted and then it
ends with an error.

Fix the issue by removing the old file in advance before signing, as
signing tool doesn't have a cmdline option to replace the file.

Fixes: https://github.com/igoropaniuk/meta-lmp/commit/11fa2be280fb83933f3d70471aeb8d700ad700c3("bsp: tf-a-fio: add signing support for stm32mp15-disco-sec")
Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>
```