### PR TITLE
bsp: wic: stm32mp15: fix align param

### DIFF
--- a/meta-lmp-bsp/wic/sdimage-stm32mp157c-dk2-optee.wks.in
+++ b/meta-lmp-bsp/wic/sdimage-stm32mp157c-dk2-optee.wks.in
@@ -17,6 +17,6 @@ part fip2 --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b 
 
 part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 16K --offset 9216K
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --active --offset 16384K --size 16M
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096K
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096
 
 bootloader --ptable gpt


### PR DESCRIPTION
It's not possible to specify size prefix for --align option, it's by default in KBytes. Fix this error:
Fix sdimage-stm32mp157c-dk2-optee.wks:20: argument --align: invalid int value: '4096K'

Fixes: 1e1897d0dc("bsp: wic: stm32mp1: wks file improvements")