### PR TITLE
base: luks-reencryption: stop on first luks match

### DIFF
--- a/meta-lmp-base/recipes-support/luks-reencryption/luks-reencryption/luks-reencryption
+++ b/meta-lmp-base/recipes-support/luks-reencryption/luks-reencryption/luks-reencryption
@@ -7,7 +7,7 @@ set -e
 
 [ $(whoami) = "root" ] || { echo "E: You must be root" && exit 1; }
 
-DEVICE=$(lsblk -f | awk '/crypto_LUKS/ {print $1}' | awk '{sub(/^[^a-zA-Z]*/, ""); print}')
+DEVICE=$(lsblk -f | awk '/crypto_LUKS/ {print $1; exit}' | awk '{sub(/^[^a-zA-Z]*/, ""); print}')
 DEVICE="/dev/${DEVICE}"
 
 # Avoid using the PIN for OP-TEE supported PKCS#11 user authentication


### PR DESCRIPTION
Assume the first luks device is the rootfs, the one requiring on-line reencryption.