### PR TITLE
bsp: linux-lmp-fslc-imx: update to L6.6.52_2.2.1

### DIFF
--- a/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.6.bb
+++ b/meta-lmp-bsp/recipes-kernel/linux/linux-lmp-fslc-imx_6.6.bb
@@ -11,7 +11,7 @@ include recipes-kernel/linux/kmeta-linux-lmp-6.6.y.inc
 LINUX_VERSION ?= "6.6.52"
 KERNEL_BRANCH ?= "6.6-2.2.x-imx"
 
-SRCREV_machine = "e0f9e2afd4cff3f02d71891244b4aa5899dfc786"
+SRCREV_machine = "90192c5d29cb650fd7f7dd9094af14eefb38837d"
 
 SRC_URI += " \
     file://0004-FIO-toup-hwrng-optee-support-generic-crypto.patch \


### PR DESCRIPTION
Align kernel revision with L6.6.52_2.2.1.

Relevant changes:
- 90192c5d29cb LF-15731: mxc: vpu: wave6: no copyright in one header file
- 1ed1a4c7d1c7 LF-15735: drivers: crypto: caam: fix mx8ulp caam probe
- 4ca54a8f6c7b LF-15136 PCI: imx6: Force CLKREQ override active low for i.MX95 PCIe
- 2a072ac6cd41 LF-14084 arm64: dts: imx95-15x15-evk: Keep m2 regulator always on
- 051c87ef3c92 LF-14933: drivers: tee: crypto: remove limitation in buf sz
- d415b45bdca0 LF-15637: drivers: firmware: imx: se: fix ELE Get FW version API
- 91e187c98293 MGS-7915 gpu: Add shader and tiler utilization
- 6a6a1513dfd6 MGS-7869 gpu: use u64 for dvfs_utilization output
- 451966cce424 MGS-8128 gpu: fix page-isolation/page-free race
- 810d42edf36b MGS-8080 gpu: keep flushing MMU addr util no user
- 1b7dfb97b139 MGS-8080 gpu: Unmap the USER_IO pages
- 227a52dc69d7 MGS-8080 gpu: Unmap the USER_IO pages
- b1d8a6dd8bef LF-4656-1 gpu: disable systrace by default
- a3040a1a76a2 MGS-7751 gpu: Remove UAF during ctx termination
- 7fcf60852717 LF-14837: Unregister ELE TRNG
- 296c64f09692 LF-15348: firmware: imx: Add ioctl flag
- 19ce6042dd03 net: phy: clear phydev->devlink when the link is deleted
- 51b1d708b113 LF-15144-4: dts: mx95: updated node properties
- 2df35457d9cb LF-15144-3: dts: mx93: updated node properties
- 7c0da21907ac LF-15144-2: dts: mx91: updated node properties
- c2d9443609f2 LF-15144-1: dts: mx8ulp: updated node properties
- a811eadb2234 LF-15144: dts: i.MX8DXL, QXP: updated node properties
- be13b6c87d75 drivers: nvmem: imx: ports ocotp driver to updated se kernel driver.
- 1cb1ded9c9de i.MX93: drivers: soc: imx: lpm: ports to updated se kernel driver
- 89391c3b3dc1 LF-14885-2: drivers: firmware: imx: se: enable dual FW support
- 840627037381 LF-14885: drivers: firmware: imx: se: add ele-get-fw-version
- 934c85903f5b LF-15060: drivers: firmware: imx: se: Enables support of i.MX95 rev B0
- 9d86c4874b9d LF-14029-1: drivers: firmware: imx: new api v2x debug dump
- d97abaf3e7e5 LF-14029: drivers: firmware: imx: v2x suspend resume
- af7dddacedc3 LF-14060-1: drivers: firmware: imx: msg-seq flow applied
- 9773681cdd48 LF-14060: drivers: firmware: imx: enforce msg-seq flow
- 88996dad6b9a LF-13910-9: drivers: firmware: imx: add IOCTL for performance benchmarking
- 4faa6aeb8bc3 LF-13910-8: drivers: firmware: imx: add support for i.MX8DXL/QXP/QM
- 9e7d5cc9f66d LF-13910-7: drivers: firmware: imx: add support for i.MX95 soc
- b47a70ecb15d LF-13910-6: drivers: firmware: imx: export se-api(s) in se_api.h
- c44540c6a870 LF-13910-5: drivers: firmware: imx: add support for imx93 soc
- 2c2034c656bb LF-13910-4: drivers: firmware: imx: se debug dump log file
- ad497d1c5b36 LF-13910-3: firmware: imx: additional changes to the upstream driver.
- 9dfd27b6b2e3 LF-13910-2: firmware: imx: add miscdev
- a21e6e64e3a1 LF-13910-1: firmware: imx: add driver for NXP EdgeLock Enclave
- bdeff7cd5639 LF-13910: remove base driver for secure-enclave
- ab72b4936fe3 Revert "LF-14286-2: mxc: vpu: wave6: remove the second parameter in __assign_str()"
- f7e7a3f15102 LF-15138-2 nvmem: imx-ocotp-fsb-s400: fix the bug caused by not getting the se-fw2 device
- 41adc16f987e LF-15138-1 nvmem: imx95: update imx-ocotp-fsb-s400.c for i.MX95
- d6b4952355f1 LF-15259 drm/imx: dpu95: Fix maximum FrameGen display clock frequency
- 313264178368 LF-14995-3 arm64: dts: imx95: add some USB3 PHY tuning properties
- 48a046dcbf3d LF-15173-3 arm64: dts: imx8mp: fix USB3 PHY tuning parameters
- 382c67812e39 LF-14995-2 phy: fsl-imx8mq-usb: add i.MX95 tuning support
- 118c0dcb7656 LF-15173-2 phy: fsl-imx8mq-usb: fix phy_tx_vboost_level_from_property()
- ac2107351a85 LF-14995-1 dt-bindings: phy: imx8mq-usb: add imx95 tuning support
- 9437748c7866 LF-15173-1 dt-bindings: phy: imx8mq-usb: fix fsl,phy-tx-vboost-level-microvolt property
- af7c47e57857 dt-bindings: phy: imx8mq-usb: add compatible "fsl,imx95-usb-phy"
- 3b53d8b471a3 LF-15180: media: imx-jpeg: Account for data_offset when getting image address
- 1e18a7646b6e LF-15186-3 dts: remove gpumix_blk_ctrl register
- 1045958fd47d LF-15186-2 gpu: remove IMX_GPU_BLK_CTRL
- 55018aa9dd8d LF-15186-1 gpu: remove gpumix block ctrl
- 1ab4f3d81e85 LF-15170 drm/imx: dpu95-crtc: Queue state event early for page flip
- 53f47a4cc19e LF-15139 drm/imx: dpu95: Add VScaler support for i.MX95 B0 SoC
- f9e55df6e071 LF-15176 drm/imx: dpu95-plane: Add scaling filter property
- 2bf7775093bb LF-14991 arm64: dts: imx95-19x19: Add SMMU support for NETC
- a618e4b6cb29 LF-15009 arm64: dts: imx95: update the DTS files for TJA1103 RMII mode
- 8ae0b840798e usb: dwc3: imx8mp: add snps,tx-max-burst property to limit tx maxburst on i.MX95 A1
- c5e81393548b LF-15002 Revert "LF-11008 arm64: dts: imx95: add snps,tx-max-burst property to workaround USB3.0 host controller EP OUT issue"
- ea1ccc106e4e MGS-8182 arm64: dts: update the gpu clkid
- 55c1e61714bb LF-14286-2: mxc: vpu: wave6: remove the second parameter in __assign_str()
- a792be88ba04 MA-23263: mxc: vpu: wave6: Allow 2x2 cropping size for the encoder.
- 8e8c10515d93 LF-14462: mxc: vpu: wave6: Add 'identical size ranges' feature for vpu encoder
- b33d9ef0f073 MA-23237-2: mxc: vpu: wave6: Support decoding size up to 4096x4096
- d60f271ccc25 MA-23268-3: mxc: vpu: wave6: Handle colorspace change
- 36922ae53f53 MA-23268-2: media: docs: dev-decoder: Trigger dynamic source change for colorspace
- 7b2fbfc9f451 MA-23268-1: media: v4l: dev-decoder: Add source change V4L2_EVENT_SRC_CH_COLORSPACE
- e88de905f538 CARPL-471: mxc: vpu: wave6: Guarantee vpu power state in requiring work
- 31699a5f0b3c CARPL-467-2: mxc: vpu: wave6: Preallocate some work buffer
- ec0d4d646892 CARPL-467-1: mxc: vpu: wave6: Add delay in read_poll_timeout
- 25da9355baa8 LF-14286: mxc: vpu: wave6: update to driver v1.3.11
- 6aaa52e44842 LF-15094 clocksource: timer-imx-sysctr: Restrict the quirk for i.MX95 A0/A1.
- 1e4af140c003 LF-15093 imx95: Set iommus for SDHC
- 8835cd9bec02 LF-14924 thermal: imx91: change the register DATA0 read value type
- 316c68654809 LF-14753 thermal: imx91: change continuous mode into periodic one-shot mode
- 86aad7676dde LF-14922 net: enetc: Fix null pointer accces in fsl-netc-prb-ierb driver probe
- d8f7322db0fa nvmem: imx-ocotp-fsb-s400: BUG: Fix the word count
- d67b11a2717e LF-13936 PCI: imx6: Correct PME_TURN_OFF kick off method on i.MX95
- 6cfe1695438d LF-14048 gpio: pca953x: do not enable regmap cache when there is no regulator
- 6f6bc10c9cec LF-14498: arm64: dts: imx91: Correct ENET1_TD3 and I2C2_SCL pad macro name