### PR TITLE
bsp: intel-corei7-64: add 0 tries left suffixes

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -143,7 +143,7 @@ WKS_FILE_DEPENDS:append:intel-corei7-64 = " ${INITRD_IMAGE_LIVE} efitools"
 WKS_FILE_DEPENDS_BOOTLOADERS:remove:intel-corei7-64 = "grub-efi"
 ## wic-based installer requires image to be available via IMAGE_BOOT_FILES
 IMAGE_BOOT_FILES:intel-corei7-64 = "${@bb.utils.contains('WKS_FILE', 'image-efi-installer.wks.in', 'systemd-bootx64.efi;EFI/BOOT/bootx64.efi systemd-bootx64.efi;EFI/systemd/systemd-bootx64.efi ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ota-ext4;rootfs.img', '', d)}"
-IMAGE_EFI_BOOT_FILES:append:intel-corei7-64 = " lockdown.conf;loader/entries/doprovision_lock.conf unlock.conf;loader/entries/doprovision_unlock.conf LockDown.efi UnLock-signed.efi ${@make_efi_cer_boot_files(d)}"
+IMAGE_EFI_BOOT_FILES:append:intel-corei7-64 = " lockdown.conf;loader/entries/doprovision_lock+0.conf unlock.conf;loader/entries/doprovision_unlock+0.conf LockDown.efi UnLock-signed.efi ${@make_efi_cer_boot_files(d)}"
 
 # Common for iMX targets
 ## Prefer IMX_DEFAULT_BSP=nxp as mainline removes every common machine override

--- a/meta-lmp-bsp/scripts/lib/wic/plugins/source/bootimg-sota-efi.py
+++ b/meta-lmp-bsp/scripts/lib/wic/plugins/source/bootimg-sota-efi.py
@@ -128,7 +128,7 @@ class BootimgSotaEFIPlugin(SourcePlugin):
 
             # list of tuples (src_name, dst_name)
             deploy_files = []
-            for src_entry in re.findall(r'[\w;\-\./\*]+', boot_files):
+            for src_entry in re.findall(r'[\w;\-\.\+/\*]+', boot_files):
                 if ';' in src_entry:
                     dst_entry = tuple(src_entry.split(';'))
                     if not dst_entry[0] or not dst_entry[1]:


### PR DESCRIPTION
According to boot entries sorting rules in bootloader spec [1]:
- Entries which are subject to boot counting and are marked as “bad”, should be sorted later than all other entries. Entries which are marked as “indeterminate” or “good” (or were not subject to boot counting at all), are thus sorted earlier.

Mark unlock/lockdown boot entries as bad by adding +0 suffix (0 tries left), as a result the entries will be still shown (so it's possible to select them manually) and always be sorted late.

[1] https://uapi-group.org/specifications/specs/boot_loader_specification/#sorting
Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>