### PR TITLE
base:classes: Fix path for recipeinfo license file

### DIFF
--- a/meta-lmp-base/classes/image-license-checker.bbclass
+++ b/meta-lmp-base/classes/image-license-checker.bbclass
@@ -99,7 +99,15 @@ def license_expr_for_recipe(d, recipe):
     """
     Get a license expression for a recipe.
     """
-    file = os.path.join(d.getVar("LICENSE_DIRECTORY"), recipe, "recipeinfo")
+
+    pkgarchs = d.getVar("SSTATE_ARCHS").split()
+    pkgarchs.reverse()
+    for pkgarch in pkgarchs:
+        file = os.path.join(d.getVar("LICENSE_DIRECTORY"), pkgarch, recipe, "recipeinfo")
+        if os.path.exists(file):
+            break
+    if not os.path.exists(file):
+        bb.fatal("Couldn't find license information for recipe %s" % recipe)
     keys_in_file = ["LICENSE"]
     return license_expr_from_file(file, keys_in_file)
 


### PR DESCRIPTION
There are a fix in the DEPLOY_DIR/licenses/recipe/recipeinfo path generation in Scarthgap. The archtecture was included to avoid overlaping.

This patch uses the same mechanism used in license.bbclass to deploy the license files to search for them in image-license-checker.bbclass.

We can have references such as
https://patchwork.yoctoproject.org/project/oe-core/patch/20230919214621.903967-1-richard.purdie@linuxfoundation.org/ https://github.com/yoctoproject/poky/commit/6cc2a3649a03da8b2ebc4fff4b7bd9ba4eb76497