### PR TITLE
base: opensc: drop bbappend

### DIFF
--- a/meta-lmp-base/recipes-support/opensc/opensc_%.bbappend
+++ b/meta-lmp-base/recipes-support/opensc/opensc_%.bbappend
@@ -1,2 +1,0 @@
-# There is no runtime dependency on readline if not built with support for it
-RDEPENDS:${PN}:remove = "readline"


### PR DESCRIPTION
This is already fixed uptreamy

opensc: Add 'readline' PACKAGECONFIG option
https://git.openembedded.org/meta-openembedded/commit/?id=c066a6ff83cf0170a3d8770024ad45ff1c1eaec9