### PR TITLE
base: distro: lmp: keep ext4 image

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -80,7 +80,7 @@ USERADD_ERROR_DYNAMIC = "error"
 # Default image formats
 IMAGE_FSTYPES += "wic wic.gz wic.bmap"
 IMAGE_FSTYPES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', 'ota-ext4.gz', ' ', d)}"
-IMAGE_FSTYPES:remove = "tar.gz tar.xz tar.bz2 ext4 wic.xz wic.bz2"
+IMAGE_FSTYPES:remove = "tar.gz tar.xz tar.bz2 wic.xz wic.bz2"
 
 # No Ostree tarball by default (prefer ota instead)
 BUILD_OSTREE_TARBALL ?= "0"


### PR DESCRIPTION
Don't remove/keep ext4 image in deploy folder, as it might be needed by other scripts responsible for flashing a target.