### PR TITLE
bsp: linux-lmp-ti-staging: fix KERNEL_REPO

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-kernel/linux/linux-lmp-ti-staging_git.bb
+++ b/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-kernel/linux/linux-lmp-ti-staging_git.bb
@@ -2,7 +2,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 include recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
 
-KERNEL_REPO ?= "git://git.ti.com/ti-linux-kernel/ti-linux-kernel.git"
+KERNEL_REPO ?= "git://git.ti.com/git/ti-linux-kernel/ti-linux-kernel.git"
 KERNEL_REPO_PROTOCOL ?= "https"
 KERNEL_BRANCH ?= "ti-linux-6.1.y"
 


### PR DESCRIPTION
Use the same URL that is on meta-ti/meta-ti-bsp/recipes-kernel/linux/linux-ti-staging_6.1.bb

This was causing some troubles on main-next:
```
ERROR: linux-lmp-ti-staging-6.1.69+git-r0 do_unpack: Bitbake Fetcher Error: UnpackError('No up to date source found: clone directory not available or not up to date: /srv/oe/downloads/git2/git.ti.com.ti-linux-kernel.ti-linux-kernel.git; shallow clone not enabled', 'git://git.ti.com/ti-linux-kernel/ti-linux-kernel.git;protocol=https;branch=ti-linux-6.1.y;name=machine;')
```