### PR TITLE
Tegra: make our internal downstream fork Xavier specific

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-bsp/tegra-binaries/tegra-helper-scripts-native_35.6.0.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-bsp/tegra-binaries/tegra-helper-scripts-native_35.6.0.bbappend
@@ -1,1 +1,1 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/tegra-helper-scripts:"
+FILESEXTRAPATHS:prepend := "${@bb.utils.contains('SOC_FAMILY', 'tegra194', '${THISDIR}/tegra-helper-scripts:', '', d)}"

--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-core/initrdscripts/tegra-flash-init_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-core/initrdscripts/tegra-flash-init_%.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://add-format-mmc-support.patch"
+SRC_URI:append:tegra194 = " file://add-format-mmc-support.patch"


### PR DESCRIPTION
We have support in https://github.com/foundriesio/meta-lmp/commit/7340131185416ca42f6a7f07d5b6f3f3c1719bf7 for WIC image on the external SSD on the Xavier and for that we added:

- Support for formatting the internal mmc, patching the target recipe `tegra-flash-init`
- Forked the `initrd-flash.sh` part of the recipe `tegra-helper-scripts-native`

We need to rewrite this initrd-flash API using hooks available upstream and we will do that in a followup.
https://github.com/OE4T/meta-tegra/commit/f619e64dddef91ff80b3013ea4e6a51a54083a66
https://github.com/OE4T/meta-tegra/commit/1d1466fa269e6e9e58b7e0509995389b009fdfee

This PR will restrict the downstream fork to Xavier and will follow with the upstream in the Orin SoC.