### PR TITLE
Bump aklite and composectl

### DIFF
--- a/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
+++ b/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=504a5c2455c8bb2fc5b76678
 GO_IMPORT = "github.com/foundriesio/composeapp"
 GO_IMPORT_PROTO ?= "https"
 SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO};branch=main"
-SRCREV = "ebbba333aaefb642edbdb5e55e71f8d0c390322e"
+SRCREV = "1b6f1f2d8f55d40fef10c8ddfef224a9a58caa27"
 UPSTREAM_CHECK_COMMITS = "1"
 
 inherit go-mod

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "f07b189fb2f9ea46c01764d379dbcbdc63524723"
+SRCREV:lmp = "6df80343d752305d9cb1e72323eb5b274323c664"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
Use `composectl` to uninstall, rm, and prune apps and their images and containers.