### PR TITLE
base: rc: composectl: Bump version 862e6be

### DIFF
--- a/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
+++ b/meta-lmp-base/recipes-containers/composeapp/composectl_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=504a5c2455c8bb2fc5b76678
 GO_IMPORT = "github.com/foundriesio/composeapp"
 GO_IMPORT_PROTO ?= "https"
 SRCBRANCH = "v95"
-SRCREV = "b06f6d1194cb67398f5ad7c009f32eb0362dc3ab"
+SRCREV = "862e6bee1d6596a80855c43c19f0655870e2d505"
 SRC_URI = "git://${GO_IMPORT};protocol=${GO_IMPORT_PROTO};branch=${SRCBRANCH}"
 UPSTREAM_CHECK_COMMITS = "1"
 


### PR DESCRIPTION
Relevant changes:
- 862e6be ps: Don't print info about ext images if json output