### PR TITLE
bsp: linux-lmp-fslc-imx-rt: bump to latest commit

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx-rt_6.6.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx-rt_6.6.bb
@@ -7,5 +7,5 @@ LINUX_VERSION = "6.6.36"
 KERNEL_BRANCH = "linux_6.6.36"
 
 KERNEL_REPO = "git://github.com/nxp-real-time-edge-sw/real-time-edge-linux.git"
-SRCREV_machine = "e7369ce0b24dbacba728e7f7ee29016d4759a7ce"
+SRCREV_machine = "f03af81d60b7ae14e03fafa8f4c4289c30a73f93"
 LINUX_KERNEL_TYPE = "preempt-rt"


### PR DESCRIPTION
Relevant changes:
- f03af81d60b7 net: mscc: ocelot: be resilient to loss of PTP packets during transmission
- 72bc664feb34 net: felix: fix gcl configuration lost when clock adjust