### PR TITLE
base: rc: composeapp: Bump version to 2488a0e

### DIFF
--- a/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
+++ b/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=504a5c2455c8bb2fc5b76678
 GO_IMPORT = "github.com/foundriesio/composeapp"
 GO_IMPORT_PROTO ?= "https"
 SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO};branch=main"
-SRCREV = "3787eda71c4e9d556ac0fbc433c56e633cf58cd6"
+SRCREV = "2488a0e79aa4301e87650a7fdd4ce1e21ad1217a"
 UPSTREAM_CHECK_COMMITS = "1"
 
 inherit go-mod
@@ -16,7 +16,7 @@ GO_INSTALL = "${GO_IMPORT}/cmd/composectl"
 GO_EXTRA_LDFLAGS = "\
     -X '${GO_IMPORT}/cmd/composectl/cmd.storeRoot=/var/sota/reset-apps' \
     -X '${GO_IMPORT}/cmd/composectl/cmd.composeRoot=/var/sota/compose-apps' \
-    -X '${GO_IMPORT}/cmd/composectl/cmd.overrideConfigDir=/usr/lib/docker' \
+    -X '${GO_IMPORT}/cmd/composectl/cmd.baseSystemConfig=/usr/lib/docker' \
 "
 do_install:append() {
     cd ${D}/${bindir}


### PR DESCRIPTION
Relevant changes:
- 17796ca Add ability to define a system-wide base config