### PR TITLE
base: optee-fiovb: update to d659770

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-fiovb_git.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-fiovb_git.bb
@@ -8,7 +8,7 @@ DEPENDS = "optee-client optee-os-tadevkit"
 require optee-fio.inc
 
 SRC_URI = "git://github.com/foundriesio/optee-fiovb.git;protocol=https;branch=master"
-SRCREV = "2c20a4af345a9dc1dcb4bb61e405301a9053065b"
+SRCREV = "d65977034839e01fc69c9577071059b84ea08f1d"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 


### PR DESCRIPTION
Relevant changes:
- d659770 Makefile: break build if VENDOR_CREATE is set but no prefix was provided
- ff5c4d1 ta: avoid creating vendor variables with "vendor_" prefix
- e38e905 ta: only create vendor variables if CFG_FIOVB_VENDOR_CREATE is set