### PR TITLE
bsp: linux-lmp-fslc: bump kernel 6.1-2.2.x-imx to 1e6abd59ab9ff1

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-FIO-extras-arm64-dts-imx8mm-evk-use-imx8mm-evkb-for-.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-FIO-extras-arm64-dts-imx8mm-evk-use-imx8mm-evkb-for-.patch
@@ -1,4 +1,4 @@
-From a47f2cef1ce51c81e238622d5a3c6b20353f56d0 Mon Sep 17 00:00:00 2001
+From 39390475a682706cc0a095f2099ffcc385108e6e Mon Sep 17 00:00:00 2001
 From: Ricardo Salveti <ricardo@foundries.io>
 Date: Fri, 14 May 2021 13:36:10 -0300
 Subject: [PATCH] [FIO extras] arm64: dts: imx8mm-evk: use imx8mm-evkb for the
@@ -21,7 +21,7 @@ Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
  .../dts/freescale/imx8mm-evk-ecspi-slave.dts  |   2 +-
  .../imx8mm-evk-hifiberry-dacplus.dts          |   2 +-
  .../freescale/imx8mm-evk-iqaudio-dacplus.dts  |   2 +-
- .../freescale/imx8mm-evk-iqaudio-dacpro.dts   |  69 ++++++++-
+ .../freescale/imx8mm-evk-iqaudio-dacpro.dts   |  69 +++++++-
  .../boot/dts/freescale/imx8mm-evk-lk.dts      |   2 +-
  .../boot/dts/freescale/imx8mm-evk-pcie-ep.dts |   2 +-
  .../dts/freescale/imx8mm-evk-qca-wifi.dts     |   3 +-
@@ -29,15 +29,15 @@ Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
  .../boot/dts/freescale/imx8mm-evk-root.dts    |   2 +-
  .../boot/dts/freescale/imx8mm-evk-rpmsg.dts   |   2 +-
  .../dts/freescale/imx8mm-evk-usd-wifi.dts     |   2 +-
- arch/arm64/boot/dts/freescale/imx8mm-evk.dts  | 139 +----------------
- arch/arm64/boot/dts/freescale/imx8mm-evkb.dts | 142 ++++++++++++++++++
- 17 files changed, 227 insertions(+), 152 deletions(-)
+ arch/arm64/boot/dts/freescale/imx8mm-evk.dts  | 147 +----------------
+ arch/arm64/boot/dts/freescale/imx8mm-evkb.dts | 153 ++++++++++++++++++
+ 17 files changed, 237 insertions(+), 161 deletions(-)
  mode change 100755 => 100644 arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts
  mode change 100755 => 100644 arch/arm64/boot/dts/freescale/imx8mm-evk.dts
  create mode 100644 arch/arm64/boot/dts/freescale/imx8mm-evkb.dts
 
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-8mic-revE.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-8mic-revE.dts
-index 5facaecc733f..36d70369af08 100644
+index 5facaecc733f09..36d70369af083b 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-8mic-revE.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-8mic-revE.dts
 @@ -3,7 +3,7 @@
