### PR TITLE
base: rs: Bump ostreeuploader ver 5cd2cf9

### DIFF
--- a/meta-lmp-base/recipes-sota/ostreeuploader/ostreeuploader_git.bb
+++ b/meta-lmp-base/recipes-sota/ostreeuploader/ostreeuploader_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=2a944942e1496af1886903d2
 GO_IMPORT = "github.com/foundriesio/ostreeuploader"
 GO_IMPORT_PROTO ?= "https"
 SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO};branch=master"
-SRCREV = "b3732aa3982b84da0b13027b627200374993a174"
+SRCREV = "5cd2cf990d85a8459c7e9a3f156894d009485e86"
 
 UPSTREAM_CHECK_COMMITS = "1"
 


### PR DESCRIPTION
Relevant changes:
- 5cd2cf9 check: Reduce a number of goroutine to check file existing
- e318913 fiopush: Treat summary update failure as error
- 5991933 push: Decrease number of push goroutines