### PR TITLE
bsp: conf: x86: append provision tools only with signatures

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -143,7 +143,7 @@ WKS_FILE_DEPENDS:append:intel-corei7-64 = " ${INITRD_IMAGE_LIVE} efitools"
 WKS_FILE_DEPENDS_BOOTLOADERS:remove:intel-corei7-64 = "grub-efi"
 ## wic-based installer requires image to be available via IMAGE_BOOT_FILES
 IMAGE_BOOT_FILES:intel-corei7-64 = "${@bb.utils.contains('WKS_FILE', 'image-efi-installer.wks.in', 'systemd-bootx64.efi;EFI/BOOT/bootx64.efi systemd-bootx64.efi;EFI/systemd/systemd-bootx64.efi ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ota-ext4;rootfs.img', '', d)}"
-IMAGE_EFI_BOOT_FILES:append:intel-corei7-64 = " lockdown.conf;loader/entries/doprovision_lock+0.conf unlock.conf;loader/entries/doprovision_unlock+0.conf LockDown.efi UnLock-signed.efi ${@make_efi_cer_boot_files(d)}"
+IMAGE_EFI_BOOT_FILES:append:intel-corei7-64 = "${@bb.utils.contains('UEFI_SIGN_ENABLE', '1', ' lockdown.conf;loader/entries/doprovision_lock+0.conf unlock.conf;loader/entries/doprovision_unlock+0.conf LockDown.efi UnLock-signed.efi ${@make_efi_cer_boot_files(d)} ', '', d)}"
 
 # Common for iMX targets
 ## Prefer IMX_DEFAULT_BSP=nxp as mainline removes every common machine override


### PR DESCRIPTION
There is no value in appending the provisioning tools to the WIC unless UEFI signatures have been enabled.