### PR TITLE
Backporting switching generic arm64 to systemd-boot

### DIFF
--- a/meta-lmp-base/wic/image-efi-installer-grub.wks.in
+++ b/meta-lmp-base/wic/image-efi-installer-grub.wks.in
@@ -1,8 +1,0 @@
-# create an EFI compatible installer disk image
-# populate content to install using IMAGE_BOOT_FILES (e.g. rootfs)
-
-part /boot --source bootimg-efi --sourceparams="loader=${EFI_PROVIDER},title=Install ${DISTRO_NAME} (${DISTRO_VERSION}),label=install-efi,initrd=${INITRD_IMAGE_LIVE}-${MACHINE}.${INITRAMFS_FSTYPES}" --ondisk sda --label install --active --align 1024 --use-uuid --size 100
-
-part / --source bootimg-partition --ondisk sda --fstype=ext4 --label image --use-uuid --align 1024
-
-bootloader --ptable gpt --timeout=5

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -123,13 +123,19 @@ QB_DRIVE_TYPE:qemuarm = "/dev/vdb"
 QB_OPT_APPEND:qemuarm = "-no-acpi -bios ${DEPLOY_DIR_IMAGE}/u-boot.bin -d unimp"
 
 # ARM64 Generic (SystemReady)
-OSTREE_BOOTLOADER:generic-arm64 ?= "grub"
+OSTREE_BOOTLOADER:generic-arm64 ?= "none"
+OSTREE_KERNEL_ARGS:generic-arm64 ?= "console=ttyAMA0,115200 ${OSTREE_KERNEL_ARGS_COMMON}"
 MACHINE_FEATURES:append:generic-arm64 = " acpi pci usbhost tpm2"
-EFI_PROVIDER:generic-arm64 ?= "grub-efi"
-WKS_FILE:generic-arm64:sota ?= "image-efi-installer-grub.wks.in"
+UEFI_SIGN_ENABLE:generic-arm64 = "1"
+EFI_PROVIDER:generic-arm64 ?= "systemd-boot"
+OSTREE_SPLIT_BOOT:generic-arm64 = "1"
+OSTREE_LOADER_LINK:generic-arm64 = "0"
+KERNEL_CLASSES:generic-arm64 = " kernel-lmp-efi "
+WKS_FILE:generic-arm64:sota ?= "efidisk-sota.wks.in"
 WKS_FILE_DEPENDS:append:generic-arm64 = " ${INITRD_IMAGE_LIVE}"
 ## wic-based installer requires image to be available via IMAGE_BOOT_FILES
-IMAGE_BOOT_FILES:generic-arm64 = "${@bb.utils.contains('WKS_FILE', 'image-efi-installer-grub.wks.in', 'grub-efi-bootaa64.efi;EFI/BOOT/bootaa64.efi ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}${IMAGE_NAME_SUFFIX}.ota-ext4;rootfs.img', '', d)}"
+IMAGE_BOOT_FILES:generic-arm64 = "${@bb.utils.contains('WKS_FILE', 'image-efi-installer.wks.in', 'systemd-bootaa64.efi;EFI/BOOT/bootaa64.efi systemd-bootaa64.efi;EFI/systemd/systemd-bootaa64.efi ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ota-ext4;rootfs.img', '', d)}"
+IMAGE_EFI_BOOT_FILES:append:generic-arm64 = "${@bb.utils.contains('UEFI_SIGN_ENABLE', '1', '${@make_efi_cer_boot_files(d)} ', '', d)}"
 
 # Intel
 MACHINE_EXTRA_RRECOMMENDS:remove:intel-corei7-64 = "linux-firmware"

--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -124,7 +124,7 @@ QB_OPT_APPEND:qemuarm = "-no-acpi -bios ${DEPLOY_DIR_IMAGE}/u-boot.bin -d unimp"
 
 # ARM64 Generic (SystemReady)
 OSTREE_BOOTLOADER:generic-arm64 ?= "grub"
-MACHINE_FEATURES:append:generic-arm64 = " acpi pci usbhost"
+MACHINE_FEATURES:append:generic-arm64 = " acpi pci usbhost tpm2"
 EFI_PROVIDER:generic-arm64 ?= "grub-efi"
 WKS_FILE:generic-arm64:sota ?= "image-efi-installer-grub.wks.in"
 WKS_FILE_DEPENDS:append:generic-arm64 = " ${INITRD_IMAGE_LIVE}"


### PR DESCRIPTION
Grub2 is not supported anymore by is.