### PR TITLE
Bump aklite and composectl

### DIFF
--- a/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
+++ b/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=504a5c2455c8bb2fc5b76678
 GO_IMPORT = "github.com/foundriesio/composeapp"
 GO_IMPORT_PROTO ?= "https"
 SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO};branch=main"
-SRCREV = "1b6f1f2d8f55d40fef10c8ddfef224a9a58caa27"
+SRCREV = "3787eda71c4e9d556ac0fbc433c56e633cf58cd6"
 UPSTREAM_CHECK_COMMITS = "1"
 
 inherit go-mod

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "master"
-SRCREV:lmp = "6df80343d752305d9cb1e72323eb5b274323c664"
+SRCREV:lmp = "c1e78acceb264ee55c23256c1868339e54a4e47d"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
- aklite: Fixes of non-critical issues in app status checking and pruning.
- aklite: Handle all edge cases of app shortlisting for an offline update.
- composectl: Store `aklite/skopeo` specific files safely (fsync).