### PR TITLE
bsp: intel-corei7-64: Remove linux-firmware from RRECOMMENDS

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -132,6 +132,7 @@ WKS_FILE_DEPENDS:append:generic-arm64 = " ${INITRD_IMAGE_LIVE}"
 IMAGE_BOOT_FILES:generic-arm64 = "${@bb.utils.contains('WKS_FILE', 'image-efi-installer-grub.wks.in', 'grub-efi-bootaa64.efi;EFI/BOOT/bootaa64.efi ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}${IMAGE_NAME_SUFFIX}.ota-ext4;rootfs.img', '', d)}"
 
 # Intel
+MACHINE_EXTRA_RRECOMMENDS:remove:intel-corei7-64 = "linux-firmware"
 MACHINE_FEATURES:append:intel-corei7-64 = " tpm2"
 UEFI_SIGN_ENABLE:intel-corei7-64 = "1"
 OSTREE_BOOTLOADER:intel-corei7-64 ?= "none"


### PR DESCRIPTION
It remove the complete package linux-firware which is installed following the MACHINE_EXTRA_RRECOMMENDS recommendation from meta-intel.

Any sub package from linux-firware can still be installed.

It reduces the final image size by not installing additional extra packages.

-- 
It is tested by checking for `linux-firmware-*` packages from `buildhistory/iamges/intel_corei7-64/glibc/lmp-base-console-image/installed-package-sizes.txt`