### PR TITLE
base: optee-os-fio: 3.21: bump to 6120b1aa3bb

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_3.21.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_3.21.0.bb
@@ -1,4 +1,4 @@
 require optee-os-fio.inc
 
-SRCREV = "33d9bf3fc5d87ecb2c7da0ffda6792b18375dc03"
+SRCREV = "6120b1aa3bb758a0eb1711cb4ff8e4de222306ea"
 SRCBRANCH = "3.21+fio"


### PR DESCRIPTION
Relevant changes:

  - 6120b1aa3 Revert "[FIO toup] drivers: se050: disable SM2_* when enabled"
  - 70ef5c34e [FIO fromtree] crypto: se050: ecc: allow software fallback on key allocation requests
  - 9e31f457a [FIO fromtree] crypto_api: acipher: ecc key allocation API, pass the key type