### PR TITLE
meta-lmp-base: allow lmp-device-auto-register to use hostname

### DIFF
--- a/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register.bb
+++ b/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 RDEPENDS:${PN} += "lmp-device-register"
 
 SRC_URI = " \
-	file://lmp-device-auto-register.service \
+	file://lmp-device-auto-register.service.in \
 	file://lmp-device-auto-register \
 	file://api-token \
 "
@@ -13,6 +13,12 @@ SRC_URI = " \
 inherit systemd
 
 SYSTEMD_SERVICE:${PN} = "lmp-device-auto-register.service"
+LMP_AUTO_REGISTER_USE_HOSTNAME ?= ""
+
+do_compile() {
+    sed -e 's/@@LMP_AUTO_REGISTER_USE_HOSTNAME@@/${LMP_AUTO_REGISTER_USE_HOSTNAME}/' \
+        ${WORKDIR}/lmp-device-auto-register.service.in > ${WORKDIR}/lmp-device-auto-register.service
+}
 
 do_install() {
 	install -d ${D}${systemd_system_unitdir}

--- a/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register/lmp-device-auto-register
+++ b/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register/lmp-device-auto-register
@@ -3,6 +3,7 @@
 TOKEN_FILE=${TOKEN_FILE-/etc/lmp-device-register-token}
 TAG=""
 HSM=""
+NAME=""
 
 if [ -f /etc/sota/tag ] ; then
 	# tag file should contain only one tag
@@ -10,6 +11,10 @@ if [ -f /etc/sota/tag ] ; then
 	# single tag for device registration
 	TAG=$(</etc/sota/tag)
 	TAG="-t ${TAG}"
+fi
+
+if [ -n "${USE_HOSTNAME}" ]; then
+	NAME="-n $(cat /etc/hostname)"
 fi
 
 if [ ! -f ${TOKEN_FILE} ] ; then
@@ -47,4 +52,4 @@ else
 	echo "$0: Registering with all available apps"
 fi
 
-/usr/bin/lmp-device-register -T ${TOKEN} ${TAG} ${APPS} ${HSM}
+/usr/bin/lmp-device-register -T ${TOKEN} ${NAME} ${TAG} ${APPS} ${HSM}

--- a/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register/lmp-device-auto-register.service.in
+++ b/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register/lmp-device-auto-register.service.in
@@ -5,6 +5,7 @@ After=network-online.target time-sync.target systemd-time-wait-sync.service
 ConditionPathExists=!/var/sota/sql.db
 
 [Service]
+Environment=USE_HOSTNAME=@@LMP_AUTO_REGISTER_USE_HOSTNAME@@
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/usr/bin/lmp-device-auto-register


### PR DESCRIPTION
This patch enables lmp-device-auto-register to use /etc/hostname as FoundriesFactory device registration name. It is done by setting build time variable LMP_AUTO_REGISTER_USE_HOSTNAME. If this variable is empty lmp-device-auto-register will use randomly generated UUID.