### PR TITLE
base: non-clangable: build zeromq with gcc

### DIFF
--- a/meta-lmp-base/conf/distro/include/non-clangable.inc
+++ b/meta-lmp-base/conf/distro/include/non-clangable.inc
@@ -212,3 +212,6 @@ TOOLCHAIN:pn-libmali-xlnx = "gcc"
 
 # isp-imx fails to build with clang
 TOOLCHAIN:pn-isp-imx = "gcc"
+
+# zmq_bind missing when built with clang, causing crashes at runtime
+TOOLCHAIN:pn-zeromq = "gcc"


### PR DESCRIPTION
Function zmq_bind missing when built with clang, causing crashes at runtime, so force build with gcc for now.