### PR TITLE
base: lmp: bump version for the 4.0.22 yocto release

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -1,4 +1,4 @@
-DISTRO_VERSION = "4.0.20"
+DISTRO_VERSION = "4.0.22"
 
 # These default to 'oecore' and 'nodistro'
 SDK_NAME_PREFIX = "${DISTRO}"


### PR DESCRIPTION
Align meta-lmp with the 4.0.22 yocto release.

Lmp-manifest update will follow.