### PR TITLE
base: libnvidia-container: rdepend on tegra-libraries-cuda

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-containers/libnvidia-container/libnvidia-container_1.10.0.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-containers/libnvidia-container/libnvidia-container_1.10.0.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS:${PN}:append = " tegra-libraries-cuda"


### PR DESCRIPTION
Unblock meta-tegra bump and can be reverted when https://github.com/OE4T/meta-tegra/pull/1456 was merged