### PR TITLE
sysctl-hang-crash-helper: use UNPACKDIR and drop PACKAGE_ARCH

### DIFF
--- a/meta-lmp-base/recipes-support/sysctl-hang-crash-helper/sysctl-hang-crash-helper_0.1.bb
+++ b/meta-lmp-base/recipes-support/sysctl-hang-crash-helper/sysctl-hang-crash-helper_0.1.bb
@@ -8,11 +8,9 @@ SRC_URI = "file://sysctl-panic.conf"
 
 S = "${UNPACKDIR}"
 
-PACKAGE_ARCH = "${MACHINE_ARCH}"
-
 do_install () {
 	install -d ${D}${libdir}/sysctl.d
-	install -m 0644 ${WORKDIR}/sysctl-panic.conf ${D}${libdir}/sysctl.d/60-panic.conf
+	install -m 0644 ${UNPACKDIR}/sysctl-panic.conf ${D}${libdir}/sysctl.d/60-panic.conf
 }
 
 FILES:${PN} += "${libdir}/sysctl.d/60-panic.conf"


### PR DESCRIPTION
Use UNPACKDIR in do_install and drop PACKAGE_ARCH since this is expected to be all (configuration file).