### PR TITLE
bsp: linux-lmp-rpi: update to 6.6.63

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-rpi_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-rpi_git.bb
@@ -1,8 +1,8 @@
 include recipes-kernel/linux/kmeta-linux-lmp-6.6.y.inc
 
-LINUX_VERSION ?= "6.6.22"
+LINUX_VERSION ?= "6.6.63"
 KBRANCH = "rpi-6.6.y"
-SRCREV_machine = "c04af98514c26014a4f29ec87b3ece95626059bd"
+SRCREV_machine = "e442e5c1ab6bff5b5460b4fc949beb72aaf77970"
 SRCREV_meta = "${KERNEL_META_COMMIT}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"


### PR DESCRIPTION
Follow meta-raspberrypi scarthgap
https://git.yoctoproject.org/meta-raspberrypi/commit/?h=scarthgap&id=3209d986607315d17b11762e06cbe7142bf8bb70