### PR TITLE
Bump aklite and composectl

### DIFF
--- a/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
+++ b/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
@@ -1,13 +1,13 @@
 DESCRIPTION = "A CLI utility to manage compose apps"
 
 SECTION = "devel"
-LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=2a944942e1496af1886903d274dedb13"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=504a5c2455c8bb2fc5b7667833ab1a68"
 
 GO_IMPORT = "github.com/foundriesio/composeapp"
 GO_IMPORT_PROTO ?= "https"
 SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO};branch=main"
-SRCREV = "5419dab59df5b546f78269570bb47bb871654b8f"
+SRCREV = "ebbba333aaefb642edbdb5e55e71f8d0c390322e"
 UPSTREAM_CHECK_COMMITS = "1"
 
 inherit go-mod

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "95ecfb878f60c8ee3c6c6b67b618567c6db5777e"
+SRCREV:lmp = "f07b189fb2f9ea46c01764d379dbcbdc63524723"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
- Add callback support to the offline updater.
- Add bundle metadata support to the offline updater. The bundle metadata are signed by TUF targets role key and contains description of the bundle, i.e. tag, bundle targets, whether it is prod or CI bundle, etc. The offline updater checks the bundle metadata signature and use information found in it to determine whether an update should be permitted, possible, and what targets can be installed.
- Move app functionality to check whether app is fetched, installed, and running from aklite to composectl.