### PR TITLE
base: aktualizr-callback: add a callback handler example

### DIFF
--- a/recipes-sota/aktualizr/aktualizr-callback/90-handle-callback.toml
+++ b/recipes-sota/aktualizr/aktualizr-callback/90-handle-callback.toml
@@ -1,0 +1,2 @@
+[pacman]
+callback_program = /usr/bin/callback-handler

--- a/recipes-sota/aktualizr/aktualizr-callback/callback-handler
+++ b/recipes-sota/aktualizr/aktualizr-callback/callback-handler
@@ -1,0 +1,71 @@
+#!/bin/sh
+################################################################
+#
+# This is a simple handler script used to show handling of
+# aktualizr-lite callbacks
+#
+#
+# Copyright (C) 2024 Foundries.IO
+#
+# SPDX-License-Identifier: MIT
+#
+################################################################
+
+function log()
+{
+    echo "$(date +"%b %e %T") handle-callback: $*"
+}
+
+# Environment variables supplied:
+# MESSAGE             - Always onf of the following
+# RESULT              - When there is a return
+# CURRENT_TARGET      - File name and path to the current target
+# CURRENT_TARGET_NAME - When name is known
+# INSTALL_TARGET_NAME - When there is a new target
+#
+# Current messages are:
+# - check-for-update-pre  return: none
+# - check-for-update-post return: OK or FAILED: *
+# - download-pre          return: none
+# - download-post         return: OK or FAILED
+# - install-pre           return: none
+# - install-post          return: NEEDS_COMPLETION, OK, or FAILED
+# - install-final-pre     return: none (this will happen after a reboot from NEED_COMPLETION)
+
+case ${MESSAGE} in
+    check-for-update-pre)
+        log "check-for-update-pre"
+        ;;
+    check-for-update-post)
+        log "check-for-update-post" "${RESULT}"
+        if [ "OK" = "${RESULT}" ]
+        then
+            if [ -n "${INSTALL_TARGET_NAME}" ]
+            then
+                log "${CURRENT_TARGET_NAME}" to "${INSTALL_TARGET_NAME}"
+            fi
+        fi
+        ;;
+    download-pre)
+        log "download-pre" "${INSTALL_TARGET_NAME}"
+        ;;
+    download-post)
+        log "download-post:" "${RESULT}"
+        if [ "${RESULT}" = "OK" ]
+        then
+            log "download-post:" "${INSTALL_TARGET_NAME}"
+        fi
+        ;;
+    install-pre)
+        log "install-pre" "${INSTALL_TARGET_NAME}"
+        ;;
+    install-post)
+        log "install-post:" "${RESULT}"
+        ;;
+    install-final-pre)
+        log "install-final-pre:" "${CURRENT_TARGET_NAME}" "${INSTALL_TARGET_NAME}"
+        ;;
+    *)
+        log "unknown" "${MESSAGE}"
+        ;;
+esac

--- a/recipes-sota/aktualizr/aktualizr-callback_1.0.bb
+++ b/recipes-sota/aktualizr/aktualizr-callback_1.0.bb
@@ -1,0 +1,25 @@
+SUMMARY = "Aktualizr configuration snippet to enable Foundries.IO callback function"
+SECTION = "base"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
+
+inherit allarch
+
+SRC_URI = "\
+    file://90-handle-callback.toml \
+    file://callback-handler \
+"
+
+do_install() {
+    install -m 0700 -d ${D}${libdir}/sota/conf.d
+    install -m 0755 -d ${D}${bindir}
+    install -m 0644 ${WORKDIR}/90-handle-callback.toml ${D}${libdir}/sota/conf.d/90-handle-callback.toml
+    install -m 0755 ${WORKDIR}/callback-handler ${D}${bindir}/callback-handler
+}
+
+FILES:${PN} = " \
+    ${libdir}/sota/conf.d/90-handle-callback.toml \
+    ${bindir}/callback-handler \
+"
+
+RDEPENDS:${PN} = "atkualizr-lite"


### PR DESCRIPTION
Customers are not always ready to tackle a custom SOTA client and only want simple hold off of a step of the updating.

This adds a simple recipe that sets up a callback handler as an option other that using aktualizr-lite CLI or a custom client.