### PR TITLE
base: u-boot-fio-mfgtool: add default lmp-base distro cfg

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-mfgtool/lmp-base-common.cfg
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-mfgtool/lmp-base-common.cfg
@@ -1,0 +1,1 @@
+# this is only required to avoid failing in bitbake parsing on the lmp-base distro

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-mfgtool/lmp-base.cfg
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio-mfgtool/lmp-base.cfg
@@ -1,0 +1,1 @@
+# this is only required to avoid failing in bitbake parsing on the lmp-base distro


### PR DESCRIPTION
This is only required to avoid failing in bitbake parsing on the lmp-base distro. The issue can be observed when building the distro lmp-base and using the generic-arm64 machine.

It fixes the bitbake parsing ERROR:

| Unable to get checksum for u-boot-fio-mfgtool SRC_URI entry lmp-base-common.cfg: file could not be found
| Unable to get checksum for u-boot-fio-mfgtool SRC_URI entry lmp-base.cfg: file could not be found