### PR TITLE
Revert "base: lmp-staging: add vendor subdir for kernel dts if needed"

### DIFF
--- a/meta-lmp-base/classes/lmp-staging.bbclass
+++ b/meta-lmp-base/classes/lmp-staging.bbclass
@@ -9,15 +9,8 @@ LMPSTAGING_INHERIT_KERNEL_MODSIGN = ""
 
 LMPSTAGING_LOCK_TO_AVOID_OOM = "clang-native rust-native rust-llvm-native"
 
-LMPSTAGING_KERN_ADD_ST_SUBDIR = ""
-
 python __anonymous() {
     pn = d.getVar('PN')
-
-    if pn == "linux-lmp" or pn == "linux-lmp-rt":
-        (major_ver, minor_ver, rest) = d.getVar('LINUX_VERSION').split(".")
-        if int(major_ver) > 6 or (int(major_ver) == 6 and int(minor_ver) >= 4):
-            d.setVar('LMPSTAGING_KERN_ADD_ST_SUBDIR',  'st/')
 
     if bb.data.inherits_class('module', d):
         d.appendVar('DEPENDS', ' virtual/kernel')


### PR DESCRIPTION
This reverts commit e5490f56ac39823b09b6e59dbd1f3f0363a5cd20.

STM32 was moved to a partner layer, drop leftover LMPSTAGING_KERN_ADD_ST_SUBDIR