### PR TITLE
bsp: dynamic-layers: lmp-boot-firmware: use L4T_VERSION

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-bsp/lmp-boot-firmware/lmp-boot-firmware.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-bsp/lmp-boot-firmware/lmp-boot-firmware.bbappend
@@ -1,3 +1,11 @@
 TEGRA_INSTALL_DEPENDS ?= ""
 TEGRA_INSTALL_DEPENDS:tegra = "tegra-uefi-capsules:do_install"
 do_install[depends] += "${TEGRA_INSTALL_DEPENDS}"
+
+inherit l4t_version
+
+def get_dec_bsp_version(bsp_version):
+    verparts = bsp_version.split('.')
+    return int(verparts[0])<<16 | int(verparts[1])<<8 | int(verparts[2])
+
+LMP_BOOT_FIRMWARE_VERSION:tegra = "${@get_dec_bsp_version(d.getVar('L4T_VERSION'))}"


### PR DESCRIPTION
Use L4T_VERSION variable, and convert it to the same format as it's currenlty exposed via ESRT table:

$ cat /sys/firmware/efi/esrt/entries/entry0/fw_version 2295296