### PR TITLE
Revert "base: lmp: clang: disable -mbranch-protection=standard"

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -24,9 +24,6 @@ include conf/distro/include/cve-lmp-extra-exclusions.inc
 CVE_CHECK_REPORT_PATCHED ?= "0"
 CVE_CHECK_SKIP_RECIPE ?= "qemu-native qemu-system-native"
 
-# Disable branch-protection=standard from clang until properly validated (causes issues on aktualizr)
-TUNE_CCARGS:remove:toolchain-clang = "${@bb.utils.contains('TUNE_FEATURES', 'aarch64', '-mbranch-protection=standard', '', d)}"
-
 # Include distro features in pre-build configuration output
 BUILDCFG_VARS += "DISTRO_FEATURES"
 


### PR DESCRIPTION
This reverts commit d4ea7840b0ef58e0cf7ecd518b3be2fd0a166a2a.

Proposed upstream https://github.com/kraj/meta-clang/pull/1000

First fix attempt [1] end up reverted [2] because libcxx is not enough.
[1] https://github.com/foundriesio/meta-lmp/pull/1481
[2] https://github.com/foundriesio/meta-lmp/pull/1500