### PR TITLE
bsp: tegra: install tegra-redundant-boot

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -764,7 +764,6 @@ OSTREE_LOADER_LINK:tegra = "0"
 OSTREE_BOOTLOADER:tegra ?= "syslinux"
 OSTREE_DEPLOY_DEVICETREE:tegra = "1"
 PREFERRED_PROVIDER_virtual/optee-os:tegra = "optee-os"
-MACHINE_EXTRA_RDEPENDS:remove:tegra = "tegra-redundant-boot"
 MACHINE_FEATURES:append:tegra = " optee"
 ## jetson-agx-xavier-devkit (tegra194)
 OSTREE_KERNEL_ARGS:tegra194 ?= "\${cbootargs} root=LABEL=otaroot rootwait rootfstype=ext4 mminit_loglevel=4 console=tty0 console=ttyTCU0,115200 fbcon=map:0 video=efifb:off sdhci_tegra.en_boot_part_access=1"


### PR DESCRIPTION
Install tegra-redundant-boot binaries, needed for handling A/B boot firmware updates.