### PR TITLE
base: initramfs-framework: refactor access to UEFI variables

### DIFF
--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework/cryptfs_tpm2
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework/cryptfs_tpm2
@@ -5,9 +5,9 @@ cryptfs_check_tpm2() {
 	[ ! -d /sys/firmware/efi/efivars ] && fatal "EFI vars sysfs mount point not found"
 
 	# Check for SecureBoot support as PCR 7 differs based on its state
-	efi_secure=`hexdump /sys/firmware/efi/efivars/SecureBoot-* | head -n1 | awk '{print $4}'`
-	efi_mode=`hexdump /sys/firmware/efi/efivars/SetupMode-* | head -n1 | awk '{print $4}'`
-	if [ "${efi_secure}" != "0001" ] || [ "${efi_mode}" != "0000" ]; then
+	efi_secure=`efivar --name=8be4df61-93ca-11d2-aa0d-00e098032b8c-SecureBoot --print-decimal`
+	efi_mode=`efivar --name=8be4df61-93ca-11d2-aa0d-00e098032b8c-SetupMode --print-decimal`
+	if [ "${efi_secure}" != "1" ] || [ "${efi_mode}" != "0" ]; then
 		fatal "UEFI SecureBoot not enabled (required due PCR 7)"
 	fi
 

--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -20,7 +20,7 @@ PACKAGES:append = " \
 "
 
 SUMMARY:initramfs-module-cryptfs = "initramfs support for encrypted filesystems"
-RDEPENDS:initramfs-module-cryptfs = "${PN}-base libgcc e2fsprogs-resize2fs e2fsprogs-e2fsck e2fsprogs-dumpe2fs systemd-crypt"
+RDEPENDS:initramfs-module-cryptfs = "${PN}-base libgcc e2fsprogs-resize2fs e2fsprogs-e2fsck e2fsprogs-dumpe2fs systemd-crypt efivar"
 FILES:initramfs-module-cryptfs = "/init.d/80-cryptfs"
 
 SUMMARY:initramfs-module-cryptfs-pkcs11 = "encrypted filesystems with support for pkcs11"


### PR DESCRIPTION
Use efivar to access uefi variables in a standard way.