### PR TITLE
base: kmeta-linux-lmp-6.1.y: bump to cd8a7b95

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v6.1.y"
-KERNEL_META_COMMIT ?= "e118973a96dea12b1adc201b67147d93cae4341f"
+KERNEL_META_COMMIT ?= "cd8a7b95327f6ec4814887b8fa8c0eb18f9e5536"


### PR DESCRIPTION
Relevant changes:
- cd8a7b95 bsp: imx: imx8ulp: fix enabling I2C_IMX_FLEXIO