### PR TITLE
linux-lmp: refix setting a subdir for dts files

### DIFF
--- a/meta-lmp-base/classes/lmp-staging.bbclass
+++ b/meta-lmp-base/classes/lmp-staging.bbclass
@@ -9,8 +9,15 @@ LMPSTAGING_INHERIT_KERNEL_MODSIGN = ""
 
 LMPSTAGING_LOCK_TO_AVOID_OOM = "clang-native rust-native rust-llvm-native"
 
+LMPSTAGING_KERN_ADD_ST_SUBDIR = ""
+
 python __anonymous() {
     pn = d.getVar('PN')
+
+    if pn == "linux-lmp" or pn == "linux-lmp-rt":
+        (major_ver, minor_ver, rest) = d.getVar('LINUX_VERSION').split(".")
+        if int(major_ver) > 6 or (int(major_ver) == 6 and int(minor_ver) >= 4):
+            d.setVar('LMPSTAGING_KERN_ADD_ST_SUBDIR',  'st/')
 
     if bb.data.inherits_class('module', d):
         d.appendVar('DEPENDS', ' virtual/kernel')

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -634,7 +634,7 @@ LMP_FLASHLAYOUT_BOARD_NAME:stm32mp15-eval = "stm32mp157c-ev1"
 LMP_BOOT_FIRMWARE_FILES:stm32mp15-eval = "arm-trusted-firmware/tf-a-stm32mp157c-ev1-emmc.stm32 fip/fip-stm32mp157c-ev1-optee.bin"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS:append:stm32mp15-eval = " kernel kernel-devicetree u-boot-default-script"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS:remove:sota:stm32mp15-eval = "kernel kernel-devicetree u-boot-default-script"
-KERNEL_DEVICETREE:stm32mp15-eval = "st/stm32mp157c-ev1-scmi.dtb"
+KERNEL_DEVICETREE:stm32mp15-eval = "${LMPSTAGING_KERN_ADD_ST_SUBDIR}stm32mp157c-ev1-scmi.dtb"
 ## stm32mp15-disco
 TF_A_SIGN_ENABLE:sota:stm32mp15-disco = "1"
 UBOOT_SIGN_ENABLE:sota:stm32mp15-disco = "1"
@@ -656,7 +656,7 @@ WKS_FILE_DEPENDS:remove:stm32mp15-disco = "st-image-bootfs st-image-userfs"
 WKS_FILE:stm32mp15-disco = "sdimage-stm32mp157c-dk2-optee.wks.in"
 WKS_FILE:sota:stm32mp15-disco = "sdimage-stm32mp157c-dk2-optee-sota.wks.in"
 LMP_BOOT_FIRMWARE_FILES:stm32mp15-disco = "arm-trusted-firmware/tf-a-stm32mp157c-dk2-sdcard.stm32 fip/fip-stm32mp157c-dk2-optee.bin"
-KERNEL_DEVICETREE:stm32mp15-disco = "st/stm32mp157c-dk2-scmi.dtb"
+KERNEL_DEVICETREE:stm32mp15-disco = "${LMPSTAGING_KERN_ADD_ST_SUBDIR}stm32mp157c-dk2-scmi.dtb"
 ## stm32mp15-eval-sec
 SOTA_CLIENT_FEATURES:remove:sota:stm32mp15-eval-sec = "ubootenv"
 


### PR DESCRIPTION
We need to support kernel versions with and without vendor subdirs
for arm architecture dts files. Replace a static prefix with a
dynamic one set according to a kernel version.