### PR TITLE
Bump aklite version to b2140a5

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "1d23006a983913ef6b8bdf8963ba61cad7428997"
+SRCREV:lmp = "b2140a50e48537680f5832141141d6db579c6e00"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \

--- a/meta-lmp-base/recipes-sota/custom-sota-client/custom-sota-client_git.bb
+++ b/meta-lmp-base/recipes-sota/custom-sota-client/custom-sota-client_git.bb
@@ -11,7 +11,7 @@ SRC_URI = "\
 "
 
 BRANCH = "master"
-SRCREV = "05c4180840ef84c21b0632be4a542580d720491f"
+SRCREV = "b2140a50e48537680f5832141141d6db579c6e00"
 
 S = "${WORKDIR}/git/examples/custom-client-cxx"
 


### PR DESCRIPTION
- Add offline update support to the public API
- Move the `aklite-offline` to the public API usage
- Extend the custom-sota-client example with sub-commands to perform CLI-based update for both online and offline update.