### PR TITLE
bsp: dynamic-layers: stm32-mfgtool-files: change sed separator

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files_0.1.bb
+++ b/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files_0.1.bb
@@ -20,9 +20,9 @@ SRC_URI = " \
 "
 
 do_compile() {
-    sed -e 's/@@MACHINE@@/${MACHINE}/' \
-        -e 's/@@BOARD_NAME@@/${LMP_FLASHLAYOUT_BOARD_NAME}/' \
-        -e 's/@@FLASHLAYOUT_USB@@/${LMP_MFGTOOL_FLASHLAYOUT}/' \
+    sed -e 's:@@MACHINE@@:${MACHINE}:' \
+        -e 's:@@BOARD_NAME@@:${LMP_FLASHLAYOUT_BOARD_NAME}:' \
+        -e 's:@@FLASHLAYOUT_USB@@:${LMP_MFGTOOL_FLASHLAYOUT}:' \
         ${WORKDIR}/provision.sh.in > ${WORKDIR}/provision.sh
 }
 


### PR DESCRIPTION
Use ':' separator instead of '/' for sed 's' command, as for example LMP_MFGTOOL_FLASHLAYOUT value itself might also have slashes.

Fixes: 91eb22094("bsp: lmp-mfgtool: provide dynamic configuration for flashlayout class")