### PR TITLE
meta-lmp-base: allow apps selection for lmp-device-auto-register

### DIFF
--- a/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register/lmp-device-auto-register
+++ b/meta-lmp-base/recipes-support/lmp-device-auto-register/lmp-device-auto-register/lmp-device-auto-register
@@ -4,6 +4,7 @@ TOKEN_FILE=${TOKEN_FILE-/etc/lmp-device-register-token}
 TAG=""
 HSM=""
 NAME=""
+APPS=${APPS-""}
 
 if [ -f /etc/sota/tag ] ; then
 	# tag file should contain only one tag
@@ -41,10 +42,12 @@ if [ -f /etc/sota/hsm ]; then
 	fi
 fi
 
-# Done in 2 parts. This first part will remove trailing \n's and make
-# the output all space separated. The 2nd part makes it comma separated.
-[ -d /var/sota/compose-apps ] && APPS=$(ls /var/sota/compose-apps)
-APPS=$(echo ${APPS} | tr ' ' ',')
+if [ -z "${APPS}" ]; then
+	# Done in 2 parts. This first part will remove trailing \n's and make
+	# the output all space separated. The 2nd part makes it comma separated.
+	[ -d /var/sota/compose-apps ] && APPS=$(ls /var/sota/compose-apps)
+	APPS=$(echo ${APPS} | tr ' ' ',')
+fi
 if [ -n "${APPS}" ] ; then
 	echo "$0: Registering with default apps = ${APPS}"
 	APPS="-a ${APPS}"


### PR DESCRIPTION
This patch allows to auto-register with a subset of apps by setting APPS variable in the service environment.