### PR TITLE
[scarthgap] base: kmeta-linux-lmp-6.6.y: bump to a00a749e

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.6.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.6.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v6.6.y"
-KERNEL_META_COMMIT ?= "b968a4e3dfade014a8732c733de6e344bf040bfd"
+KERNEL_META_COMMIT ?= "a00a749eca82ef7363500a9ceccebab25dbcabf5"


### PR DESCRIPTION
Relevant changes:
- a00a749e bsp: raspberrypi3: config updates for 6.6

(cherry picked from commit 5a3240d697f87b15365def71cc974102fc77e6a3)