### PR TITLE
base: linux-lmp: 6.6: bump to v6.6.102

### DIFF
--- a/meta-lmp-base/recipes-kernel/linux/linux-lmp_6.6.bb
+++ b/meta-lmp-base/recipes-kernel/linux/linux-lmp_6.6.bb
@@ -1,8 +1,8 @@
 include kmeta-linux-lmp-6.6.y.inc
 
-LINUX_VERSION ?= "6.6.89"
+LINUX_VERSION ?= "6.6.102"
 KBRANCH = "linux-6.6.y"
-SRCREV_machine = "ff592c7d753fee29daece68b7d8f99fea80e0899"
+SRCREV_machine = "41c95641970d32c0269d7855f33c1ca06d0c18ac"
 SRCREV_meta = "${KERNEL_META_COMMIT}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"


### PR DESCRIPTION
(cherry picked from commit e1dedcfff03b4562f524ca620fb1a5ba1b9b489e)