### PR TITLE
base: cve-lmp-extra-exclusions: drop CVE-2022-47085

### DIFF
--- a/meta-lmp-base/conf/distro/include/cve-lmp-extra-exclusions.inc
+++ b/meta-lmp-base/conf/distro/include/cve-lmp-extra-exclusions.inc
@@ -3,7 +3,3 @@
 #
 # Issues that are also not relevant to LmP (code not used by LmP) can also be
 # included here.
-
-# ostree https://nvd.nist.gov/vuln/detail/CVE-2022-47085
-# rust-bindings not used in LmP
-CVE_CHECK_IGNORE += "CVE-2022-47085"


### PR DESCRIPTION
ostree was updated to 2024