### PR TITLE
base: kernel-lmp-fitimage: align changes with scarthgap

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-base-scr/imx8qm-mek/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-base-scr/imx8qm-mek/boot.cmd
@@ -1,5 +1,5 @@
 setenv fdt_file imx8qm-mek.dtb
-echo "Using freescale_${fdt_file}"
+echo "Using ${fdt_file}"
 
 # Default boot type and device
 setenv devtype mmc

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/am62xx-evm/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/am62xx-evm/boot.cmd
@@ -8,7 +8,7 @@ setenv rootpart 2
 setenv loadaddr 0x90000000
 setenv fit_addr "${loadaddr}"
 
-setenv bootcmd_custom_run 'run findfdt; run get_fit_config; bootm ${fit_addr}#${name_fit_config}${dtoverlay}'
+setenv fdt_file_final k3-am625-sk.dtb
 
 setenv bootloader1_src_image "tiboot3-am62x-gp-evm.bin"
 setenv board_is_closed "0"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/am64xx-evm/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/am64xx-evm/boot.cmd
@@ -4,12 +4,10 @@ setenv devtype mmc
 setenv devnum ${mmcdev}
 setenv bootpart 1
 setenv rootpart 2
-setenv name_fdt ti/k3-am642-sk.dtb
+setenv fdt_file_final k3-am642-sk.dtb
 
 setenv loadaddr 0x90000000
 setenv fit_addr "${loadaddr}"
-
-setenv bootcmd_custom_run 'run findfdt; setenv fdtfile ${name_fdt}; run get_fit_config; bootm ${loadaddr}#${name_fit_config}'
 
 setenv bootloader1_src_image "tiboot3-am64x-gp-evm.bin"
 setenv board_is_closed "0"

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx6ulevk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx6ulevk/boot.cmd
@@ -2,7 +2,7 @@
 run findfdt
 echo "Using ${fdt_file}"
 
-setenv fdt_file_final nxp_imx_${fdt_file}
+setenv fdt_file_final ${fdt_file}
 
 # Default boot type and device
 setenv bootlimit 3

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx6ullevk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx6ullevk/boot.cmd
@@ -2,7 +2,7 @@
 run findfdt
 echo "Using ${fdt_file}"
 
-setenv fdt_file_final nxp_imx_${fdt_file}
+setenv fdt_file_final ${fdt_file}
 
 # Default boot type and device
 setenv bootlimit 3

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mm-lpddr4-evk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mm-lpddr4-evk/boot.cmd
@@ -1,4 +1,4 @@
-echo "Using freescale_${fdt_file}"
+echo "Using ${fdt_file}"
 
 # Default boot type and device
 setenv bootlimit 3
@@ -8,7 +8,7 @@ setenv bootpart 1
 setenv rootpart 2
 
 # Boot image files
-setenv fdt_file_final freescale_${fdt_file}
+setenv fdt_file_final ${fdt_file}
 setenv fit_addr ${initrd_addr}
 
 # Boot firmware updates

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mn-ddr4-evk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mn-ddr4-evk/boot.cmd
@@ -1,4 +1,4 @@
-echo "Using freescale_${fdtfile}"
+echo "Using ${fdtfile}"
 
 # Default boot type and device
 setenv bootlimit 3
@@ -8,7 +8,7 @@ setenv bootpart 1
 setenv rootpart 2
 
 # Boot image files
-setenv fdt_file_final freescale_${fdtfile}
+setenv fdt_file_final ${fdtfile}
 setenv fit_addr 0x43800000
 
 # Boot firmware updates

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mn-lpddr4-evk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mn-lpddr4-evk/boot.cmd
@@ -1,4 +1,4 @@
-echo "Using freescale_${fdtfile}"
+echo "Using ${fdtfile}"
 
 # Default boot type and device
 setenv bootlimit 3
@@ -8,7 +8,7 @@ setenv bootpart 1
 setenv rootpart 2
 
 # Boot image files
