### PR TITLE
Fix the aklite image loading issue for v92 (base: rs: Bump aklite with fix for v92 838e53c)

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-BRANCH:lmp = "master"
-SRCREV:lmp = "f290020fcd2bdf07bd30ae23405ce77b93a83663"
+BRANCH:lmp = "v92"
+SRCREV:lmp = "838e53cb7732bb880e55e5badf9cb38ef53614f9"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
Relevant changes:
- 838e53c dockerclient: Calculate archive size correctly
- 6fda4d5 dockerclient: Handle tar creation errors