### PR TITLE
base: rs: aktualizr: Bump version to d2cd79e

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "v94"
-SRCREV:lmp = "0271e31b726997ad0dc0fece555cb9af7bf6836b"
+SRCREV:lmp = "d2cd79e1dc6a3c992d37de4d1609d4bdf9b750ec"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \

--- a/meta-lmp-base/recipes-sota/custom-sota-client/custom-sota-client_git.bb
+++ b/meta-lmp-base/recipes-sota/custom-sota-client/custom-sota-client_git.bb
@@ -10,8 +10,8 @@ SRC_URI = "\
     file://systemd.service \
 "
 
-BRANCH = "master"
-SRCREV = "95ecfb878f60c8ee3c6c6b67b618567c6db5777e"
+BRANCH = "v94"
+SRCREV = "d2cd79e1dc6a3c992d37de4d1609d4bdf9b750ec"
 
 S = "${WORKDIR}/git/examples/custom-client-cxx"
 


### PR DESCRIPTION
Revert use of `composectl ps` in aklite.

Relevant changes:
- 3879cfa Revert: "apps: Use `composectl` to check whether app is running"
- f9926c1 Revert: "apps: Use `composectl` to get running apps status"