### PR TITLE
bsp: tegra: linux-tegra-rt: bump to r35.6.0

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-kernel/linux/linux-tegra-rt_5.10.bb
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-kernel/linux/linux-tegra-rt_5.10.bb
@@ -3,4 +3,4 @@ require recipes-kernel/linux/linux-tegra_5.10.bb
 # Use BSP with rt-patches applied
 SRC_REPO = "github.com/foundriesio/linux.git;protocol=https"
 SRCBRANCH = "oe4t-patches${LINUX_VERSION_EXTENSION}-rt"
-SRCREV = "e0710cf2c0217aa6d704b98a3ac15b7ae90e22b9"
+SRCREV = "67c02150135fd85fbe367f76c8fa508461bd7c70"


### PR DESCRIPTION
Align rt version with linux-tegra from meta-tegra.