### PR TITLE
base: UEFI Secure Boot Provisioning

### DIFF
--- a/meta-lmp-base/recipes-bsp/efitools/efitools/lockdown.conf
+++ b/meta-lmp-base/recipes-bsp/efitools/efitools/lockdown.conf
@@ -1,0 +1,2 @@
+title UEFI Secure Boot Provisioning
+efi /LockDown.efi

--- a/meta-lmp-base/recipes-bsp/efitools/efitools_git.bb
+++ b/meta-lmp-base/recipes-bsp/efitools/efitools_git.bb
@@ -13,6 +13,7 @@ SRC_URI += " \
     file://0001-Enable-RISC-V-build.patch \
     file://build-keys-for-lockdown-only.patch \
     file://allow-local-auths.patch \
+    file://lockdown.conf \
 "
 
 COMPATIBLE_HOST = "(i.86|x86_64|arm|aarch64|riscv64).*-linux"
@@ -50,5 +51,6 @@ do_prepare_local_auths[vardeps] += "UEFI_SIGN_ENABLE UEFI_SIGN_KEYDIR"
 do_deploy() {
     install -d ${DEPLOYDIR}
     install -m 0600 ${D}${datadir}/efitools/efi/LockDown.efi ${DEPLOYDIR}
+    install -m 0600 ${WORKDIR}/lockdown.conf ${DEPLOYDIR}
 }
 addtask deploy after do_install before do_build

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -141,7 +141,7 @@ WKS_FILE_DEPENDS:append:intel-corei7-64 = " ${INITRD_IMAGE_LIVE} efitools"
 WKS_FILE_DEPENDS_BOOTLOADERS:remove:intel-corei7-64 = "grub-efi"
 ## wic-based installer requires image to be available via IMAGE_BOOT_FILES
 IMAGE_BOOT_FILES:intel-corei7-64 = "${@bb.utils.contains('WKS_FILE', 'image-efi-installer.wks.in', 'systemd-bootx64.efi;EFI/BOOT/bootx64.efi systemd-bootx64.efi;EFI/systemd/systemd-bootx64.efi ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ota-ext4;rootfs.img', '', d)}"
-IMAGE_EFI_BOOT_FILES:append:intel-corei7-64 = " LockDown.efi ${@make_efi_cer_boot_files(d)}"
+IMAGE_EFI_BOOT_FILES:append:intel-corei7-64 = " lockdown.conf;loader/entries/lockdown.conf LockDown.efi ${@make_efi_cer_boot_files(d)}"
 
 # Common for iMX targets
 ## Prefer IMX_DEFAULT_BSP=nxp as mainline removes every common machine override


### PR DESCRIPTION
Simplify the Secure Boot key provisioning process by adding a systemd-boot entry wich uses the [efitools](https://github.com/mjg59/efitools.git) EFI program [LockDown.efi](https://github.com/mjg59/efitools/blob/master/LockDown.c).

![image](https://github.com/user-attachments/assets/da6e7213-0683-42e8-86c2-b0e4d2f691bc)

On selecting that entry, the keys are provisioned after which the system  resets.

Users can then boot into Linux with a secure boot enabled chain.