### PR TITLE
base: lmp: drop custom toolchain options, switch to gcc / default

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -95,18 +95,6 @@ INHERIT += "lmp-signing"
 INHERIT += "lmp-staging"
 INHERIT += "uninative"
 
-# Clang toolchain
-TOOLCHAIN ?= "clang"
-RUNTIME = "llvm"
-# use llvm provided by clang
-# https://github.com/kraj/meta-clang/pull/799/files
-PREFERRED_PROVIDER_llvm = "clang"
-PREFERRED_PROVIDER_llvm-native = "clang-native"
-PREFERRED_PROVIDER_nativesdk-llvm = "nativesdk-clang"
-PROVIDES:pn-clang = "llvm"
-PROVIDES:pn-clang-native = "llvm-native"
-PROVIDES:pn-nativesdk-clang = "nativesdk-llvm"
-
 PREMIRRORS += "\
      git://.*/.* https://storage.googleapis.com/lmp-cache/downloads/ \n \
      ftp://.*/.* https://storage.googleapis.com/lmp-cache/downloads/ \n \


### PR DESCRIPTION
Switch back to the default oe-core toolchain (gcc) as clang still requires a substantial amount of fixes when supporting third party BSP vendors.