### PR TITLE
bsp: lmp-boot-firmware: tegra: depend on tegra-uefi-capsules

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-bsp/lmp-boot-firmware/lmp-boot-firmware.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-bsp/lmp-boot-firmware/lmp-boot-firmware.bbappend
@@ -1,0 +1,3 @@
+TEGRA_INSTALL_DEPENDS ?= ""
+TEGRA_INSTALL_DEPENDS:tegra = "tegra-uefi-capsules:do_install"
+do_install[depends] += "${TEGRA_INSTALL_DEPENDS}"


### PR DESCRIPTION
Add dependency on tegra-uefi-capsules for lmp-boot-firmware on tegra machines.