### PR TITLE
base: lmp-signing: fix append when vardeps is none

### DIFF
--- a/meta-lmp-base/classes/lmp-signing.bbclass
+++ b/meta-lmp-base/classes/lmp-signing.bbclass
@@ -70,6 +70,6 @@ def set_varfile_hash(varfile, d):
 def add_varfiles_hash_to_vardeps_of_var(varfiles, var, d):
     for varname in varfiles:
         varname_hash = set_varfile_hash(varname, d)
-        vardeps = d.getVarFlag(var, 'vardeps')
-        if vardeps and varname_hash not in vardeps:
+        vardeps = d.getVarFlag(var, 'vardeps') or ""
+        if varname_hash not in vardeps.split():
             d.appendVarFlag(var, 'vardeps', ' ' + varname_hash)


### PR DESCRIPTION
The task flag vardeps can be empty and in this case it is none.
Consequently this means that we cannot add anything to the task vardeps when it is empty.
We should also match any full string present on vardeps and not sub-strings so varname_hash should be checked on vardeps list and not string.
