### PR TITLE
Aklite and composectl sotactl v95

### DIFF
--- a/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
+++ b/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=504a5c2455c8bb2fc5b76678
 GO_IMPORT = "github.com/foundriesio/composeapp"
 GO_IMPORT_PROTO ?= "https"
 SRCBRANCH = "v95"
-SRCREV = "593cad55b6c02e9c5f983bb7ae9e5816b7800f0d"
+SRCREV = "b06f6d1194cb67398f5ad7c009f32eb0362dc3ab"
 SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO};branch=${SRCBRANCH}"
 UPSTREAM_CHECK_COMMITS = "1"
 

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -17,6 +17,7 @@ PACKAGECONFIG[ubootenv] = ",,u-boot-fw-utils,u-boot-fw-utils u-boot-default-env 
 PACKAGECONFIG[libfyaml] = ",,,libfyaml"
 PACKAGECONFIG[aklite-offline] = "-DBUILD_AKLITE_OFFLINE=ON,-DBUILD_AKLITE_OFFLINE=OFF,"
 PACKAGECONFIG[hsm] = "-DBUILD_P11=ON -DPKCS11_ENGINE_PATH=${PKCS11_ENGINE_PATH},-DBUILD_P11=OFF,libp11,aktualizr-pkcs11-label"
+PACKAGECONFIG[auto-downgrade] = "-DAUTO_DOWNGRADE=ON"
 
 SYSTEMD_PACKAGES += "${PN}-lite"
 SYSTEMD_SERVICE:${PN}-lite = "aktualizr-lite.service"

--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-BRANCH:lmp = "master"
-SRCREV:lmp = "84f3a65edf85d52e2c524bc06ea479c50507beea"
+BRANCH:lmp = "v95"
+SRCREV:lmp = "9d0d1306132bc0ec5b27afe6d164045d1675bc54"
 
 SRC_URI:remove:lmp = "gitsm://github.com/uptane/aktualizr;branch=${BRANCH};name=aktualizr;protocol=https"
 SRC_URI:append:lmp = " \


### PR DESCRIPTION
# Aktualizr-lite

## New Features

1. Added support for EFI boot firmware updates, including functionality to get/set bootloader control environment variables using the `fioefi_setenv` and `fioefi_printenv` utilities.

2. Added new CLI client commands: `check`, `pull`, `install`, and `run`. These individual commands allow users to pull, install, and apply updates from different contexts.

3. Introduced the `--src-dir` parameter for the `aktualizr-lite` CLI client, enabling offline updates.

4. Automatic downgrade prevention.

5. Added support for user-initiated rollbacks [experimental]

## Improvements

1. Integrated `composectl` for all operations involving Compose Apps, such as pruning, checking if running, etc.

2. Optimized app management to minimize the number of actions performed on Compose Apps during the update cycle.

3. Made app stopping before an update configurable.

4. Introduced several changes to the API (refer to the commit message for details).

6. Moved the custom SOTA client example from the `aktualizr-lite` repository to a dedicated repository: [`https://github.com/foundriesio/sotactl`](https://github.com/foundriesio/sotactl).

7. Transitioned the `aklite` daemon to API-based usage.

## Testing

1. Added a Compose-based environment for developing and testing `aktualizr-lite` end-to-end in a containerized setup against a real factory.


# Composectl

## New Features

1. Added the `publish` command to package a Compose App as a container image and upload it to a container registry.

2. Added the `show` command to print app manifest and Compose project details.

3. Introduced App bundle indexing, which includes hash generation for each item in the bundle. The hashes are verified during app OTA updates, installation, and starting. Additionally, the maximum app bundle size is now limited to 1GB.

## Bug Fixes

- Resolved several minor issues, mainly related to app blob pruning and checking whether an app is installed and running.  
  See the commit message for more details.

## Testing

1. Added a Compose-based environment for development and end-to-end testing of `composectl` in a containerized setup.

2. Implemented a series of end-to-end tests, including tests for edge cases.

