### PR TITLE
base: gmp: prefer GPLv2-or-later as main license

### DIFF
--- a/meta-lmp-base/recipes-support/gmp/gmp_6.3.0.bbappend
+++ b/meta-lmp-base/recipes-support/gmp/gmp_6.3.0.bbappend
@@ -1,0 +1,3 @@
+# Upstream is dual licensed on GPLv2 | LGPLv3, so force GPLv2 in order
+# to allow safe checks via image-license-checker
+LICENSE = "GPL-2.0-or-later"


### PR DESCRIPTION
Upstream is dual licensed on GPLv2 | LGPLv3, so force GPLv2 in order to allow safe checks via image-license-checker.

There is no conflicting user by default, but users linking to libgmp need to be aware of the license implication.