### PR TITLE
mfgtool-files: upgrade to 1.5.179

### DIFF
--- a/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb
+++ b/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb
@@ -9,20 +9,22 @@ inherit deploy nopackages
 INITRAMFS_IMAGE = "fsl-image-mfgtool-initramfs"
 DEPENDS = "${INITRAMFS_IMAGE}"
 
-UUU_RELEASE = "1.5.141"
+UUU_RELEASE = "1.5.179"
 MFGTOOL_FLASH_IMAGE ?= "lmp-base-console-image"
 
 SRC_URI = " \
     https://github.com/NXPmicro/mfgtools/releases/download/uuu_${UUU_RELEASE}/uuu;downloadfilename=uuu-${UUU_RELEASE};name=Linux \
-    https://github.com/NXPmicro/mfgtools/releases/download/uuu_${UUU_RELEASE}/uuu_mac;downloadfilename=uuu-${UUU_RELEASE}_mac;name=Mac \
+    https://github.com/NXPmicro/mfgtools/releases/download/uuu_${UUU_RELEASE}/uuu_mac_arm;downloadfilename=uuu-${UUU_RELEASE}_mac_arm;name=Mac_arm \
+    https://github.com/NXPmicro/mfgtools/releases/download/uuu_${UUU_RELEASE}/uuu_mac_x86;downloadfilename=uuu-${UUU_RELEASE}_mac_x86;name=Mac_x86 \
     https://github.com/NXPmicro/mfgtools/releases/download/uuu_${UUU_RELEASE}/uuu.exe;downloadfilename=uuu-${UUU_RELEASE}.exe;name=Windows \
     file://bootloader.uuu.in \
     file://full_image.uuu.in \
 "
 
-SRC_URI[Linux.sha256sum] = "561012195adcea9ea92e81afc17f85a1a36af234aeadd0cf7688cedd60153578"
-SRC_URI[Mac.sha256sum] = "d3d8e7c998a553648d3c75307b1a8d83415c6b2e6bb99591e877f10f64b4bba3"
-SRC_URI[Windows.sha256sum] = "342be5d2f1d934e7c808c9835b0440063a86f783160017372c4ce5b0adae3815"
+SRC_URI[Linux.sha256sum] = "2be8c39b3af0b20c0c9604035ea49965d664777fff6da60572ee61d8dd226319"
+SRC_URI[Mac_arm.sha256sum] = "f7722d0b12c273ee27279045dcb877cfbe59f6fd04513f2ed1f9f4fdecc649ba"
+SRC_URI[Mac_x86.sha256sum] = "1558e23be37ce35cce556f480e296db3f68e21d40f17808beb7d25c3049f2953"
+SRC_URI[Windows.sha256sum] = "e2c54198437b2c3235b35eabf886ec9540105c855a23c044083912cd91af4861"
 
 S = "${WORKDIR}"
 
@@ -39,7 +41,8 @@ do_compile() {
 do_deploy() {
     install -d ${DEPLOYDIR}/${PN}
     install -m 0755 ${WORKDIR}/uuu-${UUU_RELEASE} ${DEPLOYDIR}/${PN}/uuu
-    install -m 0755 ${WORKDIR}/uuu-${UUU_RELEASE}_mac ${DEPLOYDIR}/${PN}/uuu_mac
+    install -m 0755 ${WORKDIR}/uuu-${UUU_RELEASE}_mac_arm ${DEPLOYDIR}/${PN}/uuu_mac_arm
+    install -m 0755 ${WORKDIR}/uuu-${UUU_RELEASE}_mac_x86 ${DEPLOYDIR}/${PN}/uuu_mac_x86
     install -m 0644 ${WORKDIR}/uuu-${UUU_RELEASE}.exe ${DEPLOYDIR}/${PN}/uuu.exe
     install -m 0644 ${WORKDIR}/bootloader.uuu ${DEPLOYDIR}/${PN}
     install -m 0644 ${WORKDIR}/full_image.uuu ${DEPLOYDIR}/${PN}


### PR DESCRIPTION
=== New feature
  * Provide macos arm prebuild version.
  * Support i.MX91
  * Support yocto bmap file to skip unused block
  * Support i.MX95

==== Bug fixes
  * Fixed a crash with -d option when change back file.
  * Static link tinyxml to avoid difference version ubuntu tinyxml version mismatch problem.
  * Fixed usb pipe error when download image with FCB