### PR TITLE
bsp: linux-lmp-fslc-imx: Bump kernel 6.6-2.2.x-imx to 5ff4cf4d

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.6.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.6.bb
@@ -11,7 +11,7 @@ include recipes-kernel/linux/kmeta-linux-lmp-6.6.y.inc
 LINUX_VERSION ?= "6.6.74"
 KERNEL_BRANCH ?= "6.6-2.2.x-imx"
 
-SRCREV_machine = "92bdc37231596ea6b737cf897cea98c356b9d248"
+SRCREV_machine = "5ff4cf4d61e11f0fdf8d4e2e54fbb203e46d34b2"
 
 SRC_URI:append:imx8mp-lpddr4-evk = " \
     ${@bb.utils.contains('MACHINE_FEATURES', 'se05x', 'file://0001-FIO-internal-arch-arm64-dts-imx8mp-enable-I2C5-bus.patch', '', d)} \


### PR DESCRIPTION
Relevant changes:
- 5ff4cf4d61e1 Merge pull request #713 from angolini/fix_imx93
- e587f8fe42f1 firmware: se_fw: remove info_list from ro section
- a0609cb5220a Merge pull request #712 from angolini/push_one
- 0f638960dcff media: Kconfig: fix double VIDEO_DEV
- 226bfffe04bc Merge pull request #709 from fs-csenatore/6.6-2.2.x-imx
- 198242c057e0 drivers:clk:imx:clk-imx8mp-audiomix: remove duplicated CLK_GATE_PARENT definition
- 427223e3206d Merge pull request #707 from iceaway/revert_u-serial_patch
- 4f5936d7391f Revert "usb: gadget: u_serial: Disable ep before setting port to null to fix the crash caused by port being null"
- 00aabf3c03c3 Merge pull request #705 from unitexe/6.6-2.2.x-imx
- 997b7e13e413 imx8mp-olimex.dts: Olimex iMX8MP-SOM-EVB-IND
- 2a0fc42db4d4 Merge pull request #704 from ernestvh/6.6-2.2.x-imx-forward-port
- b746c990ecba Revert "LF-12740: mxc: vpu: hantro_v4l2: report performance statistics"
- e349e6c45a94 arm64: imx_v8_defconfig: Enable CONFIG_GPIO_VF610
- 5a015324eddc arm64: dts: imx8qm: add missing imx8-ss-cm40.dtsi include
- 8a8245d395d5 arm64: dts: imx8: img: add #address-cells and #size-cells to I2C MIPI CSI nodes
- db13648c4be6 fw: imx: seco_mu: change dev_err to dev_err_probe for -EPROBE_DEFER
- 0451236fd0ae clk: imx: imx8qm: add more resources to whitelist
- 2ee789512d1b drm/imx: lcdifv3: Fix videomode settings
- 5cd4c30ec228 i2c: imx: Remove unnecessary clock reconfiguration
- 583f2a703c5d tty: vt: conmakehash: remove non-portable code printing comment header
- 4ddc4dae8515 tty: vt: conmakehash: cope with abs_srctree no longer in env
- 46a05495bce3 drm: of: Fix build without CONFIG_OF