### PR TITLE
bsp: tegra-helper-scripts: update initrd-flash.sh fork with lastest changes

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o pipefail
+
 me=$(basename "$0")
 here=$(readlink -f $(dirname "$0"))
 
@@ -433,7 +435,7 @@ write_to_device() {
         # the raw image name.
         # XXX
         simgname="${ROOTFS_IMAGE%.*}.img"
-        sed -i -e"s,$simgname,$ROOTFS_IMAGE," -e"s,APPFILE_b,$ROOTFS_IMAGE," -e"s,APPFILE,$ROOTFS_IMAGE," $datased initrd-flash.xml
+        sed -i -e"s,$simgname,$ROOTFS_IMAGE," -e"s,APPFILE_b,$ROOTFS_IMAGE," -e"s,APPFILE,$ROOTFS_IMAGE," -e"s,DTB_FILE,kernel_$DTBFILE," $datased initrd-flash.xml
     fi
     if "$here/make-sdcard" -y $opts $extraarg initrd-flash.xml "$dev"; then
 	rc=0


### PR DESCRIPTION
Includes:

- e034e0e2 initrd-flash: set pipefail option
https://github.com/OE4T/meta-tegra/commit/e034e0e271dea2e0f51a55e11fcf881ef0e675e5
https://github.com/OE4T/meta-tegra/pull/1458

- f8cb5c6a initrd-flash.sh: ensure substitution for DTB_FILE
https://github.com/OE4T/meta-tegra/commit/f8cb5c6ad2617755f5cb74f85a1b0b2cd6380f6c
https://github.com/OE4T/meta-tegra/pull/1453