### PR TITLE
base: systemd: add pool.ntp.org to the ntp fallback list

### DIFF
--- a/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
@@ -57,7 +57,7 @@ RRECOMMENDS:${PN} += "systemd-crypt"
 
 ALTERNATIVE_PRIORITY[resolv-conf] = "300"
 
-DEF_FALLBACK_NTP_SERVERS ?= "time1.google.com time2.google.com time3.google.com time4.google.com time.cloudflare.com"
+DEF_FALLBACK_NTP_SERVERS ?= "time1.google.com time2.google.com time3.google.com time.cloudflare.com pool.ntp.org"
 EXTRA_OEMESON += ' \
 	-Dntp-servers="${DEF_FALLBACK_NTP_SERVERS}" \
 '


### PR DESCRIPTION
Replace time4.google.com with pool.ntp.org in order to have at least one entry specific to the most commonly used ntp server.