### PR TITLE
base: rrdtool: remove graph via PACKAGECONFIG

### DIFF
--- a/meta-lmp-base/recipes-extended/rrdtool/rrdtool_%.bbappend
+++ b/meta-lmp-base/recipes-extended/rrdtool/rrdtool_%.bbappend
@@ -1,8 +1,5 @@
 # Disable rrd_graph as it requires cairo and pango
-DEPENDS:remove = "cairo pango"
-EXTRA_OECONF += " \
-    --disable-rrd_graph \
-"
+PACKAGECONFIG:remove = "graph"
 
 # Fix perl install rdepends and path
 RDEPENDS:${PN}:remove = "perl"


### PR DESCRIPTION
Graph removal is now done via PACKAGECONFIG, update our override to reflect the changes from meta-oe.