### PR TITLE
RFC: Add CDI generator for Wayland displays in (x)wayland images

### DIFF
--- a/meta-lmp-base/recipes-containers/docker/files/daemon.json.in
+++ b/meta-lmp-base/recipes-containers/docker/files/daemon.json.in
@@ -3,6 +3,9 @@
   "log-opts": {
     "tag": "{{.Name}}"
   },
+  "features": {
+    "cdi": true
+  },
   @@DOCKER_DAEMON_JSON_CUSTOM@@
   "max-concurrent-downloads": @@MAX_CONCURRENT_DOWNLOADS@@,
   "max-download-attempts": @@MAX_DOWNLOAD_ATTEMPTS@@

--- a/meta-lmp-base/recipes-containers/wayland-cdi/files/wayland-cdi-generate
+++ b/meta-lmp-base/recipes-containers/wayland-cdi/files/wayland-cdi-generate
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+cditmp="/run/cdi/.wayland.yaml.tmp"
+
+mkdir -p /run/cdi
+cat >${cditmp} <<EOF
+cdiVersion: "0.6.0"
+kind: org.wayland/display
+devices:
+EOF
+
+mounts=""
+for x in `find /run/user -mindepth 2 -maxdepth 2 -type s -name wayland-\*` ; do
+	echo Found Wayland instance: $x
+	found=1
+	xdg_dir="$(dirname $x)"
+	display_name="$(basename $x)"
+	mounts="${mounts} ${xdg_dir}"
+	cat >>${cditmp} <<EOF
+- name: ${display_name}
+  containerEdits:
+    env:
+    - WAYLAND_DISPLAY=${display_name}
+    - XDG_RUNTIME_DIR=${xdg_dir}
+EOF
+done
+
+if [ -n "${mounts}" ] ; then
+	cat >>${cditmp} <<EOF
+containerEdits:
+  mounts:
+EOF
+
+	for x in ${mounts} ; do
+		cat >>${cditmp} <<EOF
+  - type: bind
+    hostPath: ${x}
+    containerPath: ${x}
+    options:
+    - rbind
+    - rprivate
+EOF
+	done
+	mv ${cditmp} /run/cdi/wayland.yaml
+else
+	rm ${cditmp}
+fi

--- a/meta-lmp-base/recipes-containers/wayland-cdi/files/wayland-cdi.service
+++ b/meta-lmp-base/recipes-containers/wayland-cdi/files/wayland-cdi.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=CDI device entry generator for Wayland
+After=weston.service
+Before=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/wayland-cdi-generate
+RemainAfterExit=yes
+
+[Install]
+WantedBy=weston.service
+RequiredBy=docker.service

--- a/meta-lmp-base/recipes-containers/wayland-cdi/wayland-cdi_0.1.bb
+++ b/meta-lmp-base/recipes-containers/wayland-cdi/wayland-cdi_0.1.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Sets up a CDI device entry for the Wayland display"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit allarch systemd
+
+SRC_URI = "file://wayland-cdi.service \
+    file://wayland-cdi-generate \
+"
+
+SYSTEMD_SERVICE:${PN} = "wayland-cdi.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+do_install() {
+	install -d ${D}${bindir}
+	install -m 0755 ${WORKDIR}/wayland-cdi-generate ${D}${bindir}/wayland-cdi-generate
+
+	install -d ${D}${systemd_system_unitdir}
+	install -m 0644 ${WORKDIR}/wayland-cdi.service ${D}${systemd_system_unitdir}
+}

--- a/meta-lmp-base/recipes-samples/images/lmp-feature-docker.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-feature-docker.inc
@@ -3,6 +3,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     docker \
     docker-credential-helper-fio \
     docker-compose \
+    ${@bb.utils.contains("DISTRO_FEATURES", "wayland", "wayland-cdi", "", d)} \
 "
 
 EXTRA_USERS_PARAMS += "\


### PR DESCRIPTION
We have a hard-to-remember way of running wayland applications inside Docker. By leveraging [CDI](https://github.com/cncf-tags/container-device-interface/) we can make this much easier for users so that you could simply run:
```
 docker run --device org.wayland/display=wayland-1 <image>
```

and have all the correct bind-mounts and environment variables set inside the container.