### PR TITLE
base: compose-apps-early-start: avoid composectl call with empty apps list

### DIFF
--- a/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start
+++ b/meta-lmp-base/recipes-support/compose-apps-early-start/compose-apps-early-start/compose-apps-early-start
@@ -57,7 +57,7 @@ start_restorable_apps() {
 				start_compose_app ${app}
 			done
 		else
-			composectl run --apps "${shortlist}"
+			echo "No apps to start"
 		fi
 	else
 		composectl run --apps "${shortlist}"


### PR DESCRIPTION
In start_restorable_apps(), when shortlist is empty (all default apps are already present locally) and the compose-apps directory is also empty, the code fell into an else branch and executed:
```
composectl run --apps ""
```
      
Since shortlist is empty, there are no apps to restore. Calling composectl with an empty --apps argument is pointless and may trigger an error that fails the service.

Replace this branch with a log message to make the no-op explicit.
