### PR TITLE
[kirkstone] firmware: fix downstream firmware-nxp-wifi conflicts with the upstream linux-firmware

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/firmware-imx/firmware-nxp-wifi_1.0.bbappend
@@ -1,0 +1,3 @@
+RPROVIDES:${PN}-nxp-common = "linux-firmware-nxp-common"
+RREPLACES:${PN}-nxp-common = "linux-firmware-nxp-common"
+RCONFLICTS:${PN}-nxp-common = "linux-firmware-nxp-common"

--- a/meta-lmp-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-lmp-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -58,3 +58,15 @@ FILES:${PN}-bcm4356-pcie += " \
 "
 
 PACKAGES:remove:imx-nxp-bsp = "${PN}-imx-sdma-license ${PN}-imx-sdma-imx6q ${PN}-imx-sdma-imx7d"
+
+PACKAGES =+ "${PN}-nxp8987-sdio ${PN}-nxp-common"
+
+FILES:${PN}-nxp8987-sdio = " \
+        ${nonarch_base_libdir}/firmware/nxp/*8987* \
+"
+RDEPENDS:${PN}-nxp8987-sdio += "${PN}-nxp-common"
+
+FILES:${PN}-nxp-common = " \
+        ${nonarch_base_libdir}/firmware/nxp/wifi_mod_para.conf \
+        ${nonarch_base_libdir}/firmware/nxp/helper_uart_3000000.bin \
+"


### PR DESCRIPTION
Fix for:
```
* check_data_file_clashes: Package linux-firmware wants to install file /lmp/build-lmp-imx8mm-lpddr4-evk-kirkstone/tmp-lmp/work/imx8mm_lpddr4_evk-lmp-linux/lmp-base-console-image/1.0-r0/rootfs/usr/lib/firmware/nxp/helper_uart_3000000.bin
        But that file is already provided by package  * firmware-nxp-wifi-nxp-common
 * check_data_file_clashes: Package linux-firmware wants to install file /lmp/build-lmp-imx8mm-lpddr4-evk-kirkstone/tmp-lmp/work/imx8mm_lpddr4_evk-lmp-linux/lmp-base-console-image/1.0-r0/rootfs/usr/lib/firmware/nxp/uartuart8987_bt.bin
        But that file is already provided by package  * firmware-nxp-wifi-nxp8987-sdio
```


Steps to replicate is installing the upstream `linux-firmware` using the machine `imx8mm-lpddr4-evk`