### PR TITLE
base: init-install-efi: installer: support encrypted rootfs

### DIFF
--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-module-install-efi_%.bbappend
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-module-install-efi_%.bbappend
@@ -2,4 +2,4 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 # Prefer gptfdisk instead of parted
 RDEPENDS:${PN}:remove = "parted dosfstools"
-RDEPENDS:${PN} += "efibootmgr gptfdisk"
+RDEPENDS:${PN} += "efibootmgr gptfdisk systemd-crypt efivar"


### PR DESCRIPTION
Add support for a CI encrypted rootfs USB installer.