### PR TITLE
bsp: tegra: libnvidia-container: fix build error

### DIFF
--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-containers/libnvidia-container/libnvidia-container/0003-nvcgo-fix-build-with-go-1.24.patch
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-containers/libnvidia-container/libnvidia-container/0003-nvcgo-fix-build-with-go-1.24.patch
@@ -1,0 +1,43 @@
+From d44307d59b60926e016b98f27aa87aadb050e4a6 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Sun, 9 Mar 2025 07:34:57 -0700
+Subject: [PATCH] nvcgo: fix build with go 1.24
+
+Go doesn't allow adding methods to types defined elsewhere,
+leading to this error:
+
+/main.go:35:10: cannot define new methods on non-local type CDeviceRule
+
+Change the locally-defined method to be an ordinary function instead.
+
+Upstream-Status: Pending
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ src/nvcgo/main.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/nvcgo/main.go b/src/nvcgo/main.go
+index 1523a06d..380ebfb0 100644
+--- a/src/nvcgo/main.go
++++ b/src/nvcgo/main.go
+@@ -32,7 +32,7 @@ func main() {}
+ type CDeviceRule = C.struct_device_rule
+ 
+ // Convert a C-based DeviceRule to a Go-based cgroup.DeviceRule
+-func (r *CDeviceRule) convert() cgroup.DeviceRule {
++func convert(r *CDeviceRule) cgroup.DeviceRule {
+ 	return cgroup.DeviceRule{
+ 		Allow:  bool(r.allow),
+ 		Type:   C.GoString(r._type),
+@@ -100,7 +100,7 @@ func AddDeviceRules(version C.int, cgroupPath *C.char, crules []CDeviceRule, rer
+ 
+ 	rules := make([]cgroup.DeviceRule, len(crules))
+ 	for i, cr := range crules {
+-		rules[i] = cr.convert()
++		rules[i] = convert(&cr)
+ 	}
+ 
+ 	err = api.AddDeviceRules(C.GoString(cgroupPath), rules)
+-- 
+2.43.0
+

--- a/meta-lmp-bsp/dynamic-layers/tegra/recipes-containers/libnvidia-container/libnvidia-container_1.10.0.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/tegra/recipes-containers/libnvidia-container/libnvidia-container_1.10.0.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0003-nvcgo-fix-build-with-go-1.24.patch"


### PR DESCRIPTION
Add a patch to libnvidia-container to fix build issues with go 1.24.