### PR TITLE
bsp: k3: add serial console configuration

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -467,6 +467,7 @@ PREFERRED_PROVIDER_virtual/kernel:k3 ?= "linux-lmp-ti-staging"
 WKS_FILE_DEPENDS:append:k3 = " virtual/bootloader"
 OSTREE_DEPLOY_USR_OSTREE_BOOT:k3 = "${@bb.utils.contains('DISTRO_FEATURES', 'luks', '1', '0', d)}"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS:remove:k3 = "kernel-image-image"
+OSTREE_KERNEL_ARGS:k3 ?= "console=ttyS2,115200n8 earlycon=ns16550a,mmio32,0x02800000 ${OSTREE_KERNEL_ARGS_COMMON}"
 
 # TI AM62x
 MACHINE_FEATURES:append:am62xx = " optee"


### PR DESCRIPTION
Add configuration for the serial console in the bootargs. The bootargs
were removed in commit bb3d65787("arm64: dts: ti: k3-am642-sk|evm: Drop
bootargs, add aliases") in the ti-linux-6.6.y branch. This change was
also sent upstream [1].

Providing the proper serial configuration in bootargs fixes the
broken console output in the Linux kernel:
Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 6.6.44-lmp-standard (oe-user@oe-host)

[1] https://lore.kernel.org/all/20230414073328.381336-11-nm@ti.com/