### PR TITLE
bsp: meson: fixup the imx meson backported

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -151,8 +151,8 @@ OSTREE_KERNEL_ARGS:mx6ull-generic-bsp ?= "console=tty1 console=ttymxc0,115200 ${
 OSTREE_KERNEL_ARGS:mx7d-generic-bsp ?= "console=tty1 console=ttymxc0,115200 ${OSTREE_KERNEL_ARGS_COMMON}"
 OSTREE_KERNEL_ARGS:mx7ulp-generic-bsp ?= "console=tty1 console=ttyLP0,115200 ${OSTREE_KERNEL_ARGS_COMMON}"
 
-PREFERRED_VERSION_meson:imx8-nxp-bsp ?= "0.63.3.imx"
-PREFERRED_VERSION_meson:imx9-nxp-bsp ?= "0.63.3.imx"
+PREFERRED_VERSION_meson ?= "0.61.3"
+PREFERRED_VERSION_meson:imx-generic-bsp ?= "0.63.3.imx"
 
 # Embedded Artists i.MX7ULP COM
 UBOOT_SIGN_ENABLE:sota:imx7ulpea-ucom ?= "1"


### PR DESCRIPTION
Using the DEFAULT_PREFERENCE on the meson_0.63.3.imx.bb does not work in this case because
we cannot use the DEFAULT_PREFERENCE to choose versions in lower priority layers,
which are basically almost all of them because we have a very high priority value on the
BBFILE_PRIORITY.
So we need to also set the default PREFERRED_VERSION_meson with the version available
on oe-core because we can't use the DEFAULT_PREFERENCE.
Another issue fixed was the overrides used imx8-nxp-bsp and imx9-nxp-bsp that are not defined
on the IMX bsp layer, we can use the imx-generic-bsp which is common to all IMX.