### PR TITLE
Bump aklite and composectl

### DIFF
--- a/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
+++ b/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
@@ -6,8 +6,8 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=504a5c2455c8bb2fc5b76678
 
 GO_IMPORT = "github.com/foundriesio/composeapp"
 GO_IMPORT_PROTO ?= "https"
-SRCBRANCH = "v94"
-SRCREV = "5691069fd3fb823a658bfdb3271245c2dee5686a"
+SRCBRANCH = "main"
+SRCREV = "1b16abc3bcd36f31f5e4c18b88c9ed7ea70405c5"
 SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO};branch=${SRCBRANCH}"
 UPSTREAM_CHECK_COMMITS = "1"
 

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-BRANCH:lmp = "v94"
-SRCREV:lmp = "814f26a5b75c0357d39f913f0f6aec29c2d50b82"
+BRANCH:lmp = "master"
+SRCREV:lmp = "0a2357d028271a37b8ac0331f58c7c039107040e"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \

--- a/meta-lmp-base/recipes-sota/custom-sota-client/custom-sota-client_git.bb
+++ b/meta-lmp-base/recipes-sota/custom-sota-client/custom-sota-client_git.bb
@@ -1,19 +1,19 @@
 DESCRIPTION = "Custom SOTA Client example based on the aktualizr-lite C++ API"
 SECTION = "base"
-LICENSE = "MPL-2.0"
-LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE;md5=815ca599c9df247a0c7f619bab123dad"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE;md5=504a5c2455c8bb2fc5b7667833ab1a68"
 
 inherit pkgconfig cmake systemd
 
 SRC_URI = "\
-    git://github.com/foundriesio/aktualizr-lite;protocol=https;branch=${BRANCH} \
+    git://github.com/foundriesio/sotactl;protocol=https;branch=${BRANCH} \
     file://systemd.service \
 "
 
-BRANCH = "v94"
-SRCREV = "d2cd79e1dc6a3c992d37de4d1609d4bdf9b750ec"
+BRANCH = "main"
+SRCREV = "45d4ebba834e9e80ac13c1386841b38939449699"
 
-S = "${WORKDIR}/git/examples/custom-client-cxx"
+S = "${WORKDIR}/git"
 
 DEPENDS = "jsoncpp boost aktualizr"
 

--- a/meta-lmp-base/recipes-sota/custom-sota-client/files/systemd.service
+++ b/meta-lmp-base/recipes-sota/custom-sota-client/files/systemd.service
@@ -10,7 +10,7 @@ RestartSec=180
 Restart=always
 ExecStartPre=/usr/bin/mkdir -p /run/aktualizr
 Environment="TMPDIR=/run/aktualizr"
-ExecStart=/usr/bin/custom-sota-client
+ExecStart=/usr/bin/sotactl
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Bump `aklite` and `composectl` to the current dev main.
This is the current candidate for v95 that includes:
1. the fix to `composectl` related to checking status of running apps in some edge cases.
2. the fix to `composectl` related to checking whether app is installed if it includes images hosted in the docker hub.
3. Moving from the custom-sota-client hosted in the aklite repo to the dedicated repo (`sotactl`).