### PR TITLE
bsp: linux-lmp-fslc-imx: backport fixes for imx6ull ethernet

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-clk-imx-imx6ul-fix-default-parent-for-enet-_ref_sel.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-clk-imx-imx6ul-fix-default-parent-for-enet-_ref_sel.patch
@@ -1,0 +1,52 @@
+From c2ee6de22dac61bbf406019b9f83455222413af3 Mon Sep 17 00:00:00 2001
+From: Sebastien Laveze <slaveze@smartandconnective.com>
+Date: Tue, 28 May 2024 17:14:33 +0200
+Subject: [PATCH] clk: imx: imx6ul: fix default parent for enet*_ref_sel
+
+[ Upstream commit e52fd71333b4ed78fd5bb43094bdc46476614d25 ]
+
+The clk_set_parent for "enet1_ref_sel" and  "enet2_ref_sel" are
+incorrect, therefore the original requirements to have "enet_clk_ref" as
+output sourced by iMX ENET PLL as a default config is not met.
+
+Only "enet[1,2]_ref_125m" "enet[1,2]_ref_pad" are possible parents for
+"enet1_ref_sel" and "enet2_ref_sel".
+
+This was observed as a regression using a custom device tree which was
+expecting this default config.
+
+This can be fixed at the device tree level but having a default config
+matching the original behavior (before refclock mux) will avoid breaking
+existing configs.
+
+Fixes: 4e197ee880c2 ("clk: imx6ul: add ethernet refclock mux support")
+Link: https://lore.kernel.org/lkml/20230306020226.GC143566@dragon/T/
+Signed-off-by: Sebastien Laveze <slaveze@smartandconnective.com>
+Reviewed-by: Oleksij Rempel <o.rempel@pengutronix.de>
+Link: https://lore.kernel.org/r/20240528151434.227602-1-slaveze@smartandconnective.com
+Signed-off-by: Abel Vesa <abel.vesa@linaro.org>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+
+Upstream-Status: Backport
+---
+ drivers/clk/imx/clk-imx6ul.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/clk/imx/clk-imx6ul.c b/drivers/clk/imx/clk-imx6ul.c
+index f9394e94f69d73..05c7a82b751f3c 100644
+--- a/drivers/clk/imx/clk-imx6ul.c
++++ b/drivers/clk/imx/clk-imx6ul.c
+@@ -542,8 +542,8 @@ static void __init imx6ul_clocks_init(struct device_node *ccm_node)
+ 
+ 	clk_set_parent(hws[IMX6UL_CLK_ENFC_SEL]->clk, hws[IMX6UL_CLK_PLL2_PFD2]->clk);
+ 
+-	clk_set_parent(hws[IMX6UL_CLK_ENET1_REF_SEL]->clk, hws[IMX6UL_CLK_ENET_REF]->clk);
+-	clk_set_parent(hws[IMX6UL_CLK_ENET2_REF_SEL]->clk, hws[IMX6UL_CLK_ENET2_REF]->clk);
++	clk_set_parent(hws[IMX6UL_CLK_ENET1_REF_SEL]->clk, hws[IMX6UL_CLK_ENET1_REF_125M]->clk);
++	clk_set_parent(hws[IMX6UL_CLK_ENET2_REF_SEL]->clk, hws[IMX6UL_CLK_ENET2_REF_125M]->clk);
+ 
+ 	imx_register_uart_clocks();
+ }
+-- 
+2.43.2
+

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-net-enetc-Use-IRQF_NO_AUTOEN-flag-in-request_irq.patch
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx/0001-net-enetc-Use-IRQF_NO_AUTOEN-flag-in-request_irq.patch
@@ -1,0 +1,43 @@
+From 1e8fc4ffa9554dfaf24a90158c2ad523dc4392bb Mon Sep 17 00:00:00 2001
+From: Jinjie Ruan <ruanjinjie@huawei.com>
+Date: Wed, 11 Sep 2024 17:44:44 +0800
+Subject: [PATCH] net: enetc: Use IRQF_NO_AUTOEN flag in request_irq()
+
+[ Upstream commit 799a9225997799f7b1b579bc50a93b78b4fb2a01 ]
+
+disable_irq() after request_irq() still has a time gap in which
+interrupts can come. request_irq() with IRQF_NO_AUTOEN flag will
+disable IRQ auto-enable when request IRQ.
+
+Fixes: bbb96dc7fa1a ("enetc: Factor out the traffic start/stop procedures")
+Signed-off-by: Jinjie Ruan <ruanjinjie@huawei.com>
+Link: https://patch.msgid.link/20240911094445.1922476-3-ruanjinjie@huawei.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+
+Upstream-Status: Backport
+---
+ drivers/net/ethernet/freescale/enetc/enetc.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/net/ethernet/freescale/enetc/enetc.c b/drivers/net/ethernet/freescale/enetc/enetc.c
+index 0f5a4ec505ddbf..18e3a9cd4fc017 100644
+--- a/drivers/net/ethernet/freescale/enetc/enetc.c
++++ b/drivers/net/ethernet/freescale/enetc/enetc.c
+@@ -2305,12 +2305,11 @@ static int enetc_setup_irqs(struct enetc_ndev_priv *priv)
+ 
+ 		snprintf(v->name, sizeof(v->name), "%s-rxtx%d",
+ 			 priv->ndev->name, i);
+-		err = request_irq(irq, enetc_msix, 0, v->name, v);
++		err = request_irq(irq, enetc_msix, IRQF_NO_AUTOEN, v->name, v);
+ 		if (err) {
+ 			dev_err(priv->dev, "request_irq() failed!\n");
+ 			goto irq_err;
+ 		}
+-		disable_irq(irq);
+ 
+ 		v->tbier_base = hw->reg + ENETC_BDR(TX, 0, ENETC_TBIER);
+ 		v->rbier = hw->reg + ENETC_BDR(RX, i, ENETC_RBIER);
+-- 
+2.43.2
+

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.6.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.6.bb
@@ -21,6 +21,8 @@ SRC_URI += " \
     file://0003-FIO-toup-gpu-drm-cadence-select-hdmi-helper.patch \
     file://0004-FIO-toup-media-imx8-select-v4l2_-for-mxc-mipi-csi2_y.patch \
     file://0001-FIO-toimx-firmware-se_fw-remove-info_list-from-ro-section.patch \
+    file://0001-net-enetc-Use-IRQF_NO_AUTOEN-flag-in-request_irq.patch \
+    file://0001-clk-imx-imx6ul-fix-default-parent-for-enet-_ref_sel.patch \
 "
 
 SRC_URI:append:imx8mp-lpddr4-evk = " \


### PR DESCRIPTION
Backport kernel fixes required to fix the broken ethernet support on imx6ul/imx6ull devices.