### PR TITLE
base: optee-os-fio: 3.21: bump to 33d9bf3fc

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.21.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.21.0.bb
@@ -1,4 +1,4 @@
 require optee-os-fio.inc
 
-SRCREV = "2c3278116402a01078c688d5ca2a1ab247212e35"
+SRCREV = "33d9bf3fc5d87ecb2c7da0ffda6792b18375dc03"
 SRCBRANCH = "3.21+fio"


### PR DESCRIPTION
Relevant changes:
- 33d9bf3fc [FIO toup] drivers: se050: disable SM2_* when enabled