### PR TITLE
base: systemd: switch to cgroupv2 by default

### DIFF
--- a/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-lmp-base/recipes-core/systemd/systemd_%.bbappend
@@ -10,6 +10,7 @@ PACKAGECONFIG ?= " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'efi', 'gnu-efi', '', d)} \
     backlight \
     binfmt \
+    cgroupv2 \
     cryptsetup \
     cryptsetup-plugins \
     gshadow \


### PR DESCRIPTION
There is no reason anymore to keep using cgroupv1 (every component using cgroups is already v2 compatible), so switch to v2 by default, as done on every major linux distribution.

https://github.com/opencontainers/runc/blob/main/docs/cgroup-v2.md