### PR TITLE
Revert "base: aktualizr: fix RDEPENDS"

### DIFF
--- a/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/meta-lmp-base/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -77,8 +77,8 @@ FILES:${PN}-lite-dev = "${includedir}/${PN}-lite"
 FILES:${PN}-lite-offline = "${bindir}/aklite-offline"
 
 # Force same RDEPENDS, packageconfig rdepends common to both
-RDEPENDS:${PN}-lite:class-target = "\
-    aktualizr \
+RDEPENDS:${PN}-lite = "\
+    ${RDEPENDS:aktualizr} \
     ${@bb.utils.contains('PACKAGECONFIG', 'aklite-offline', '${PN}-lite-offline', '', d)} \
 "
-RDEPENDS:${PN}-lite-lib:class-target = "aktualizr composectl"
+RDEPENDS:${PN}-lite-lib = "${RDEPENDS:aktualizr} composectl"


### PR DESCRIPTION
This reverts commit d7f6d1b10ea6b21b41a9be86511265e936050141.

Its chnaged the RDEPENDS and that was not what was expected. The aktualizr-lite and aktualizr-lite-lib packages significantly change their runtime dependencies:

|- aktualizr-pkcs11-label libfyaml lshw
|+ aktualizr

The "${RDEPENDS:aktualizr}" is not suported anymore on the master branch but we need to find a different solution to this problem than the one proposed.

Suggested-by: Mike Sul <mike.sul@foundries.io>