### PR TITLE
base: optee-os-fio: bump to 88da158

### DIFF
--- a/meta-lmp-base/recipes-security/optee/optee-os-fio_4.4.0.bb
+++ b/meta-lmp-base/recipes-security/optee/optee-os-fio_4.4.0.bb
@@ -1,4 +1,4 @@
 require optee-os-fio.inc
 
-SRCREV = "acfcdb74ce84219ff0a2faf7cd9f5a6fd1c0ac6c"
+SRCREV = "88da15801ac113be49ec6ad2e28f4019846402d7"
 SRCBRANCH = "4.4.0+fio"


### PR DESCRIPTION
Relevant changes:
- 88da15801 [FIO from tree] drivers: caam: check only format
- a8d4fd26f [FIO from tree] drivers: caam: Update comments in RSA

Fixes RSA decrypt regresion detected in CI
https://github.com/OP-TEE/optee_os/issues/7362