### PR TITLE
base: tpm2-tss: drop libgcrypt

### DIFF
--- a/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-tss/tpm2-tss_4.0.1.bb
+++ b/meta-lmp-base/dynamic-layers/tpm-layer/recipes-tpm2/tpm2-tss/tpm2-tss_4.0.1.bb
@@ -4,7 +4,7 @@ LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=500b2e742befc3da00684d8a1d5fd9da"
 SECTION = "tpm"
 
-DEPENDS = "autoconf-archive-native libgcrypt openssl"
+DEPENDS = "autoconf-archive-native openssl"
 
 SRC_URI = "https://github.com/tpm2-software/${BPN}/releases/download/${PV}/${BPN}-${PV}.tar.gz \
            file://fixup_hosttools.patch \
@@ -89,5 +89,3 @@ FILES:${PN} = "\
     ${sysconfdir}/tmpfiles.d \
     ${sysconfdir}/tpm2-tss \
     ${sysconfdir}/sysusers.d"
-
-RDEPENDS:libtss2 = "libgcrypt"


### PR DESCRIPTION
Upstream removed gcrypt backend as part of the 3.0.0 release (https://github.com/tpm2-software/tpm2-tss/pull/1781), but it was not removed from the recipe during the update.

Also sent to meta-security: https://lists.yoctoproject.org/g/yocto-patches/message/361