### PR TITLE
base: systemd-boot: display order

### DIFF
--- a/meta-lmp-base/recipes-bsp/efitools/efitools/lockdown.conf
+++ b/meta-lmp-base/recipes-bsp/efitools/efitools/lockdown.conf
@@ -1,2 +1,3 @@
 title UEFI Secure Boot Provisioning
 efi /LockDown.efi
+sort-key 01

--- a/meta-lmp-base/recipes-bsp/efitools/efitools/unlock.conf
+++ b/meta-lmp-base/recipes-bsp/efitools/efitools/unlock.conf
@@ -1,2 +1,3 @@
 title UEFI Secure Boot PK Clear
 efi /UnLock-signed.efi
+sort-key 02

--- a/meta-lmp-base/recipes-core/systemd/systemd-boot/efi-boot-display-sort-key-default.patch
+++ b/meta-lmp-base/recipes-core/systemd/systemd-boot/efi-boot-display-sort-key-default.patch
@@ -1,0 +1,33 @@
+From 01f64cfa48f5a2b38f35dac1b18482a2707fce0e Mon Sep 17 00:00:00 2001
+From: Jorge Ramirez-Ortiz <jorge@foundries.io>
+Date: Wed, 29 Jan 2025 15:43:31 +0100
+Subject: [PATCH] [PATCH] boot: efi: enable new style display order
+
+The UEFI provisioning applications should be displayed after all other
+entries.
+
+To avoid defaulting to the old display order - causing the provisioning
+applications to raise to the top of the display menu - move undefined
+configs to the top of the display.
+
+Upstream-Status: Inappropriate [lmp specific]
+
+Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
+---
+ src/boot/efi/boot.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 83207a5afe..688d9454a2 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -1430,6 +1430,7 @@ static void boot_entry_add_type1(
+         *entry = (BootEntry) {
+                 .tries_done = -1,
+                 .tries_left = -1,
++                .sort_key = xstrdup16(L"00"),
+         };
+
+         while ((line = line_get_key_value(content, " \t", &pos, &key, &value)))
+--
+2.34.1

--- a/meta-lmp-base/recipes-core/systemd/systemd-boot_%.bbappend
+++ b/meta-lmp-base/recipes-core/systemd/systemd-boot_%.bbappend
@@ -1,6 +1,11 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
 # Ostree handles the default boot configuration
 RDEPENDS:${PN}:remove:sota = "virtual-systemd-bootconf"
 
+SRC_URI:append = " \
+	file://efi-boot-display-sort-key-default.patch \
+"
 # Install systemd-boot at expected path for tools such as bootctl
 do_install:append() {
 	install -d ${D}${nonarch_base_libdir}/systemd/boot/efi


### PR DESCRIPTION
By using the sort-key [1] label in the conf files, this PR positions ostree deployments above UEFI provisioning applications.

Setting the default sort-key enforces the new systemd-boot style ordering patch.

[1] https://uapi-group.org/specifications/specs/boot_loader_specification/#sorting