### PR TITLE
bsp: stm32mp15-disco: fix size of u-boot-env partition

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -609,7 +609,7 @@ FLASHLAYOUT_PARTITION_OFFSET:lmp:sdcard:u-boot-env = "0x00900000"
 FLASHLAYOUT_PARTITION_TYPE:lmp:sdcard:u-boot-env = "Binary"
 # RootFS
 FLASHLAYOUT_PARTITION_ENABLE:lmp:sdcard:rootfs = "P"
-FLASHLAYOUT_PARTITION_OFFSET:lmp:sdcard:rootfs = "0x00910000"
+FLASHLAYOUT_PARTITION_OFFSET:lmp:sdcard:rootfs = "0x00904000"
 FLASHLAYOUT_PARTITION_BIN2LOAD:lmp:sdcard:rootfs = "${MFGTOOL_FLASH_IMAGE}.bin"
 FLASHLAYOUT_PARTITION_TYPE:lmp:sdcard:rootfs = "System"
 


### PR DESCRIPTION
Fix the size of u-boot-env partition, which should be 0x4000 as defined in CONFIG_ENV_SIZE, otherwise U-Boot uses the last 0x4000 bytes to place the environment [1].

[1] https://github.com/u-boot/u-boot/blob/v2024.04/env/mmc.c#L124
Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>