### PR TITLE
base: aktualizr: fix RDEPENDS

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -77,8 +77,8 @@ FILES:${PN}-lite-dev = "${includedir}/${PN}-lite"
 FILES:${PN}-lite-offline = "${bindir}/aklite-offline"
 
 # Force same RDEPENDS, packageconfig rdepends common to both
-RDEPENDS:${PN}-lite = "\
-    ${RDEPENDS:aktualizr} \
+RDEPENDS:${PN}-lite:class-target = "\
+    aktualizr \
     ${@bb.utils.contains('PACKAGECONFIG', 'aklite-offline', '${PN}-lite-offline', '', d)} \
 "
-RDEPENDS:${PN}-lite-lib = "${RDEPENDS:aktualizr} composectl"
+RDEPENDS:${PN}-lite-lib:class-target = "aktualizr composectl"


### PR DESCRIPTION
The "${RDEPENDS:aktualizr}" syntax is not supported in bitbake.
Also take the opurtunity to apply it just for the class-target