-setenv fdt_file_final freescale_${fdtfile}
+setenv fdt_file_final ${fdtfile}
 setenv fit_addr 0x43800000
 
 # Boot firmware updates

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mp-lpddr4-evk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mp-lpddr4-evk/boot.cmd
@@ -1,4 +1,4 @@
-echo "Using freescale_${fdtfile}"
+echo "Using ${fdtfile}"
 
 # Default boot type and device
 setenv bootlimit 3
@@ -8,7 +8,7 @@ setenv bootpart 1
 setenv rootpart 2
 
 # Boot image files
-setenv fdt_file_final freescale_${fdtfile}
+setenv fdt_file_final ${fdtfile}
 setenv fit_addr 0x43800000
 
 # Boot firmware updates

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mq-evk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8mq-evk/boot.cmd
@@ -1,4 +1,4 @@
-setenv fdt_file_final freescale_imx8mq-evk.dtb
+setenv fdt_file_final imx8mq-evk.dtb
 echo "Using ${fdt_file_final}"
 
 # Default boot type and device

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8qm-mek/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx8qm-mek/boot.cmd
@@ -1,5 +1,5 @@
 setenv fdt_file imx8qm-mek.dtb
-echo "Using freescale_${fdt_file}"
+echo "Using ${fdt_file}"
 
 # Default boot type and device
 setenv bootlimit 3
@@ -16,14 +16,14 @@ setenv initrd_high
 
 # Boot image files
 setenv fit_addr ${ramdisk_addr_r}
-setenv fdt_file_final freescale_${fdt_file}
+setenv fdt_file_final ${fdt_file}
 
 setenv bootcmd_boot_hdmi 'hdp load ${loadaddr}'
 setenv bootcmd_boot_m4_0 'dcache flush; bootaux ${loadaddr} 0'
 setenv bootcmd_boot_m4_1 'dcache flush; bootaux ${loadaddr} 1'
-setenv bootcmd_load_hdmi 'if imxtract ${ramdisk_addr_r}#conf-freescale_${fdt_file} loadable-${hdmi_image} ${loadaddr}; then run bootcmd_boot_hdmi; fi'
-setenv bootcmd_load_m4_0 'if imxtract ${ramdisk_addr_r}#conf-freescale_${fdt_file} loadable-${m4_0_image} ${loadaddr}; then run bootcmd_boot_m4_0; fi;'
-setenv bootcmd_load_m4_1 'if imxtract ${ramdisk_addr_r}#conf-freescale_${fdt_file} loadable-${m4_1_image} ${loadaddr}; then run bootcmd_boot_m4_1; fi;'
+setenv bootcmd_load_hdmi 'if imxtract ${ramdisk_addr_r}#conf-${fdt_file} loadable-${hdmi_image} ${loadaddr}; then run bootcmd_boot_hdmi; fi'
+setenv bootcmd_load_m4_0 'if imxtract ${ramdisk_addr_r}#conf-${fdt_file} loadable-${m4_0_image} ${loadaddr}; then run bootcmd_boot_m4_0; fi;'
+setenv bootcmd_load_m4_1 'if imxtract ${ramdisk_addr_r}#conf-${fdt_file} loadable-${m4_1_image} ${loadaddr}; then run bootcmd_boot_m4_1; fi;'
 setenv bootcmd_load_fw 'run bootcmd_load_hdmi; run bootcmd_load_m4_0; run bootcmd_load_m4_1;'
 
 # Boot firmware updates

--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx93-11x11-lpddr4x-evk/boot.cmd
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-ostree-scr-fit/imx93-11x11-lpddr4x-evk/boot.cmd
@@ -1,4 +1,4 @@
-echo "Using freescale_${fdtfile}"
+echo "Using ${fdtfile}"
 
 # Default boot type and device
 setenv bootlimit 3
@@ -8,7 +8,7 @@ setenv bootpart 1
 setenv rootpart 2
 
 # Boot image files
-setenv fdt_file_final freescale_${fdtfile}
+setenv fdt_file_final ${fdtfile}
 setenv fit_addr ${initrd_addr}
 
 # Boot firmware updates


### PR DESCRIPTION
Align with the kernel-fitimage changes available in scarthgap.

This will help us upstreaming the changes as we can easily generate a diff based on what is available in scarthgap.