### PR TITLE
bsp: beaglebone-yocto: drop bt / wl firmware and related scripts

### DIFF
--- a/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
+++ b/meta-lmp-bsp/conf/machine/include/lmp-machine-custom.inc
@@ -11,7 +11,6 @@ DTB_FILES:append:beaglebone-yocto = " am335x-boneblack-wireless.dtb"
 IMAGE_BOOT_FILES:beaglebone-yocto = "u-boot.img MLO boot.itb"
 KERNEL_IMAGETYPE:beaglebone-yocto = "fitImage"
 KERNEL_CLASSES:beaglebone-yocto = " kernel-lmp-fitimage "
-MACHINE_EXTRA_RRECOMMENDS:append:beaglebone-yocto = " bt-fw wl18xx-calibrator wl18xx-target-scripts wl18xx-fw wlconf"
 UBOOT_ENTRYPOINT:beaglebone-yocto = "0x80008000"
 UBOOT_LOADADDRESS:beaglebone-yocto = "0x80008000"
 ## beaglebone-yocto.conf appends kernel-image-zimage by default

--- a/meta-lmp-bsp/dynamic-layers/meta-ti-extras/recipes-connectivity/wlconf/wlconf_8.7.3.bbappend
+++ b/meta-lmp-bsp/dynamic-layers/meta-ti-extras/recipes-connectivity/wlconf/wlconf_8.7.3.bbappend
@@ -1,8 +1,0 @@
-SRC_URI:append:beaglebone-yocto = " \
-    https://github.com/beagleboard/beaglebone-black-wireless/raw/d9135000a223228158d92fd2e3f00e495f642fee/firmware/wl18xx-conf.bin;name=wl18xx-conf-beagle \
-"
-SRC_URI[wl18xx-conf-beagle.sha256sum] = "e68e9a37995ab782faa41971704f24fd597d5abf16c47463708e90f8f080d335"
-
-do_install:append:beaglebone-yocto() {
-    install -m 0644 ${WORKDIR}/wl18xx-conf.bin ${D}${nonarch_base_libdir}/firmware/ti-connectivity/
-}


### PR DESCRIPTION
Drop bluetooth and wifi firmware and scripts which are provided by meta-ti, as it is now removed from the standard manifest list.