### PR TITLE
bsp: optee-os-fio: imx: disable CFG_CORE_HUK_SUBKEY_COMPAT_USE_OTP_DI…

### DIFF
--- a/meta-lmp-bsp/recipes-security/optee/optee-os-fio-bsp-mfgtool.inc
+++ b/meta-lmp-bsp/recipes-security/optee/optee-os-fio-bsp-mfgtool.inc
@@ -9,6 +9,10 @@ OPTEEMACHINE:imx8qm-mek = "imx-mx8qmmek"
 OPTEEMACHINE:imx93-11x11-lpddr4x-evk = "imx-mx93evk"
 
 # SoC Settings
+# https://github.com/OP-TEE/optee_os/issues/7327
+EXTRA_OEMAKE:append:imx-generic-bsp = " \
+    CFG_CORE_HUK_SUBKEY_COMPAT_USE_OTP_DIE_ID=n \
+"
 EXTRA_OEMAKE:append:mx8m-nxp-bsp = " \
     CFG_NXP_CAAM=y CFG_NXP_CAAM_RNG_DRV=y \
     CFG_WITH_SOFTWARE_PRNG=n CFG_CRYPTO_DRIVER=y CFG_HWRNG_PTA=y CFG_HWRNG_QUALITY=1024 \

--- a/meta-lmp-bsp/recipes-security/optee/optee-os-fio-bsp.inc
+++ b/meta-lmp-bsp/recipes-security/optee/optee-os-fio-bsp.inc
@@ -12,6 +12,10 @@ OPTEEMACHINE:imx93-11x11-lpddr4x-evk = "imx-mx93evk"
 OPTEEMACHINE:qemuarm64 = "vexpress-qemu_armv8a"
 
 # SoC Settings
+# https://github.com/OP-TEE/optee_os/issues/7327
+EXTRA_OEMAKE:append:imx-generic-bsp = " \
+    CFG_CORE_HUK_SUBKEY_COMPAT_USE_OTP_DIE_ID=n \
+"
 EXTRA_OEMAKE:append:mx8m-nxp-bsp = " \
     CFG_NXP_CAAM=y CFG_NXP_CAAM_RNG_DRV=y \
     CFG_WITH_SOFTWARE_PRNG=n CFG_CRYPTO_DRIVER=y CFG_HWRNG_PTA=y CFG_HWRNG_QUALITY=1024 \


### PR DESCRIPTION
…E_ID

Manually disable CFG_CORE_HUK_SUBKEY_COMPAT_USE_OTP_DIE_ID as it was enabled upstream as part of
https://github.com/OP-TEE/optee_os/commit/fc80dabbd5a7d2d09834fc3f6175ef7eac3d6fd7, but causes a bad side effect on users during updates, as the subkey will change as a consequence.