### PR TITLE
base: lmp: Add diagnostic tool

### DIFF
--- a/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
+++ b/meta-lmp-base/recipes-samples/images/lmp-image-common.inc
@@ -43,6 +43,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     sudo \
     tzdata \
     zram \
+    fio-diag \
 "
 
 # Additional packages when sota is available

--- a/meta-lmp-base/recipes-support/fio-diag/fio-diag_0.1.bb
+++ b/meta-lmp-base/recipes-support/fio-diag/fio-diag_0.1.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Foundries.io Diagnostic Tool for a Device"
+SECTION = "devel"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9"
+HOMEPAGE = "https://github.com/foundriesio/lmp-tools/tree/master/device-scripts"
+
+SRCREV = "4096c9b825155273b2ec72dccbde45a904b7c9b5"
+
+SRC_URI = " \
+    git://github.com/foundriesio/lmp-tools;protocol=https;branch=master;name=lmp-tools \
+"
+
+S = "${WORKDIR}/git/device-scripts"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_install () {
+	install -d ${D}${sbindir}
+	install -m 0755 ${S}/fio-diag.sh ${D}${sbindir}
+}


### PR DESCRIPTION
This adds the first version of fio-diag.sh to an lmp image

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>
