### PR TITLE
bsp: tegra: systemd-boot: double dtb buffer size

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-core/systemd/systemd-boot/0001-Increase-the-dtb-size.patch
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-core/systemd/systemd-boot/0001-Increase-the-dtb-size.patch
@@ -1,0 +1,60 @@
+From 919601f2598eb3dd17fe88d26cafed88420daad2 Mon Sep 17 00:00:00 2001
+From: Brian McGillion <bmg.avoin@gmail.com>
+Date: Thu, 23 Jan 2025 13:08:15 +0400
+Subject: [PATCH] Increase the dtb size
+
+This is probably due to fact systemd-boot does not allocate any extra space for the device tree.
+Without the modification, because there is not any extra space, the UEFI will fail applying the
+overlay changes from its .dtbo files
+
+Fixes:
+| EFI stub: ERROR: Invalid header detected on UEFI supplied FDT, ignoring ...
+| EFI stub: Generating empty DTB
+
+References:
+https://github.com/anduril/jetpack-nixos/issues/111
+
+Upstream-Status: Pending [https://github.com/tiiuae/ghaf/blob/main/modules/common/systemd/systemd-boot-double-dtb-buffer-size.patch]
+
+Signed-off-by: Brian McGillion <bmg.avoin@gmail.com>
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ src/boot/efi/devicetree.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/boot/efi/devicetree.c b/src/boot/efi/devicetree.c
+index 61a43cd77d..f939a79963 100644
+--- a/src/boot/efi/devicetree.c
++++ b/src/boot/efi/devicetree.c
+@@ -3,6 +3,7 @@
+ #include "devicetree.h"
+ #include "proto/dt-fixup.h"
+ #include "util.h"
++#include <endian.h>
+ 
+ #define FDT_V1_SIZE (7*4)
+ 
+@@ -88,7 +89,8 @@ EFI_STATUS devicetree_install(struct devicetree_state *state, EFI_FILE *root_dir
+                 /* 32MB device tree blob doesn't seem right */
+                 return EFI_INVALID_PARAMETER;
+ 
+-        len = info->FileSize;
++        /* Double the length to be allocated so there's space for modifications */
++        len = info->FileSize * 4;
+ 
+         err = devicetree_allocate(state, len);
+         if (err != EFI_SUCCESS)
+@@ -102,6 +104,10 @@ EFI_STATUS devicetree_install(struct devicetree_state *state, EFI_FILE *root_dir
+         if (err != EFI_SUCCESS)
+                 return err;
+ 
++        /* Double the size inside the device tree structure */
++        uint32_t *totalsize = (uint32_t *)(((char *)PHYSICAL_ADDRESS_TO_POINTER(state->addr) + 4));
++        (*totalsize) = htobe32(be32toh(*totalsize) * 4);
++
+         return BS->InstallConfigurationTable(
+                         MAKE_GUID_PTR(EFI_DTB_TABLE), PHYSICAL_ADDRESS_TO_POINTER(state->addr));
+ }
+-- 
+2.48.1
+

--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-core/systemd/systemd-boot_%.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-core/systemd/systemd-boot_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:orin-nano = " file://0001-Increase-the-dtb-size.patch"


### PR DESCRIPTION
This is probably due to fact systemd-boot does not allocate any extra space for the device tree. Without the modification, because there is not any extra space, the UEFI will fail applying the overlay changes from its .dtbo files

Fixes:
```
EFI stub: ERROR: Invalid header detected on UEFI supplied FDT, ignoring ... 
EFI stub: Generating empty DTB
```
References:
https://github.com/anduril/jetpack-nixos/issues/111