### PR TITLE
u-boot-fio_imx: fix uuu_bootloader_tag class inherit

### DIFF
--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2022.04.bb
@@ -1,9 +1,10 @@
 require u-boot-fio-common.inc
 
-UUU_BOOTLOADER = "uuu_bootloader_tag"
-UUU_BOOTLOADER:mx8-generic-bsp = ""
-UUU_BOOTLOADER:mx9-generic-bsp = ""
-inherit_defer ${UUU_BOOTLOADER}
+UUU_BOOTLOADER_TAG = ""
+UUU_BOOTLOADER_TAG:imx-generic-bsp = "uuu_bootloader_tag"
+UUU_BOOTLOADER_TAG:mx8-generic-bsp = ""
+UUU_BOOTLOADER_TAG:mx9-generic-bsp = ""
+inherit_defer ${UUU_BOOTLOADER_TAG}
 
 SRCREV = "605d0aa5c016915058c7b19051f76d592e103b32"
 SRCBRANCH = "2022.04+lf-6.1.1-1.0.0-fio"

--- a/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2024.04.bb
+++ b/meta-lmp-base/recipes-bsp/u-boot/u-boot-fio_imx-2024.04.bb
@@ -1,9 +1,10 @@
 require u-boot-fio-common.inc
 
-UUU_BOOTLOADER = "uuu_bootloader_tag"
-UUU_BOOTLOADER:mx8-generic-bsp = ""
-UUU_BOOTLOADER:mx9-generic-bsp = ""
-inherit_defer ${UUU_BOOTLOADER}
+UUU_BOOTLOADER_TAG = ""
+UUU_BOOTLOADER_TAG:imx-generic-bsp = "uuu_bootloader_tag"
+UUU_BOOTLOADER_TAG:mx8-generic-bsp = ""
+UUU_BOOTLOADER_TAG:mx9-generic-bsp = ""
+inherit_defer ${UUU_BOOTLOADER_TAG}
 
 SRCREV = "adbe53791d8f3cc2d7ecf2a3f308494d561def9e"
 SRCBRANCH = "2024.04+lf-6.6.52-2.2.0-fio"


### PR DESCRIPTION
uuu_bootloader_tag bbclass is only available when meta-freescale is also enabled in LmP, causing a parser error when not added by default.