### PR TITLE
base: rc: composeapp: Bump version 5691069

### DIFF
--- a/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
+++ b/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
@@ -6,8 +6,9 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=504a5c2455c8bb2fc5b76678
 
 GO_IMPORT = "github.com/foundriesio/composeapp"
 GO_IMPORT_PROTO ?= "https"
-SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO};branch=main"
-SRCREV = "2488a0e79aa4301e87650a7fdd4ce1e21ad1217a"
+SRCBRANCH = "v94"
+SRCREV = "5691069fd3fb823a658bfdb3271245c2dee5686a"
+SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO};branch=${SRCBRANCH}"
 UPSTREAM_CHECK_COMMITS = "1"
 
 inherit go-mod


### PR DESCRIPTION
Relevant changes:
- f1e3fce root: Add command to print version

Also, switching to the version branch usage. It simplifies bug fixing and their delivering to customers if LmP version goes further.  