### PR TITLE
base: rs: aktualizr: Bump version to 95ecfb8

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "b2140a50e48537680f5832141141d6db579c6e00"
+SRCREV:lmp = "95ecfb878f60c8ee3c6c6b67b618567c6db5777e"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \

--- a/meta-lmp-base/recipes-sota/custom-sota-client/custom-sota-client_git.bb
+++ b/meta-lmp-base/recipes-sota/custom-sota-client/custom-sota-client_git.bb
@@ -11,7 +11,7 @@ SRC_URI = "\
 "
 
 BRANCH = "master"
-SRCREV = "b2140a50e48537680f5832141141d6db579c6e00"
+SRCREV = "95ecfb878f60c8ee3c6c6b67b618567c6db5777e"
 
 S = "${WORKDIR}/git/examples/custom-client-cxx"
 


### PR DESCRIPTION
Relevant changes:
- bd52b57 api, cli, liteclient: Distinguish different checkin errors
- 54a5320 tuf: Move MetadataNotFoundException to tuf.h