### PR TITLE
base: initramfs: check for secure boot

### DIFF
--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework/cryptfs_tpm2
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-framework/cryptfs_tpm2
@@ -7,7 +7,7 @@ cryptfs_check_tpm2() {
 	# Check for SecureBoot support as PCR 7 differs based on its state
 	efi_secure=`efivar --name=8be4df61-93ca-11d2-aa0d-00e098032b8c-SecureBoot --print-decimal`
 	efi_mode=`efivar --name=8be4df61-93ca-11d2-aa0d-00e098032b8c-SetupMode --print-decimal`
-	if [ "${efi_secure}" != "1" ] || [ "${efi_mode}" != "0" ]; then
+	if [ "${efi_secure}" -ne 1 ] || [ "${efi_mode}" -ne 0 ]; then
 		fatal "UEFI SecureBoot not enabled (required due PCR 7)"
 	fi
 

--- a/meta-lmp-base/recipes-core/initrdscripts/initramfs-module-install-efi/init-install-efi.sh
+++ b/meta-lmp-base/recipes-core/initrdscripts/initramfs-module-install-efi/init-install-efi.sh
@@ -17,7 +17,7 @@ check_secure_boot() {
 
     efi_secure=`efivar --name=8be4df61-93ca-11d2-aa0d-00e098032b8c-SecureBoot --print-decimal`
     efi_mode=`efivar --name=8be4df61-93ca-11d2-aa0d-00e098032b8c-SetupMode --print-decimal`
-    if [ "${efi_secure}" != "1" ] || [ "${efi_mode}" != "0" ]; then
+    if [ "${efi_secure}" -ne 1 ] || [ "${efi_mode}" -ne 0 ]; then
 	echo "UEFI SecureBoot not enabled, installation aborted"
 	exit 1
     fi


### PR DESCRIPTION
Using efivar --print-decimal returns an integer.