### PR TITLE
Revert "Revert "base: lmp: clang: disable -mbranch-protection=standard""

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -24,6 +24,9 @@ include conf/distro/include/cve-lmp-extra-exclusions.inc
 CVE_CHECK_REPORT_PATCHED ?= "0"
 CVE_CHECK_SKIP_RECIPE ?= "qemu-native qemu-system-native"
 
+# Disable branch-protection=standard from clang until properly validated (causes issues on aktualizr)
+TUNE_CCARGS:remove:toolchain-clang = "${@bb.utils.contains('TUNE_FEATURES', 'aarch64', '-mbranch-protection=standard', '', d)}"
+
 # Include distro features in pre-build configuration output
 BUILDCFG_VARS += "DISTRO_FEATURES"
 


### PR DESCRIPTION
This reverts commit bb1529ab8d239ea176fd20c3a4ce093345f7b1d7.

Fix in meta-clang is not enough for all the clang consumers (e.g. aktualizr).