### PR TITLE
Revert "bsp: lmsensors-config: add fancontrol config for kv260"

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/lm_sensors/lmsensors-config_1.0.bbappend
+++ b/meta-lmp-bsp/recipes-bsp/lm_sensors/lmsensors-config_1.0.bbappend
@@ -1,4 +1,0 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-
-# /usr/bin/rrdcgi is provided by rrdtool
-INSANE_SKIP:${PN}-cgi += "file-rdeps"


### PR DESCRIPTION
This reverts commit 591daf5876895f5ee1cf66629c0fdbb539a68a3c.

Fixup for c3d48d9 bsp: Xilinx: Remove the LmP support

We removed the config file lmsensors-config/kv260/fancontrol but the bbappend stayed there.