### PR TITLE
Revert "bsp: libnvidia-container: rdepend on tegra-libraries-cuda"

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-containers/libnvidia-container/libnvidia-container_1.10.0.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-containers/libnvidia-container/libnvidia-container_1.10.0.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:append = " tegra-libraries-cuda"


### PR DESCRIPTION
This reverts commit 49c2b20a0e8d37239ee0410d5cbcc39e041e4c77.

Part of meta-tegra kirkstone ece7adfd9527a3edcc26a4855498e54fdee1ec56.