### PR TITLE
bsp: linux-lmp.inc: makes it mandatory

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx.inc
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx.inc
@@ -12,4 +12,4 @@ SRC_URI = "${KERNEL_REPO};protocol=${KERNEL_REPO_PROTOCOL};branch=${KERNEL_BRANC
 
 KMETA = "kernel-meta"
 
-include recipes-kernel/linux/linux-lmp.inc
+require recipes-kernel/linux/linux-lmp.inc

--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-rpi_git.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-rpi_git.bb
@@ -13,6 +13,6 @@ SRC_URI = "git://github.com/raspberrypi/linux.git;protocol=https;branch=${KBRANC
 
 KMETA = "kernel-meta"
 
-include recipes-kernel/linux/linux-lmp.inc
+require recipes-kernel/linux/linux-lmp.inc
 
 KERNEL_DTC_FLAGS += "-@ -H epapr"


### PR DESCRIPTION
On the lmp base layer the linux-lmp.inc already uses the 'require' so the build fail when the file not found.
The same should also happen in the lmp bsp layer.