### PR TITLE
mfgtool-files: make it compatible with specific supported bsp

### DIFF
--- a/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb
+++ b/meta-lmp-base/recipes-support/mfgtool-files/mfgtool-files_0.1.bb
@@ -30,6 +30,8 @@ S = "${WORKDIR}"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
+COMPATIBLE_MACHINE = "(imx-generic-bsp|imx-nxp-bsp)"
+
 do_compile() {
     sed -e 's/@@MACHINE@@/${MACHINE}/' ${S}/bootloader.uuu.in > bootloader.uuu
     sed -e 's/@@MACHINE@@/${MACHINE}/' \

--- a/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-support/ti-mfgtool-files/ti-mfgtool-files_0.1.bb
+++ b/meta-lmp-bsp/dynamic-layers/meta-ti-bsp/recipes-support/ti-mfgtool-files/ti-mfgtool-files_0.1.bb
@@ -9,6 +9,8 @@ S = "${WORKDIR}"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
+COMPATIBLE_MACHINE = "(ti-soc)"
+
 SRC_URI = " \
     file://flash.sh.in \
 "

--- a/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files_0.1.bb
+++ b/meta-lmp-bsp/dynamic-layers/stm-st-stm32mp/recipes-support/stm32-mfgtool-files/stm32-mfgtool-files_0.1.bb
@@ -13,6 +13,8 @@ S = "${WORKDIR}"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
+COMPATIBLE_MACHINE = "(stm32mpcommon)"
+
 SRC_URI = " \
     file://provision.sh.in \
 "


### PR DESCRIPTION
This will avoid getting the error of using it in unsupported bsp's