### PR TITLE
bsp: freescale: cairo: fix compatibility with 1.16

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-graphics/cairo/cairo_1.16.0.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-graphics/cairo/cairo_1.16.0.bbappend
@@ -1,0 +1,2 @@
+PACKAGECONFIG:append:imxgpu3d = " egl glesv2"
+PACKAGECONFIG:remove:imxgpu3d = "opengl"


### PR DESCRIPTION
The commit [1] breaks compatibility with cairo < 1.18. LmP is still based on OE kirkstone, that uses cairo 1.16. Return back compatibility.

[1]
commit 0e478bde ("cairo: Drop the removed packageconfigs")