### PR TITLE
bsp: linux-lmp-fslc-imx: update to include the lf-6.1.55-2.2.0 tag

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp-dev-mfgtool_git.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp-dev-mfgtool_git.bb
@@ -5,9 +5,9 @@ compatible Linux Kernel to be used in updater environment"
 # Use Freescale kernel by default
 KERNEL_REPO ?= "git://github.com/Freescale/linux-fslc.git"
 KERNEL_REPO_PROTOCOL ?= "https"
-LINUX_VERSION ?= "6.1.38"
-KERNEL_BRANCH ?= "6.1-2.0.x-imx"
-KERNEL_COMMIT ?= "b872b1170fc8843b55e9f8838dd373ff43bb7552"
+LINUX_VERSION ?= "6.1.70"
+KERNEL_BRANCH ?= "6.1-2.2.x-imx"
+KERNEL_COMMIT ?= "4e3fc5471376a15279ee5c99e791a7c7b065cbc1"
 
 # Drop features that are appended by other layers (not required here)
 KERNEL_FEATURES:remove = "cfg/fs/vfat.scc"

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.1.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.1.bb
@@ -8,10 +8,10 @@ include recipes-kernel/linux/linux-lmp-fslc-imx.inc
 include recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
 
 # Use Freescale kernel by default
-LINUX_VERSION ?= "6.1.57"
-KERNEL_BRANCH ?= "6.1-2.1.x-imx"
+LINUX_VERSION ?= "6.1.70"
+KERNEL_BRANCH ?= "6.1-2.2.x-imx"
 
-SRCREV_machine = "241e2f51bd87beb652196d1db92f0387c1209bfb"
+SRCREV_machine = "4e3fc5471376a15279ee5c99e791a7c7b065cbc1"
 
 SRC_URI += " \
     file://0004-FIO-toup-hwrng-optee-support-generic-crypto.patch \


### PR DESCRIPTION
Update branch and stable-base version to include the lf-6.1.55-2.2.0 tag.