### PR TITLE
bsp: lmp-machine-custom: intel-corei7-64: make the provision only on sota

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -145,7 +145,7 @@ WKS_FILE_DEPENDS:append:intel-corei7-64 = " ${INITRD_IMAGE_LIVE} efitools"
 WKS_FILE_DEPENDS_BOOTLOADERS:remove:intel-corei7-64 = "grub-efi"
 ## wic-based installer requires image to be available via IMAGE_BOOT_FILES
 IMAGE_BOOT_FILES:intel-corei7-64 = "${@bb.utils.contains('WKS_FILE', 'image-efi-installer.wks.in', 'systemd-bootx64.efi;EFI/BOOT/bootx64.efi systemd-bootx64.efi;EFI/systemd/systemd-bootx64.efi ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ota-ext4;rootfs.img', '', d)}"
-IMAGE_EFI_BOOT_FILES:append:intel-corei7-64 = "${@bb.utils.contains('UEFI_SIGN_ENABLE', '1', ' lockdown.conf;loader/entries/doprovision_lock+0.conf unlock.conf;loader/entries/doprovision_unlock+0.conf LockDown.efi UnLock-signed.efi ${@make_efi_cer_boot_files(d)} ', '', d)}"
+IMAGE_EFI_BOOT_FILES:append:intel-corei7-64:sota = "${@bb.utils.contains('UEFI_SIGN_ENABLE', '1', ' lockdown.conf;loader/entries/doprovision_lock+0.conf unlock.conf;loader/entries/doprovision_unlock+0.conf LockDown.efi UnLock-signed.efi ${@make_efi_cer_boot_files(d)} ', '', d)}"
 
 # Common for iMX targets
 ## Prefer IMX_DEFAULT_BSP=nxp as mainline removes every common machine override


### PR DESCRIPTION
This breaks the do_image_wic on the lmp-base distro variant

```
| + BUILDDIR=/lmp/build-lmp-base-intel-corei7-64-scarthgap PSEUDO_UNLOAD=1 wic create /lmp/build-lmp-base-intel-corei7-64-scarthgap/tmp-lmp_base/work/intel_corei7_64-lmp-linux/lmp-base-console-image/1.0/systemd-bootdisk-microcode.wks --vars /lmp/build-lmp-base-intel-corei7-64-scarthgap/tmp-lmp_base/sysroots/intel-corei7-64/imgdata/ -e lmp-base-console-image -o /lmp/build-lmp-base-intel-corei7-64-scarthgap/tmp-lmp_base/work/intel_corei7_64-lmp-linux/lmp-base-console-image/1.0/build-wic/ -w /lmp/build-lmp-base-intel-corei7-64-scarthgap/tmp-lmp_base/work/intel_corei7_64-lmp-linux/lmp-base-console-image/1.0/tmp-wic |
| INFO: Creating image(s)...
|
| ERROR: _exec_cmd: install -m 0644 -D /lmp/build-lmp-base-intel-corei7-64-scarthgap/deploy/images/intel-corei7-64/0.conf /lmp/build-lmp-base-intel-corei7-64-scarthgap/tmp-lmp_base/work/intel_corei7_64-lmp-linux/lmp-base-console-image/1.0/tmp-wic/hdd/boot/0.conf returned '1' instead of 0 | output: install: cannot stat '/lmp/build-lmp-base-intel-corei7-64-scarthgap/deploy/images/intel-corei7-64/0.conf': No such file or directory
```