### PR TITLE
Revert "bsp: stm32-mfgtool-files: keep track of the variables used"

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files_0.1.bb
+++ b/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files_0.1.bb
@@ -25,7 +25,6 @@ do_compile() {
         -e 's:@@FLASHLAYOUT_USB@@:${LMP_MFGTOOL_FLASHLAYOUT}:' \
         ${WORKDIR}/provision.sh.in > ${WORKDIR}/provision.sh
 }
-do_compile[vardeps] += "MACHINE LMP_FLASHLAYOUT_BOARD_NAME LMP_MFGTOOL_FLASHLAYOUT"
 
 do_deploy() {
     install -d ${DEPLOYDIR}/${PN}


### PR DESCRIPTION
This reverts commit 7600a79bd17504c0544a8bd5152740def380f884.

I have tested this localy and it works without the do_compile[vardeps] and so the do_compile task runs when the LMP_MFGTOOL_FLASHLAYOUT or LMP_FLASHLAYOUT_BOARD_NAME change.