### PR TITLE
[RFC] Fioefi feature

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr-fioefi-env-rollback.bb
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr-fioefi-env-rollback.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Aktualizr configuration snippet to enable Foundries.IO UEFI Capsule updates"
+HOMEPAGE = "https://github.com/advancedtelematic/aktualizr"
+SECTION = "base"
+LICENSE = "MPL-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MPL-2.0;md5=815ca599c9df247a0c7f619bab123dad"
+
+inherit allarch
+
+SRC_URI = "file://sota-fioefi-env.toml"
+
+PV = "1.0"
+
+S = "${WORKDIR}"
+
+do_install() {
+    install -m 0700 -d ${D}${libdir}/sota/conf.d
+    install -m 0644 ${WORKDIR}/sota-fioefi-env.toml ${D}${libdir}/sota/conf.d/30-rollback.toml
+}
+
+FILES:${PN} = " \
+    ${libdir}/sota/conf.d \
+    ${libdir}/sota/conf.d/30-rollback.toml \
+"

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr-fioefi-env-rollback/sota-fioefi-env.toml
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr-fioefi-env-rollback/sota-fioefi-env.toml
@@ -1,0 +1,2 @@
+[bootloader]
+rollback_mode = "fioefi"

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -10,8 +10,9 @@ SRC_URI:append:lmp = " \
     file://tmpfiles.conf \
     "
 
-PACKAGECONFIG += "${@bb.utils.filter('MACHINE_FEATURES', 'fiovb', d)} libfyaml"
-PACKAGECONFIG[fiovb] = ",,,optee-fiovb aktualizr-fiovb-env-rollback"
+PACKAGECONFIG += "${@bb.utils.filter('MACHINE_FEATURES', 'fiovb', d)} ${@bb.utils.filter('MACHINE_FEATURES', 'fioefi', d)} libfyaml"
+PACKAGECONFIG[fiovb] = ",,,optee-fiovb aktualizr-fiovb-env-rollback,,fioefi"
+PACKAGECONFIG[fioefi] = ",,,fioefi aktualizr-fioefi-env-rollback,,fiovb"
 PACKAGECONFIG[ubootenv] = ",,u-boot-fw-utils,u-boot-fw-utils u-boot-default-env aktualizr-uboot-env-rollback"
 PACKAGECONFIG[libfyaml] = ",,,libfyaml"
 PACKAGECONFIG[aklite-offline] = "-DBUILD_AKLITE_OFFLINE=ON,-DBUILD_AKLITE_OFFLINE=OFF,"

--- a/meta-lmp-base/recipes-sota/fioefi/fioefi/fioefi.sh.in
+++ b/meta-lmp-base/recipes-sota/fioefi/fioefi/fioefi.sh.in
@@ -1,0 +1,58 @@
+#!/bin/sh
+#
+# Copyright (C) 2024 Foundries.IO
+#
+# SPDX-License-Identifier: MIT
+#
+set -e
+
+scriptName="$(basename "$0")"
+
+error_exit() {
+	if [ -n "${1}" ] ; then
+		echo "ERROR:  ${1}"
+	else
+		echo "ERROR: Command execution failure"
+	fi
+	exit 1
+}
+
+debug() {
+	if [ -n "${1}" ] ; then
+		echo "DEBUG: ${1}"
+	else
+		echo "DEBUG: Command execution failure"
+	fi
+}
+
+matches() {
+	input="$1"
+	pattern="$2"
+	echo "$input" | grep -q "$pattern"
+}
+
+@@INCLUDE_SOC_FUNCTIONS@@
+
+# Mock functions. On real targets only *_soc implementations
+# should be used
+getenv() {
+	debug "Get value of '${1}'"
+}
+
+setenv() {
+	debug "Assign value '${1} = ${2}'"
+}
+
+if matches "$scriptName" "printenv"; then
+	if type 'getenv_soc' 2>/dev/null | grep -q 'function'; then
+		getenv_soc "${1}"
+	else
+		getenv "${1}"
+	fi
+elif matches "$scriptName" "setenv"; then
+	if type 'setenv_soc' 2>/dev/null | grep -q 'function'; then
+		setenv_soc "${1}" "${2}"
+	else
+		setenv "${1}" "${2}"
+	fi
+fi