@@ -50,7 +50,7 @@ index 5facaecc733f..36d70369af08 100644
  / {
  	mic_leds {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-ak4497.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-ak4497.dts
-index ca8e5d7b35d8..4cf5b10b55a6 100644
+index ca8e5d7b35d84f..4cf5b10b55a6e6 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-ak4497.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-ak4497.dts
 @@ -3,7 +3,7 @@
@@ -63,7 +63,7 @@ index ca8e5d7b35d8..4cf5b10b55a6 100644
  / {
  	sound-ak4458 {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-ak5558.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-ak5558.dts
-index 4d3da8e33688..149b5cf67ce7 100644
+index 4d3da8e33688c3..149b5cf67ce76d 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-ak5558.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-ak5558.dts
 @@ -4,7 +4,7 @@
@@ -76,7 +76,7 @@ index 4d3da8e33688..149b5cf67ce7 100644
  / {
  	sound-ak5558 {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-dpdk.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-dpdk.dts
-index e600a7208c1f..08a4c3232ccf 100644
+index e600a7208c1ff4..08a4c3232ccf2e 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-dpdk.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-dpdk.dts
 @@ -3,7 +3,7 @@
@@ -89,7 +89,7 @@ index e600a7208c1f..08a4c3232ccf 100644
  &ethphy0 {
  	/delete-property/ reset-assert-us;
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-ecspi-slave.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-ecspi-slave.dts
-index e06dbc00d9dc..b0670f2cde37 100644
+index e06dbc00d9dc78..b0670f2cde372b 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-ecspi-slave.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-ecspi-slave.dts
 @@ -2,7 +2,7 @@
@@ -102,7 +102,7 @@ index e06dbc00d9dc..b0670f2cde37 100644
  /delete-node/&spidev0;
  
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-hifiberry-dacplus.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-hifiberry-dacplus.dts
-index 9115dd67eb70..47273b11ec6c 100644
+index 9115dd67eb7054..47273b11ec6c9e 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-hifiberry-dacplus.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-hifiberry-dacplus.dts
 @@ -3,7 +3,7 @@
@@ -115,7 +115,7 @@ index 9115dd67eb70..47273b11ec6c 100644
  / {
  	ext_osc_22m: ext-osc-22m {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacplus.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacplus.dts
-index 3a1ccd204a5a..e5df1348c8e3 100644
+index 3a1ccd204a5ad6..e5df1348c8e3ad 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacplus.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacplus.dts
 @@ -3,7 +3,7 @@
@@ -128,7 +128,7 @@ index 3a1ccd204a5a..e5df1348c8e3 100644
  / {
  	reg_3v3_vext: regulator-3v3-vext {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacpro.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacpro.dts
-index ce99f4338cd2..85b3ec59fef3 100644
+index ce99f4338cd2d7..85b3ec59fef306 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacpro.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-iqaudio-dacpro.dts
 @@ -3,10 +3,77 @@
@@ -211,7 +211,7 @@ index ce99f4338cd2..85b3ec59fef3 100644
 +	status = "okay";
 +};
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-lk.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-lk.dts
-index ccf3e9901e32..16e32e7f1aed 100644
+index ccf3e9901e323c..16e32e7f1aed06 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-lk.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-lk.dts
 @@ -3,7 +3,7 @@
@@ -224,7 +224,7 @@ index ccf3e9901e32..16e32e7f1aed 100644
  / {
  	interrupt-parent = <&gic>;
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-pcie-ep.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-pcie-ep.dts
-index 2f96420e3230..61202cae7f3b 100644
+index 2f96420e3230ef..61202cae7f3b89 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-pcie-ep.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-pcie-ep.dts
 @@ -5,7 +5,7 @@
@@ -239,7 +239,7 @@ index 2f96420e3230..61202cae7f3b 100644
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts
 old mode 100755
 new mode 100644
-index aa1a25f00f55..b5cbd103880d
+index aa1a25f00f5508..b5cbd103880d50
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-qca-wifi.dts
 @@ -5,10 +5,11 @@
@@ -256,7 +256,7 @@ index aa1a25f00f55..b5cbd103880d
  
  /delete-node/&pmic_nxp;
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-rm67191.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-rm67191.dts
-index 958912c409b2..d6563b7a41da 100644
+index 958912c409b2c7..d6563b7a41dadd 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-rm67191.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-rm67191.dts
 @@ -3,7 +3,7 @@
@@ -269,7 +269,7 @@ index 958912c409b2..d6563b7a41da 100644
  &adv_bridge {
  	status = "disabled";
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-root.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-root.dts
-index 426b0adc31ce..3986daaec096 100644
+index 426b0adc31ce61..3986daaec096f0 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-root.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-root.dts
 @@ -3,7 +3,7 @@
@@ -282,7 +282,7 @@ index 426b0adc31ce..3986daaec096 100644
  / {
  	interrupt-parent = <&gic>;
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-rpmsg.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-rpmsg.dts
-index 2a477c74b634..46e817739e9f 100644
+index 2a477c74b6343c..46e817739e9fe9 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-rpmsg.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-rpmsg.dts
 @@ -5,7 +5,7 @@
@@ -295,7 +295,7 @@ index 2a477c74b634..46e817739e9f 100644
  / {
  	reserved-memory {
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk-usd-wifi.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk-usd-wifi.dts
-index 9bf4ce755d5c..c9c792ca4c3d 100644
+index 9bf4ce755d5c15..c9c792ca4c3d40 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk-usd-wifi.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk-usd-wifi.dts
 @@ -5,7 +5,7 @@
@@ -310,15 +310,10 @@ index 9bf4ce755d5c..c9c792ca4c3d 100644
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evk.dts b/arch/arm64/boot/dts/freescale/imx8mm-evk.dts
 old mode 100755
 new mode 100644
-index bd7705d6d7a5..c5e542942aaf
+index 932bb7cc3bb981..3156cb0d49ed40
 --- a/arch/arm64/boot/dts/freescale/imx8mm-evk.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evk.dts
-@@ -1,143 +1,8 @@
- // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
- /*
-- * Copyright 2019-2020 NXP
-+ * Copyright 2021 Foundries.IO
-  */
+@@ -5,149 +5,4 @@
  
  /dts-v1/;
  
@@ -333,11 +328,15 @@ index bd7705d6d7a5..c5e542942aaf
 -		spi0 = &flexspi;
 -	};
 -
--	usdhc1_pwrseq: usdhc1_pwrseq {
--		compatible = "mmc-pwrseq-simple";
+-	reg_usdhc1_vmmc: regulator-usdhc1 {
+-		compatible = "regulator-fixed";
+-		regulator-name = "WLAN_EN";
 -		pinctrl-names = "default";
--		pinctrl-0 = <&pinctrl_usdhc1_gpio>;
--		reset-gpios = <&gpio2 10 GPIO_ACTIVE_LOW>;
+-		pinctrl-0 = <&pinctrl_reg_usdhc1_vmmc>;
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		gpio = <&gpio2 10 GPIO_ACTIVE_HIGH>;
+-		enable-active-high;
 -	};
 -};
 -
@@ -366,7 +365,7 @@ index bd7705d6d7a5..c5e542942aaf
 -	keep-power-in-suspend;
 -	non-removable;
 -	wakeup-source;
--	mmc-pwrseq = <&usdhc1_pwrseq>;
+-	vmmc-supply = <&reg_usdhc1_vmmc>;
 -	fsl,sdio-async-interrupt-enabled;
 -	status = "okay";
 -
@@ -391,6 +390,12 @@ index bd7705d6d7a5..c5e542942aaf
 -};
 -
 -&iomuxc {
+-	pinctrl_reg_usdhc1_vmmc: regusdhc1vmmcgrp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_SD1_RESET_B_GPIO2_IO10	0x141
+-		>;
+-	};
+-
 -	pinctrl_flexspi: flexspigrp {
 -		fsl,pins = <
 -			MX8MM_IOMUXC_NAND_ALE_QSPI_A_SCLK               0x1c2
@@ -461,10 +466,10 @@ index bd7705d6d7a5..c5e542942aaf
 +#include "imx8mm-evk-qca-wifi.dts"
 diff --git a/arch/arm64/boot/dts/freescale/imx8mm-evkb.dts b/arch/arm64/boot/dts/freescale/imx8mm-evkb.dts
 new file mode 100644
-index 000000000000..7129fbb7c228
+index 00000000000000..932bb7cc3bb981
 --- /dev/null
 +++ b/arch/arm64/boot/dts/freescale/imx8mm-evkb.dts
-@@ -0,0 +1,142 @@
+@@ -0,0 +1,153 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright 2019-2020 NXP
@@ -483,11 +488,15 @@ index 000000000000..7129fbb7c228
 +		spi0 = &flexspi;
 +	};
 +
-+	usdhc1_pwrseq: usdhc1_pwrseq {
-+		compatible = "mmc-pwrseq-simple";
++	reg_usdhc1_vmmc: regulator-usdhc1 {
++		compatible = "regulator-fixed";
++		regulator-name = "WLAN_EN";
 +		pinctrl-names = "default";
-+		pinctrl-0 = <&pinctrl_usdhc1_gpio>;
-+		reset-gpios = <&gpio2 10 GPIO_ACTIVE_LOW>;
++		pinctrl-0 = <&pinctrl_reg_usdhc1_vmmc>;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&gpio2 10 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
 +	};
 +};
 +
@@ -512,10 +521,11 @@ index 000000000000..7129fbb7c228
 +	pinctrl-0 = <&pinctrl_usdhc1>, <&pinctrl_wlan>;
 +	pinctrl-1 = <&pinctrl_usdhc1_100mhz>, <&pinctrl_wlan>;
 +	pinctrl-2 = <&pinctrl_usdhc1_200mhz>, <&pinctrl_wlan>;
++	bus-width = <4>;
 +	keep-power-in-suspend;
 +	non-removable;
 +	wakeup-source;
-+	mmc-pwrseq = <&usdhc1_pwrseq>;
++	vmmc-supply = <&reg_usdhc1_vmmc>;
 +	fsl,sdio-async-interrupt-enabled;
 +	status = "okay";
 +
@@ -540,6 +550,12 @@ index 000000000000..7129fbb7c228
 +};
 +
 +&iomuxc {
++	pinctrl_reg_usdhc1_vmmc: regusdhc1vmmcgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD1_RESET_B_GPIO2_IO10	0x141
++		>;
++	};
++
 +	pinctrl_flexspi: flexspigrp {
 +		fsl,pins = <
 +			MX8MM_IOMUXC_NAND_ALE_QSPI_A_SCLK               0x1c2
@@ -608,5 +624,5 @@ index 000000000000..7129fbb7c228
 +	};
 +};
 -- 
-2.34.1
+2.43.2
 

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.1.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.1.bb
@@ -11,7 +11,7 @@ include recipes-kernel/linux/kmeta-linux-lmp-6.1.y.inc
 LINUX_VERSION ?= "6.1.70"
 KERNEL_BRANCH ?= "6.1-2.2.x-imx"
 
-SRCREV_machine = "4e3fc5471376a15279ee5c99e791a7c7b065cbc1"
+SRCREV_machine = "1e6abd59ab9ff1cd4ea453383e72d12c120d193e"
 
 SRC_URI += " \
     file://0004-FIO-toup-hwrng-optee-support-generic-crypto.patch \


### PR DESCRIPTION
This revision includes the lf-6.1.55-2.2.0 tag.

Refresh patches based on the new kernel rev.

Relevant changes:
- 1e6abd59ab9ff1 Merge pull request #669 from tq-niebelm/6.1-2.2.x-imx-update-to-lf-6.1.55-2.2.1
- dbc41281fba822 Merge tag 'lf-6.1.55-2.2.1' into 6.1-2.2.x-imx
- de69f223c019fe Merge pull request #659 from tq-niebelm/6.1-2.2.x-imx-ti-sn65dsi83-reverts
- 60fecd90ea6bce Revert "drm/bridge: ti-sn65dsi83: Fix enable/disable flow to meet spec"
- 131f7215711540 Revert "drm/bridge: sn65dsi83: Register and attach our DSI device at probe"
- 8fe2b6682a9340 Revert "drm/bridge: ti-sn65dsi83: Do not cache dsi_lanes and host twice"
- bcb5541dc3a599 Revert "drm/bridge: ti-sn65dsi83: Convert to drm_of_get_data_lanes_count"
- 2bfda7392e6621 Merge pull request #658 from tq-niebelm/6.1-2.2.x-imx
- 86a389d3e879c2 Merge remote-tracking branch 'lf-6.1.y' into 6.1-2.2.x-imx
- dad30ee7194687 Merge pull request #657 from tq-niebelm/fslc-6.1-2.2.x-imx-fixes
- 5f6af3b3075532 arm64: dts: imx8mm: fix csi nodes for NXP vendor stack
- 2443a1146bfd3b phy: phy-fsl-lynx-28g: fix wrong merge resolve
- de8d5a614f8ffb MGS-7591 [#imx-3270] Modify CONFIG_PM_RUNTIME version usage issues
- 97efb032676c50 LF-8498: config: Enable polyval, xctr cipher test support
- 0ae20f1e6f8113 LF-11170-1: arm64: dts: imx91p-11x11-evk-aud-hat: probe regulater before codec
- 83d6d215f7c620 iio: adc: imx8qxp: Fix address for command buffer registers
- 7afdcff705d96f LF-11170: arm64: dts: imx93-11x11-evk-aud-hat: probe regulater before codec
- cf8fcbc8523fa3 LF-11134-1: arm64: dts: imx93-11x11-evk-aud-hat: Add GPIO power control
- ffc3e55f631662 LF-11134: arm64: dts: imx91p-11x11-evk-aud-hat: Add GPIO power control
- 770c5fe2c1d152 LF-10611 arm64: dts: imx8mq-evk-rpmsg: fix CMA memory reservation fail
- 64960d896c1cb6 net: sdk_fman: avoid division by zero
- 9cc41a972bcce5 net: fman: fix variable type
- 142a245ddfeef7 soc: fsl: qbman: check kzalloc return value
- 7b3fb7cdb5a5be net: phylink: fix phylink_validate() call with c73 from phylink_ethtool_ksettings_set()
- 37c18120a2f3a6 LF-10500: arm64: dts: fix imx8qxp WCPU rpmsg dts issue
- c38fea2a0493b0 LF-10485: mtd: spinand: gigadevice: Fix the get ecc status issue
- 71d8f04a1b0841 LF-9073 ASoC: soc-compress: Fix deadlock in soc_compr_open_fe
- 0392c61d9eb5cb phy: lynx-10g: fix bugs in 'fsl,ls1088a-serdes1' and mark it as tested
- 55dab2ec82591e phy: lynx-10g: remove the 'not tested' comment from 'fsl,ls2088a-serdes1'
- bfba0600429302 LF-7770: arm64: config: imx_v8_defconfig: enable rpmsg sample modules
- a80a7f5af6e51b LF-10420-3: arm64: dts: imx8mp: swpdm: add fsl,sai-mclk-direction-output
- 4f95512483e89f LF-10420-2: arm64: dts: imx8mn: swpdm: add fsl,sai-mclk-direction-output
- 9fae93985eabcf LF-10420-1: arm64: dts: imx8mm: swpdm: add fsl,sai-mclk-direction-output
- 452a99068fe59a bus: fsl-mc: fix double-free on mc_dev
- f18c15e9a0f195 phy: lynx-10g: stop on lynx_pccr_read() in lynx_10g_backup_pccr_val()
- 6b4dc6d20b6714 arch: arm64: lx2160a-rdb: comment out tx-disable-gpios from the SFP cage description
- 2cee209afbdd81 net: phy: lynx-10g: implement phy_exit() operation
- 3479611119244e net: phy: lynx-28g: implement phy_exit() operation
- 867b5c9b17c119 net: dpaa2-mac: fix the case with no 'phys' in the DT node
- faa38ac84e7d93 MLK-26155 arm64: dts: imx8mp-evk-sof-pdm: Fix PDM CLK rate
- 48ca927d214630 LF-10365 nvmem: imx: i.MX8ULP: update fsb_bank_reg of imx8ulp_fsb_s400_hw
- 9cf822ab277204 Revert "LF-9994-2 mmc: sdio: hold retuning when sdio device in 1 bit mode"
- 7db012d43f8569 net: pcs: mtip_backplane: fix ineffective mtip_run_irqpoll_once()
- 11b6c43ff2bff7 MGS-6408 [#imx-2696] Add array index check for gckDEVICE_Profiler_Dispatch
- 1c45afaf0ac684 MGS-7320 [#ccc] Fix gcoOS_MemCopy crash issue in VSI GPU library
- 8a182e1463bafd LF-10341: ASoC: SOF: imx: Add SNDRV_PCM_INFO_BATCH flag
- 7e3463ae041a59 MA-21376 [#imx-3195] 4Kp60 video playback is tearing and not smooth when not full-screen
- 2167588233074e LF-10338-4 mtd: spinand: winbond: Add support for W25N02KW
- ba78f2f7748079 LF-10338-3 mtd: spinand: winbond: Fix ecc_get_status
- 1b2587251b95e3 LF-10338-2 mtd: spinand: winbond: add Winbond W25N02KV flash support
- e7894488d03f32 LF-10338-1 mtd: spinand: winbond: fix flash identification
- ab75c177174670 LF-9376-10 arm64: dts: Add sdma3 root clock
- 68bc33f81a00fd LF-9376-9 ASoC: SOF: ipc3: Add MICFIL type
- 316014cc74c88c LF-9376-8 ASoC: SOF: ipc3: Add micfil_tokens
- 7a0c832405c4dc arm64: dts: lx2160a: add compatible string to Lynx PCS devices
- bba200f774e02b net: dpaa: add support for copper backplanes using the mtip phylib wrapper
- c2c2993a809b3e net: phy: mtip_backplane: add a phylib wrapper over the phylink_pcs core
- 0b661c4889c3b8 phy: lynx-10g: new driver
- 2dcbc1d2a6ae16 dt-bindings: phy: lynx-10g: initial document
- f665001bd4296b phy: lynx-28g: add support for multi-lane 40GBase-KR4
- 3eb4303a931224 phy: lynx-28g: report the current protocol converter's MDEV_PORT through phy_get_status()
- a322e39fa41e69 phy: lynx-28g: set up equalization for 25G according to AN12950
- a72d50fd112e2d phy: lynx-28g: add algorithm for IEEE 802.3 C72 (10GBase-KR) link training
- c9c9d09e10215e phy: lynx-28g: add support for backplane modes through PHY_MODE_ETHERNET_LINKMODE
- f74d6747a377b7 phy: lynx-28g: refactor the CDR lock check from the work to a function
- 134cd5b20205bd phy: lynx-28g: convert iowrite32() calls with magic values to macros
- 09636425cbd47a phy: lynx-28g: distinguish between 10GBASE-R and USXGMII
- 2dc301dcb6a663 phy: lynx-28g: refactor lane->interface to lane->mode
- 265b29ab1370e6 phy: lynx-28g: replace LYNX_28G_SGMIIaCR1_SGPCS_DIS with 0
- 00a02e98ac1671 phy: lynx-28g: restructure protocol configuration register accesses
- 43cd22ed046f79 phy: lynx-28g: add debugging print in CDR lock workaround
- e0f3ef0b77ff1d phy: lynx-28g: implement phy_get_status() for CDR lock
- f73df580c2379a phy: lynx-28g: truly power the lanes up or down
- cc6a01127be365 phy: lynx-28g: don't concatenate macros for lynx_28g_lane_rmw() args "val" and "mask"
- 6b1763a81cb51d phy: lynx-28g: serialize concurrent phy_set_mode_ext() calls to shared registers
- 8842744c5998a7 phy: lynx-28g: lock PHY while performing CDR lock workaround
- fc32b4c550fc26 phy: lynx-28g: cancel the CDR check work item on the remove path
- 30775640da9d21 net: pcs: lynx: use MTIP AN/LT block for copper backplanes
- 3a83aad7281076 net: pcs: mtip_backplane: add driver for MoreThanIP backplane AN/LT core
- d919593772b747 phy: allow querying the address of protocol converters through phy_get_status()
- ae7386d1ebb917 phy: ethernet: add configuration interface for copper backplane Ethernet PHYs
- aa5e31dc62f069 phy: introduce the PHY_MODE_ETHERNET_LINKMODE mode for phy_set_mode_ext()
- 5d9af070508e9d phy: introduce phy_get_status() and use it to report CDR lock
- a37336d73be5c4 net: enetc: integrate SerDes phys with lynx pcs
- 445393b71617e5 net: dsa: felix: integrate SerDes phys with lynx pcs
- 07aa56adb7caf5 net: mscc: ocelot: expose serdes configuration function
- 264e9f11e2813a net: mscc: ocelot: expose generic phylink_mac_config routine
- d1b4d68f95a0eb net: dpaa2-mac: add phylink c73 support
- b19b8a126a7d9b net: dpaa2-mac: extend serdes code for multiple phys
- 7a560782c979c7 net: pcs: lynx: incorporate SerDes PHY handling from dpaa2-mac
- b07601ef3420f3 Revert "net: dpaa2: add support for retimer runtime configuration"
- 50bd0f45b581de dt-bindings: net: fsl-dpmac: allow phys, phy-names and num-lanes
- 601448a5f0cbe4 dt-bindings: lynx-pcs: add a second compatible string for LX2160A
- 436cacc339441f dt-bindings: net: Add Lynx PCS binding
- 437a7c67817908 net: phylink: add support for managed = "c73"
- 9694e62e0c74da net: explicitly check in of_phy_is_fixed_link() for managed = "in-band-status"
- db6dcf3afbd999 net: phylink: add the 25G link modes to phylink_c73_priority_resolution[]
- f78a11a4cc84a7 net: phylink: avoid unnecessary phylink_validate() calls during phylink_create()
- 283cd0225ae484 net: ethtool: introduce ethtool_link_mode_str()
- 1063a77a023c8a net: mii: add C73 link mode and base page helpers
- b6da0b4886f09f net: dsa: felix: introduce phy-mode = "10g-qxgmii" to replace "usxgmii"
- d9d396083c3547 net: phylink: move phylink_pcs_neg_mode() to phylink.c
- 3d19e5f8a7295c net: phylink: reimplement population of pl->supported for in-band
- a80f7dd6adfde7 net: phylink: centralize phy_interface_mode_is_8023z() && phylink_autoneg_inband() checks
- 596e70bdc2a96f net: pcs: lynx: fix lynx_pcs_link_up_sgmii() not doing anything in fixed-link mode
- 3380d4367d067d net: phylink: add support for PCS link change notifications
- 9abc48302f956d net: phylink: add pcs_pre_config()/pcs_post_config() methods
- 639ed5e4c4875c net: phylink: add pcs_enable()/pcs_disable() methods
- 2014f43b1682e0 net: pcs: lynx: update PCS driver to use neg_mode
- 2cb8adc9227a29 net: phylink: pass neg_mode into phylink_mii_c22_pcs_config()
- 0517c7f8771c14 net: pcs: pcs-lynx: use phylink_get_link_timer_ns() helper
- cc8ee2386adbe9 net: phylink: add phylink_get_link_timer_ns() helper
- 159d12b00ec635 net: phylink: convert phylink_mii_c22_pcs_config() to neg_mode
- 90b077dc3480e3 phylink: ReST-ify the phylink_pcs_neg_mode() kdoc
- eb6c6f2accfdd9 net: phylink: fix sphinx complaint about invalid literal
- f07b64de41eefb net: phylink: add PCS negotiation mode
- 901e63daf90cb3 net: dpaa2: use pcs-lynx's check for fwnode availability
- 6a7b405fab0f2c net: pcs: lynx: check that the fwnode is available prior to use
- 16cd22819755c5 net: pcs: lynx: change lynx_pcs_create() to return error-pointers
- b043d182c47d9e net: pcs: lynx: make lynx_pcs_create() static
- 5a255075e4b681 net: dpaa2-mac: use lynx_pcs_create_fwnode()
- 8c127d197cc791 net: dpaa2: Add some debug prints on deferred probe
- f75294770af50e net: pcs: lynx: add lynx_pcs_create_fwnode()
- b04fe5168fa9cc net: pcs: lynx: remove lynx_get_mdio_device()
- 894ccb7e3f8342 net: dpaa2-mac: allow lynx PCS to manage mdiodev lifetime
- e42005d464149f net: dpaa2-mac: use correct interface to free mdiodev
- ddbe59d31865e0 net: enetc: use lynx_pcs_create_mdiodev()
- 8295d74c90abfd net: dsa: ocelot: use lynx_pcs_create_mdiodev()
- e2b3f555c0bd72 net: pcs: lynx: add lynx_pcs_create_mdiodev()
- fa6bc1bc0d6ca4 net: stmmac: use xpcs_create_mdiodev()
- db88caaa2b3e5c net: pcs: xpcs: add xpcs_create_mdiodev()
- 8230ca4cd7b61d net: mdio: add mdio_device_get() and mdio_device_put()
- 4d11d54de10a63 net: dsa: mv88e6xxx: move link forcing to mac_prepare/mac_finish
- 88cba7dff22444 net: dsa: add support for mac_prepare() and mac_finish() calls
- bf134ce998706b net: phylink: provide phylink_pcs_config() and phylink_pcs_link_up()
- 1eac07fc7696f5 net: pcs: xpcs: avoid reading STAT1 more than once
- 0168b367a9e4e5 net: pcs: xpcs: use phylink_resolve_c73() helper
- 505ef7b97890fd net: pcs: xpcs: correct pause resolution
- 649d9520e9d667 net: pcs: xpcs: correct lp_advertising contents
- 8d2e906b8eaf32 net: pcs: xpcs: use mii_c73_to_linkmode() helper
- 332d8d416ef491 net: pcs: xpcs: clean up reading clause 73 link partner advertisement
- 8dcfc2ca5359fb net: phylink: add function to resolve clause 73 negotiation
- 7b8056eb0bff0b net: phylink: remove duplicated linkmode pause resolution
- ab70780e4c278d net: mdio: add clause 73 to ethtool conversion helper
- 723bcd38878c86 net: phylink: require supported_interfaces to be filled
- 7a5819b9678f27 net: phylink: remove an_enabled
- 6a803e69ddafa0 net: pcs: lynx: don't print an_enabled in pcs_get_state()
- 9298bd0409a4c0 net: pcs: xpcs: use Autoneg bit rather than an_enabled
- 86b2afb5255e19 net: dpaa2-mac: use Autoneg bit rather than an_enabled
- 187f6398afc6cb net: mdio-mux: be compatible with parent buses which only support C45
- 9ff43a6b3ce2ff net: mdio-mux: show errors on probe failure
- 005dc5699ba43c net: mdio-mux: fix C45 access returning -EIO after API change
- fcc78786880699 device property: Introduce fwnode_device_is_compatible() helper
- c0f94f4e179353 phy: Add devm_of_phy_optional_get() helper
- ea433896aa06e8 Revert v1 of MTIP backplane AN/LT support
- 2d49d167c60305 LF-9095: gpc: fwnode: Make imx pgc power domain also set the fwnode
- 63bd8fa873a2cd LF-7770: remoteproc: imx_dsp_rproc: add mandatory find_loaded_rsc_table op
- 64bba709f75824 MGS-7326 [#imx-2976] 0093-KERNEL-SPACE-Update-version-for-rel_6.4.11.p2_202308
- c7f342d2e54b2f MGS-7326 [#imx-2976] 0090-KERNEL-SPACE-Update-gc_feature_database.h-to-712476
- de8ebfd7ba292f MGS-7326 [#imx-2976] 0083-CL709461-KERNEL-SPACE-22Q2_NXP-ocl30-qnx-Merging-671
- dcac08503d160f LF-10301: tee-skcipher: fix 32-bit compilation warning
- f361f41ee5d92b net: fec: ENET-QOS on i.MX93 board
- a7323d658bf114 media: imx-jpeg: notify source chagne event when the first picture parsed
- 913125c13d0a8d LF-9420: drm/imx: imx93-ldb: filter out modes with unobtainable pixel clocks
- 870b422ad2a9ff tee: crypto: enable support for skcipher
- 65017d1e16f68c LF-10156-3 arm64: dts: imx93-14x14-evk: add different usdhc pinctrl for different timing usage
- ee40cc461b225e LF-10156-2 arm64: dts: imx93-11x11-evk: add different usdhc pinctrl for different timing usage
- 96eac99749f2ad LF-10156-1 arm64: dts: imx93-9x9-qsb: add different usdhc pinctrl for different timing usage
- 5e9f2864b8149e LF-9089-02: media: i2c: mt9m114: adjust the output frequency to 72MHz
- a17ff549365160 LF-9089-01: media: imx: parallel: fix frame sync issue
- 79ff055451c389 LF-10278: firmware: ele-mu: Update SECO_MU_IO_FLAGS_IS_IN_OUT IO buffer setup flag value
- a15dbe6a5ed010 LF-10273: Revert "clk: imx: pll14xx: dynamically configure PLL for 393216000/361267200Hz"
- a0ea06f9d769bc LF-10269-9: arm64/configs/imx_v8_defconfig: add maxim serdes modules
- d7f397d74c39e9 LF-10269-8: dts/arm64: imx93_14x14: add support for Maxim DSI SerDes
- e1ff51fa0f455e LF-10269-7: dt-bindings: mfd: add MAX96752 bindings
- 22e0eca2eaba06 LF-10269-6: dt-bindings: mfd: add MAX96789 bindings
- 4679c4f90240fa LF-10269-5: mfd: add Maxim SerDes link manager layer
- 6e64cb512d4aa5 LF-10269-4: drm/bridge: add support for MAX96752 deserializer LVDS bridge
- 11d0de6c2a0179 LF-10269-3: drm/bridge: add support for MAX96789 serializer DSI bridge
- e4381b5a592054 LF-10269-2: mfd: Add support for MAX96752 deserializer with LVDS support
- 0e22ce306a6994 LF-10269-1: mfd: Add support for max96789 MIPI-DSI serializer
- 5de87941ffa208 LF-10263 arm64: dts: imx8qm-mek: add pcie wifi WoWLAN support
- d7a9444a9b9faa LF-9973-7: arm64: dts: imx93: add fsl,sai-mclk-direction-output
- 324dcddd0b7e88 ASoC: soc-pcm.c: Make sure DAI parameters cleared if the DAI becomes inactive
- e8c453a27c2cc5 ASoC: soc-pcm.c: Clear DAIs parameters after stream_active is updated
- b7b5600d3032ac ASoC: imx-rpmsg: Set ignore_pmdown_time for dai_link
- 5a97a3191f78c5 LF-9910-2: Revert "LF-6278-2: ASoC: fsl_rpmsg: Constrain rates of wm8524 codec"
- 2b6f8abd498aa0 LF-9910-1: arm64: dts: imx8m: Let WM8524 driver constrain supported rate
- 6bc8fe95112e87 LF-9368: arm64: dts: imx93-11x11-evk-rpmsg: Enable dynamic buffer size for i2c-rpmsg
- fc7754fa3680da LF-10141-03 arm64: dts: imx93: Add the 'fsl,ext-reset-output' property for wdog3
- 799ad8d965d755 LF-10141-02 dt-bindings: watchdog: fsl-imx7ulp-wdt: Add 'fsl,ext-reset-output'
- f9a7c0d3885289 LF-10141-01 wdog: imx7ulp: Enable wdog int_en bit for watchdog any reset
- f3aa2a474474a4 LF-10040-3 arm64: dts: imx93: set the tuning start and tuning step to get a large scan range for tuning
- 61bb01d761b12c LF-10040-2 arm64: dts: imx91p: set SION for cmd and data pad of USDHC
- b21542b9ad859f LF-10040-1 arm64: dts: imx93: set SION for cmd and data pad of USDHC
- 105e6ac6fec162 LF-9994-2 mmc: sdio: hold retuning when sdio device in 1 bit mode
- 0c99057c9cee41 LF-9994-1 mmc: sdhci-esdhc-imx: optimize the manual tuing logic to get the best timing
- f1e61a61f78a85 LF-10187: arm64: dts: fix mt9m114 can't work with i.MX93-9x9 QSB A2 board
- 8f806c65ed2dc3 Bluetooth: btnxpuart: Improve inband Independent Reset handling
- a96e855790e145 Bluetooth: btnxpuart: Add support for IW624 chipset
- 0a44c11cc589ac Bluetooth: btnxpuart: Remove check for CTS low after FW download
- 87ca692a212e0b Bluetooth: btnxpuart: Add support for AW693 chipset
- f396642e14cf20 LF-9972 arch: arm64: dts: correct the use of vmmc-supply and mmc-pwrseq for SDIO WiFi
- 0629623844cb3d LF-9971 arm64: dts: imx8mq-evk-usd-wifi: improve the wifi support on imx8mq micro-sd connector
- 71359278a94c14 LF-10253: vpu: h1: solve encode dead loop
- 8c55f5403b10f2 media: imx-jpeg: initiate a drain of the capture queue in dynamic resolution change
- be4fc9832a1484 LF-9973-6: arm64: dts: imx91p: add fsl,sai-mclk-direction-output
- 08feac38b33193 LF-10193: vpu: hantro_v4l2: initiate a drain of the capture queue in dynamic resolution change
- 5fccc09d4f3eea MA-21538-2 clk: imx: clk-imx8qxp: Parent should be initialized earlier than the clock
- afc9aa1d39bfe6 MA-21538-1 Revert "clk: imx: scu: add CLK_SET_PARENT_NOCACHE"
- e2b3ebd4bce400 MA-21538 Revert "MLK-21052-08 clk: imx: Add CLK_SET_PARENT_NOCACHE"
- 6c290f12a0d0d7 ASoC: fsl: imx-pcm-rpmsg: Add SNDRV_PCM_INFO_BATCH flag
- 6883469f38256f net/fec-uio: Fixed error handling
- c4811209ac7b4b MLK-26147: net: stmmac: dwmac-imx: request high frequency mode
- 1d2c633210935f LF-9849-4: net: phy: tja11xx: call resume before soft reset.
- aa812cd54534a9 LF-10074: arm64: dts: imx8dxl-evk: correct the ext PHY reset sequence
- 8c96c3b2de12a8 Merge tag 'v6.1.55' into lf-6.1.y
- 3f83ccf0d6cd2f Merge tag 'v6.1.54' into lf-6.1.y
- 15a1048dde46a1 Revert "ASoC: fsl_sai: Disable bit clock with transmitter"
- 81c8834630b2b1 Revert "media: amphion: Fix firmware path to match linux-firmware"
- 355b08d35dfbac LF-9973-5: arm64: dts: imx8mp: add fsl,sai-mclk-direction-output
- 7d2c024a1d7d00 LF-9973-4: arm64: dts: imx93: add fsl,sai-mclk-direction-output
- 489f283b9bf713 LF-9973-3: arm64: dts: imx8mp: add fsl,sai-mclk-direction-output
- f094a505b8c3d4 LF-9973-2: arm64: dts: imx8mn: add fsl,sai-mclk-direction-output
- 0ceff7021fa6a2 LF-9973-1: arm64: dts: imx8mm: add fsl,sai-mclk-direction-output
- fc07cd2af34700 Merge tag 'v6.1.53' into lf-6.1.y