### PR TITLE
base: lmp-feature-wifi: drop linux-firmware packages

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-feature-wifi.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-wifi.inc
@@ -1,12 +1,5 @@
 # Wifi packages
 CORE_IMAGE_BASE_INSTALL += " \
     hostapd \
-    linux-firmware-ar3k \
-    linux-firmware-ath9k \
-    linux-firmware-ath10k \
-    linux-firmware-qca \
-    linux-firmware-wl18xx \
-    ${@bb.utils.contains('MACHINE_EXTRA_RRECOMMENDS', 'linux-firmware-rpidistro-bcm43430', 'linux-firmware-rpidistro-bcm43430', 'linux-firmware-bcm43430', d)} \
-    ${@bb.utils.contains('MACHINE_EXTRA_RRECOMMENDS', 'linux-firmware-rpidistro-bcm43455', 'linux-firmware-rpidistro-bcm43455', 'linux-firmware-bcm43455', d)} \
     ${@bb.utils.contains('MACHINE_FEATURES', 'mxm-mwifiex-load', 'mxm-mwifiex-setup', '', d)} \
 "


### PR DESCRIPTION
Required linux-firmware packages should be machine specific (required by machine configuration or machine specific image override) instead of generic to every image.