### PR TITLE
base: Bump distro version to 5.0.17

### DIFF
--- a/meta-lmp-base/conf/distro/include/lmp.inc
+++ b/meta-lmp-base/conf/distro/include/lmp.inc
@@ -1,4 +1,4 @@
-DISTRO_VERSION = "5.0.15"
+DISTRO_VERSION = "5.0.17"
 
 # These default to 'oecore' and 'nodistro'
 SDK_NAME_PREFIX = "${DISTRO}"


### PR DESCRIPTION
It includes the tags 5.0.16 and 5.0.17 from the community.

https://docs.yoctoproject.org/next/migration-guides/release-notes-5.0.17.html https://docs.yoctoproject.org/next/migration-guides/release-notes-5.0.16.html