### PR TITLE
base: layer.conf: exclude os-release siggen dependencie on the initramfs ostree-lmp-recovery

### DIFF
--- a/meta-lmp-base/conf/layer.conf
+++ b/meta-lmp-base/conf/layer.conf
@@ -42,6 +42,7 @@ SIGGEN_EXCLUDERECIPES_ABISAFE += " \
 # of tasks from one recipe when they depend on tasks from another recipe.
 SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += " \
     initramfs-ostree-lmp-image->os-release \
+    initramfs-ostree-lmp-recovery->os-release \
     core-image-minimal-initramfs->os-release \
     fsl-image-mfgtool-initramfs->os-release \
 "


### PR DESCRIPTION
This patch is a follow-up of 24d1016e, the initramfs-ostree-lmp-recovery is used on the machine qemuarm64-secureboot and without this patch the initramfs is rebuilded which consequently triggers a kernel rebuild.