### PR TITLE
bsp: fixup imx drop

### DIFF
--- a/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio_%.bbappend
+++ b/meta-lmp-bsp/recipes-bsp/u-boot/u-boot-fio_%.bbappend
@@ -1,3 +1,1 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-
-require u-boot-fio-bsp-common.inc

--- a/meta-lmp-bsp/recipes-security/optee/optee-os-fio-bsp.inc
+++ b/meta-lmp-bsp/recipes-security/optee/optee-os-fio-bsp.inc
@@ -1,7 +1,6 @@
 OPTEEMACHINE:qemuarm64 = "vexpress-qemu_armv8a"
 
 # Machine Settings
-"
 EXTRA_OEMAKE:append:qemuarm64 = " \
     CFG_RPMB_FS=y CFG_RPMB_WRITE_KEY=y \
 "


### PR DESCRIPTION
Fixup the IMX drop in last commit.
- The u-boot-fio-bsp-common.inc was removed
- Remove extra "