### PR TITLE
base: rc: composectl: Bump version 5419dab

### DIFF
--- a/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
+++ b/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=2a944942e1496af1886903d2
 GO_IMPORT = "github.com/foundriesio/composeapp"
 GO_IMPORT_PROTO ?= "https"
 SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO};branch=main"
-SRCREV = "06800cae019bad5071e08427fc4460a184ea225a"
+SRCREV = "5419dab59df5b546f78269570bb47bb871654b8f"
 UPSTREAM_CHECK_COMMITS = "1"
 
 inherit go-mod


### PR DESCRIPTION
Relevant changes:
- 5419dab check: Use read-only store to copy from local store