### PR TITLE
base: kmeta-linux-lmp-6.6.y: bump to 6d8bf98

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.6.y.inc
+++ b/meta-lmp-base/recipes-kernel/linux/kmeta-linux-lmp-6.6.y.inc
@@ -1,4 +1,4 @@
 KERNEL_META_REPO ?= "git://github.com/foundriesio/lmp-kernel-cache.git"
 KERNEL_META_REPO_PROTOCOL ?= "https"
 KERNEL_META_BRANCH ?= "linux-v6.6.y"
-KERNEL_META_COMMIT ?= "a00a749eca82ef7363500a9ceccebab25dbcabf5"
+KERNEL_META_COMMIT ?= "6d8bf98d3e25e89523d17ea8c84446d663fcdd2c"


### PR DESCRIPTION
Relevant changes:
- 6d8bf98 features/debug/debug-kernel: disable CONFIG_DEBUG_INFO


(cherry picked from commit b29334b86d3bb62b531f9293a5c9c61de692cf71)