--- a/meta-lmp-base/recipes-sota/fioefi/fioefi_0.1.bb
+++ b/meta-lmp-base/recipes-sota/fioefi/fioefi_0.1.bb
@@ -1,0 +1,25 @@
+SUMMARY = "OP-TEE Foundries.IO UEFI Firmware Update control script"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI = "file://fioefi.sh.in"
+
+S = "${WORKDIR}"
+B = "${WORKDIR}/build"
+
+do_compile() {
+    # Check if the file wasn't created by soc-specific do_compile() prepend
+    if [ ! -e ${B}/fioefi ]; then
+        sed -e 's/@@INCLUDE_SOC_FUNCTIONS@@//g' ${S}/fioefi.sh.in > ${B}/fioefi
+    fi
+}
+
+do_install () {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/fioefi ${D}${bindir}/fioefi
+    ln -sf fioefi ${D}${bindir}/fioefi_printenv
+    ln -sf fioefi ${D}${bindir}/fioefi_setenv
+    ln -sf fioefi ${D}${bindir}/fioefi_delenv
+}

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -765,6 +765,8 @@ OSTREE_BOOTLOADER:tegra ?= "syslinux"
 OSTREE_DEPLOY_DEVICETREE:tegra = "1"
 PREFERRED_PROVIDER_virtual/optee-os:tegra = "optee-os"
 MACHINE_FEATURES:append:tegra = " optee"
+SOTA_CLIENT_FEATURES:remove:sota:tegra = "ubootenv"
+MACHINE_FEATURES:append:sota:tegra = " fioefi"
 ## jetson-agx-xavier-devkit (tegra194)
 OSTREE_KERNEL_ARGS:tegra194 ?= "\${cbootargs} ${OSTREE_KERNEL_ARGS_COMMON} rootwait mminit_loglevel=4 console=tty0 console=ttyTCU0,115200 fbcon=map:0 video=efifb:off sdhci_tegra.en_boot_part_access=1"
 ## jetson-agx-orin-devkit (tegra234)

--- a/meta-lmp-bsp/recipes-sota/fioefi/fioefi/tegra/fioefi-soc.sh.in
+++ b/meta-lmp-bsp/recipes-sota/fioefi/fioefi/tegra/fioefi-soc.sh.in
@@ -1,0 +1,23 @@
+CAPSULE_FILE="tegra-bl.cap"
+CAPSULE_PATH="${FIO_OSTREE_TARGET_SYSROOT}/usr/lib/firmware/"
+EFI_DIR=/boot/efi/EFI/UpdateCapsule
+
+getenv_soc() {
+	exit 0
+}
+
+setenv_soc() {
+	rc=0
+	if [ "${1}" = "bootupgrade_available" ]; then
+		if [ -z "${FIO_OSTREE_TARGET_SYSROOT}" ]; then
+			exit 1
+		fi
+		if [ -e "$CAPSULE_PATH/$CAPSULE_FILE" ]; then
+			cp $CAPSULE_PATH/$CAPSULE_FILE $EFI_DIR || rc=1
+			oe4t-set-uefi-OSIndications || rc=1
+		else
+			rc=1
+		fi
+	fi
+	exit $rc
+}

--- a/meta-lmp-bsp/recipes-sota/fioefi/fioefi_%.bbappend
+++ b/meta-lmp-bsp/recipes-sota/fioefi/fioefi_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = " file://fioefi-soc.sh.in"
+
+RDEPENDS:${PN}:append:tegra = "setup-nv-boot-control"
+
+do_compile:prepend() {
+    sed -e '/@@INCLUDE_SOC_FUNCTIONS@@/ {' -e 'r ${S}/fioefi-soc.sh.in' -e 'd' -e '}' \
+        ${S}/fioefi.sh.in > ${B}/fioefi
+}


### PR DESCRIPTION
Depends on:
https://github.com/OE4T/meta-tegra/pull/1575
https://github.com/foundriesio/aktualizr-lite/pull/325
https://github.com/foundriesio/aktualizr-lite/pull/326
https://github.com/foundriesio/aktualizr/pull/75
https://github.com/OE4T/meta-tegra/pull/1527


Additionally we need to add these changes (but this requires a bump to new meta-tegra with https://github.com/OE4T/meta-tegra/pull/1527 merged):
```
LMP_BOOT_FIRMWARE_FILES:tegra = "tegra-bl.cap"
```
and in `meta-lmp-bsp/recipes-bsp/lmp-boot-firmware/lmp-boot-firmware.bbappend`:

```
DEPENDS:append:tegra = "tegra-uefi-capsules"
RDEPENDS:${PN}:append:tegra = "setup-nv-boot-control"
```