### PR TITLE
Revert "bsp: isp-imx: revert scarthgap specific changes"

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/isp-imx/isp-imx_4.2.2.24.0.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/freescale-layer/recipes-bsp/isp-imx/isp-imx_4.2.2.24.0.bbappend
@@ -1,5 +1,0 @@
-# Revert meta-freescale 4bc9568 (scarthgap specific)
-do_configure:append() {
-    patchelf --replace-needed libtinyxml2.so.10 libtinyxml2.so.9 ${S}/units/cam_device/proprietories/lib/libcam_device.so
-    patchelf --replace-needed libtinyxml2.so.10 libtinyxml2.so.9 ${S}/mediacontrol/lib/arm-64/fpga/libcam_device.so
-}


### PR DESCRIPTION
This reverts commit https://github.com/quaresmajose/meta-lmp/commit/4662f1c424ffb87dbeaa801d86d4147c066522c0.

This patch is not need anymore on lmp scarthgap and he is specific
to be used with oe-core/kirkstone.

The patch was needed prior to the scarthgap switch.
when we use the meta-freescale/scarthgap branch with the
oe-core/kirkstone branch, but now everything is on scarthgap.