### PR TITLE
Bump aklite v94.1 patch

### DIFF
--- a/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
+++ b/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
@@ -18,6 +18,7 @@ GO_EXTRA_LDFLAGS = "\
     -X '${GO_IMPORT}/cmd/composectl/cmd.storeRoot=/var/sota/reset-apps' \
     -X '${GO_IMPORT}/cmd/composectl/cmd.composeRoot=/var/sota/compose-apps' \
     -X '${GO_IMPORT}/cmd/composectl/cmd.baseSystemConfig=/usr/lib/docker' \
+    -X '${GO_IMPORT}/cmd/composectl/cmd.commit=${SRCREV}' \
 "
 do_install:append() {
     cd ${D}/${bindir}

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 BRANCH:lmp = "v94"
-SRCREV:lmp = "d2cd79e1dc6a3c992d37de4d1609d4bdf9b750ec"
+SRCREV:lmp = "814f26a5b75c0357d39f913f0f6aec29c2d50b82"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
- Bump aklite to fix the issue with app installation checking.
- Fix the composectl recipe to enable its version printing.