### PR TITLE
linux-lmp: rework a versioning of patches

### DIFF
--- a/meta-lmp-base/classes/lmp-staging.bbclass
+++ b/meta-lmp-base/classes/lmp-staging.bbclass
@@ -9,15 +9,8 @@ LMPSTAGING_INHERIT_KERNEL_MODSIGN = ""
 
 LMPSTAGING_LOCK_TO_AVOID_OOM = "clang-native rust-native rust-llvm-native"
 
-LMPSTAGING_KERN_ADD_ST_SUBDIR = ""
-
 python __anonymous() {
     pn = d.getVar('PN')
-
-    if pn == "linux-lmp" or pn == "linux-lmp-rt":
-        (major_ver, minor_ver, rest) = d.getVar('LINUX_VERSION').split(".")
-        if int(major_ver) > 6 or (int(major_ver) == 6 and int(minor_ver) >= 4):
-            d.setVar('LMPSTAGING_KERN_ADD_ST_SUBDIR',  'st/')
 
     if bb.data.inherits_class('module', d):
         d.appendVar('DEPENDS', ' virtual/kernel')

--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp-dev-mfgtool_git.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp-dev-mfgtool_git.bb
@@ -2,6 +2,8 @@ SUMMARY = "Produces a Manufacturing Tool compatible Linux Kernel"
 DESCRIPTION = "Linux Kernel recipe that produces a Manufacturing Tool \
 compatible Linux Kernel to be used in updater environment"
 
+KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = "1"
+
 # Use Freescale kernel by default
 KERNEL_REPO ?= "git://github.com/Freescale/linux-fslc.git"
 KERNEL_REPO_PROTOCOL ?= "https"

--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp-rt_6.1.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp-rt_6.1.bb
@@ -1,5 +1,7 @@
 include kmeta-linux-lmp-6.1.y.inc
 
+KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = "1"
+
 LINUX_VERSION ?= "6.1.90"
 KBRANCH = "linux-v6.1.y-rt"
 SRCREV_machine = "2c3f38782b565814ef32e585ce978327ff3dd96d"

--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp.inc
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp.inc
@@ -1,6 +1,10 @@
 DESCRIPTION = "Common Foundries.io Linux microPlatform Kernel"
 
-PV = "${LINUX_VERSION}+git${SRCPV}"
+# Save the original PV as KSHORT_VER for further use
+python __anonymous () {
+    d.setVar('KSHORT_VER', d.getVar("PV"))
+    d.setVar('PV', d.getVar("LINUX_VERSION") + d.getVar("SRCPV"))
+}
 
 KERNEL_FEATURES += "${@bb.utils.contains('MACHINE_FEATURES', 'jailhouse', ' features/jailhouse/jailhouse.scc', '', d)}"
 

--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp.inc
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp.inc
@@ -26,3 +26,31 @@ do_deploy:append() {
     cp -a ${B}/.config ${DEPLOYDIR}/${KERNEL_CONFIG_NAME}
     ln -sf ${KERNEL_CONFIG_NAME} ${DEPLOYDIR}/${KERNEL_CONFIG_LINK_NAME}
 }
+
+# Backport this function from meta-freescale:
+# f06c7376 ("linux: Add compatibility logic for 32-bit dtb move")
+# A function to strip the new 32-bit dtb sub-folders in KERNEL_DEVICETREE
+# for older kernel builds.
+# Set KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = "1" to enable.
+KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE ?= "0"
+python kernel_devicetree_32bit_compatibility_update() {
+    import os.path
+    import re
+    if d.getVar('KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE') != "1" or d.getVar('TUNE_ARCH') != "arm":
+        return
+    input = d.getVar('KERNEL_DEVICETREE').split()
+    output = ""
+    stripped = ""
+    for original in input:
+        if re.match("^.*/", original):
+            stripped = os.path.basename(original)
+            output += stripped + " "
+            bb.debug(1, "Devicetrees are moved to sub-folder, stripping the sub-folder for older kernel: %s -> %s" % (original, stripped))
+        else:
+            output += original + " "
+    if stripped:
+        bb.warn("Updating KERNEL_DEVICETREE, removing sub-folders for older kernel. Use -D for more details. Set KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = \"0\" to disable.")
+        d.setVar('KERNEL_DEVICETREE', output)
+}
+addhandler kernel_devicetree_32bit_compatibility_update
+kernel_devicetree_32bit_compatibility_update[eventmask] = "bb.event.RecipeParsed"

--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp_6.1.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp_6.1.bb
@@ -1,5 +1,7 @@
 include kmeta-linux-lmp-6.1.y.inc
 
+KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = "1"
+
 LINUX_VERSION ?= "6.1.90"
 KBRANCH = "linux-v6.1.y"
 SRCREV_machine = "c505f2906af8638a5117f640e934f5f0de121c4b"

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -7,7 +7,7 @@ WKS_FILE_DEPENDS:append:beaglebone-yocto = " u-boot-default-script"
 PREFERRED_PROVIDER_u-boot-default-script:beaglebone-yocto = "u-boot-ostree-scr-fit"
 SOTA_CLIENT_FEATURES:append:beaglebone-yocto = " ubootenv"
 OSTREE_KERNEL_ARGS:beaglebone-yocto ?= "console=ttyS0,115200n8 ${OSTREE_KERNEL_ARGS_COMMON}"
-KERNEL_DEVICETREE:append:beaglebone-yocto = " am335x-boneblack-wireless.dtb"
+KERNEL_DEVICETREE:append:beaglebone-yocto = " ti/omap/am335x-boneblack-wireless.dtb"
 IMAGE_BOOT_FILES:beaglebone-yocto = "u-boot.img MLO boot.itb"
 KERNEL_IMAGETYPE:beaglebone-yocto = "fitImage"
 KERNEL_CLASSES:beaglebone-yocto = " kernel-lmp-fitimage "
@@ -193,7 +193,7 @@ PREFERRED_VERSION_u-boot-fio:mx6ul-nxp-bsp ?= "imx-2023.04"
 # iMX6UL EVK
 UBOOT_SIGN_ENABLE:sota:imx6ulevk ?= "1"
 SOTA_CLIENT_FEATURES:append:imx6ulevk = " ubootenv"
-KERNEL_DEVICETREE:imx6ulevk = "imx6ul-14x14-evk.dtb"
+KERNEL_DEVICETREE:imx6ulevk = "nxp/imx/imx6ul-14x14-evk.dtb"
 BOOTSCR_LOAD_ADDR:imx6ulevk = "0x85000000"
 
 # iMX6ULL
@@ -221,7 +221,7 @@ PREFERRED_VERSION_u-boot-fio:mx6ull-nxp-bsp ?= "imx-2023.04"
 # iMX6ULL EVK
 UBOOT_SIGN_ENABLE:sota:imx6ullevk ?= "1"
 SOTA_CLIENT_FEATURES:append:imx6ullevk = " ubootenv"
-KERNEL_DEVICETREE:imx6ullevk = "imx6ull-14x14-evk.dtb"
+KERNEL_DEVICETREE:imx6ullevk = "nxp/imx/imx6ull-14x14-evk.dtb"
 BOOTSCR_LOAD_ADDR:imx6ullevk = "0x85000000"
 
 # iMX8QM
@@ -637,7 +637,7 @@ LMP_FLASHLAYOUT_BOARD_NAME:stm32mp15-eval = "stm32mp157c-ev1"
 LMP_BOOT_FIRMWARE_FILES:stm32mp15-eval = "arm-trusted-firmware/tf-a-stm32mp157c-ev1-emmc.stm32 fip/fip-stm32mp157c-ev1-optee.bin"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS:append:stm32mp15-eval = " kernel kernel-devicetree u-boot-default-script"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS:remove:sota:stm32mp15-eval = "kernel kernel-devicetree u-boot-default-script"
-KERNEL_DEVICETREE:stm32mp15-eval = "${LMPSTAGING_KERN_ADD_ST_SUBDIR}stm32mp157c-ev1-scmi.dtb"
+KERNEL_DEVICETREE:stm32mp15-eval = "st/stm32mp157c-ev1-scmi.dtb"
 ## stm32mp15-disco
 TF_A_SIGN_ENABLE:sota:stm32mp15-disco = "1"
 UBOOT_SIGN_ENABLE:sota:stm32mp15-disco = "1"
@@ -659,7 +659,7 @@ WKS_FILE_DEPENDS:remove:stm32mp15-disco = "st-image-bootfs st-image-userfs"
 WKS_FILE:stm32mp15-disco = "sdimage-stm32mp157c-dk2-optee.wks.in"
 WKS_FILE:sota:stm32mp15-disco = "sdimage-stm32mp157c-dk2-optee-sota.wks.in"
 LMP_BOOT_FIRMWARE_FILES:stm32mp15-disco = "arm-trusted-firmware/tf-a-stm32mp157c-dk2-sdcard.stm32 fip/fip-stm32mp157c-dk2-optee.bin"
-KERNEL_DEVICETREE:stm32mp15-disco = "${LMPSTAGING_KERN_ADD_ST_SUBDIR}stm32mp157c-dk2-scmi.dtb"
+KERNEL_DEVICETREE:stm32mp15-disco = "st/stm32mp157c-dk2-scmi.dtb"
 ## stm32mp15-eval-sec
 SOTA_CLIENT_FEATURES:remove:sota:stm32mp15-eval-sec = "ubootenv"
 

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.1.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.1.bb
@@ -3,6 +3,8 @@
 # recipe available in -rt recipe.
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
+KERNEL_DEVICETREE_32BIT_COMPATIBILITY_UPDATE = "1"
+
 include recipes-kernel/linux/linux-lmp-fslc-imx.inc
 
 include recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp_%.bbappend
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}/${KSHORT_VER}:${THISDIR}/${PN}:"
+
+SRC_URI:append:stm32mp15-disco = " \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'se05x', "file://0001-FIO-internal-arch-arm-dts-stm32mp157c-dk2-enable-I2C.patch", '', d)} \
+"

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp_6.1.bbappend
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp_6.1.bbappend
@@ -1,5 +1,0 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-
-SRC_URI:append:stm32mp15-disco = " \
-    ${@bb.utils.contains('MACHINE_FEATURES', 'se05x', 'file://6.1/0001-FIO-internal-arch-arm-dts-stm32mp157c-dk2-enable-I2C.patch', '', d)} \
-"

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp_6.6.bbappend
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp_6.6.bbappend
@@ -1,5 +1,0 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-
-SRC_URI:append:stm32mp15-disco = " \
-    ${@bb.utils.contains('MACHINE_FEATURES', 'se05x', 'file://6.6/0001-FIO-internal-arch-arm-dts-stm32mp157c-dk2-enable-I2C.patch', '', d)} \
-"


### PR DESCRIPTION
It simplifies the versioning and prepares lmp to support 2 kernel versions of linux kernel versions with a lot of patches like linux-lmp-fslc-imx.

I removed switching linux-lmp to 6.6 as it needs to bump meta-freescale* as well, we can switch to 6.6 once all changes for all linux-lmp* are in place.